### PR TITLE
Update invalidatePurchaserInfoCache docs

### DIFF
--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -302,6 +302,11 @@ class Purchases {
   }
 
   /// Invalidates the cache for purchaser information.
+  ///
+  /// Most apps will not need to use this method; invalidating the cache can leave your app in an invalid state.
+  /// Refer to https://docs.revenuecat.com/docs/purchaserinfo#section-get-user-information for more information on
+  /// using the cache properly.
+  ///
   /// This is useful for cases where purchaser information might have been updated outside of the app, like if a
   /// promotional subscription is granted through the RevenueCat dashboard.
   static Future<void> invalidatePurchaserInfoCache() async {


### PR DESCRIPTION
Invalidating the cache is simultaneously an advanced technique and attractive to beginners who might think they need to invalidate the cache on every app launch, so I added a link to our docs that explains how to work with the cache in normal circumstances.

See RevenueCat/purchases-ios#223