### PR TITLE
Add missing error codes

### DIFF
--- a/lib/errors.dart
+++ b/lib/errors.dart
@@ -18,8 +18,11 @@ enum PurchasesErrorCode {
   invalidAppUserIdError,
   operationAlreadyInProgressError,
   unknownBackendError,
+  invalidAppleSubscriptionKeyError,
+  ineligibleError,
   insufficientPermissionsError,
-  paymentPendingError
+  paymentPendingError,
+  invalidSubscriberAttributesError
 }
 
 class PurchasesErrorHelper {


### PR DESCRIPTION
This PR adds error codes that were introduced in native sdks, but missed in Dart port:
- invalidAppleSubscriptionKeyError,
- ineligibleError,
- invalidSubscriberAttributesError

Those missed error codes caused 

```
RangeError (length): Invalid value: Not in range 0..18, inclusive: 20
```

in https://github.com/RevenueCat/purchases-flutter/blob/develop/lib/errors.dart#L27 when native sdk reported error code greater than 18.