### PR TITLE
Dynamically access context and activity from registrar

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -42,13 +42,11 @@ public class PurchasesFlutterPlugin implements MethodCallHandler {
   private List<SkuDetails> products = new ArrayList<>();
   private static final String PURCHASER_INFO_UPDATED = "Purchases-PurchaserInfoUpdated";
 
-  private final Activity activity;
-  private final Context context;
+  private final Registrar registrar;
   private final MethodChannel channel;
 
   public PurchasesFlutterPlugin(Registrar registrar, MethodChannel channel) {
-    this.activity = registrar.activity();
-    this.context = registrar.context();
+    this.registrar = registrar;
     this.channel = channel;
     registrar.addViewDestroyListener(new PluginRegistry.ViewDestroyListener() {
       @Override
@@ -143,9 +141,9 @@ public class PurchasesFlutterPlugin implements MethodCallHandler {
 
   private void setupPurchases(String apiKey, String appUserID, @Nullable Boolean observerMode, final Result result) {
     if (observerMode != null) {
-      Purchases.configure(this.context, apiKey, appUserID, observerMode);
+      Purchases.configure(this.registrar.context(), apiKey, appUserID, observerMode);
     } else {
-      Purchases.configure(this.context, apiKey, appUserID);
+      Purchases.configure(this.registrar.context(), apiKey, appUserID);
     }
     Purchases.getSharedInstance().setUpdatedPurchaserInfoListener(new UpdatedPurchaserInfoListener() {
       @Override
@@ -217,7 +215,8 @@ public class PurchasesFlutterPlugin implements MethodCallHandler {
 
   private void makePurchase(final String productIdentifier, final String oldSku, final String type,
                             final Result result) {
-    if (this.activity != null) {
+    final Activity activity = this.registrar.activity()
+    if (activity != null) {
       if (products.isEmpty()) {
         Purchases.getSharedInstance().getEntitlements(new ReceiveEntitlementsListener() {
           @Override

--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -215,7 +215,7 @@ public class PurchasesFlutterPlugin implements MethodCallHandler {
 
   private void makePurchase(final String productIdentifier, final String oldSku, final String type,
                             final Result result) {
-    final Activity activity = this.registrar.activity()
+    final Activity activity = this.registrar.activity();
     if (activity != null) {
       if (products.isEmpty()) {
         Purchases.getSharedInstance().getEntitlements(new ReceiveEntitlementsListener() {

--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -35,7 +35,6 @@ import io.flutter.view.FlutterNativeView;
 import kotlin.UninitializedPropertyAccessException;
 
 import static com.revenuecat.purchases_flutter.Mappers.map;
-import static com.revenuecat.purchases_flutter.Mappers.map;
 
 /** PurchasesFlutterPlugin */
 public class PurchasesFlutterPlugin implements MethodCallHandler {


### PR DESCRIPTION
Previously `PurchasesFlutterPlugin.java` accessed context and activity once on initialisation and saved it to a variable.
However the activity could be attached to the engine after the registrar has been called.
Therefore it is necessary that this class gets the activity and context dynamically on call from the registrar.

@vegaro I hope you can publish this change with the update from [#89](https://github.com/RevenueCat/purchases-android/issues/89) from your repo `purchases-android`