### PR TITLE
Use includeBuilds for better local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ pubspec.lock
 example/ios/Flutter/flutter_export_environment.sh
 example/.flutter-plugins-dependencies
 example/ios/Flutter/Flutter.podspec
+example/android/.composite-enable

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'com.revenuecat.purchases_flutter'
 version '1.1.1'
 
 buildscript {
-    ext.kotlin_version = '1.3.71'
+    ext.kotlin_version = '1.3.72'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,6 +38,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.revenuecat.purchases:purchases:3.1.0"
     implementation "com.revenuecat.purchases:purchases-hybrid-common:1.1.2"
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -58,11 +58,12 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
 }
 
+// Call passing parameter -PcommonPath="$HOME/Development/repos/purchases-hybrid-common/android"
 task enableLocalBuild {
     group = 'Tools'
     description = 'Enable composite build'
     doLast {
-        new File(".composite-enable").createNewFile()
+        new File(".composite-enable").text = commonPath
     }
 }
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -32,7 +32,6 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.revenuecat.purchases_sample"
         minSdkVersion 16
         targetSdkVersion 28
@@ -43,7 +42,6 @@ android {
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
         }
@@ -58,4 +56,23 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
+}
+
+task enableLocalBuild {
+    group = 'Tools'
+    description = 'Enable composite build'
+    doLast {
+        new File(".composite-enable").createNewFile()
+    }
+}
+
+task disableLocalBuild {
+    group = 'Tools'
+    description = 'Disable composite build'
+    doLast {
+        File file = file(".composite-enable")
+        if (file.exists()) {
+            file.delete()
+        }
+    }
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Aug 27 13:12:17 PDT 2019
+#Mon Jun 15 14:41:47 PDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -13,3 +13,9 @@ plugins.each { name, path ->
     include ":$name"
     project(":$name").projectDir = pluginDirectory
 }
+
+// Run enableLocalBuild task to enable building purchases-hybrid-common from your local copy
+if (file(".composite-enable").exists()) {
+    includeBuild ('../../../../purchases-hybrid-common/android')
+}
+

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -16,6 +16,7 @@ plugins.each { name, path ->
 
 // Run enableLocalBuild task to enable building purchases-hybrid-common from your local copy
 if (file(".composite-enable").exists()) {
-    includeBuild ('../../../../purchases-hybrid-common/android')
+    String path = new File(".composite-enable").text
+    includeBuild (path)
 }
 


### PR DESCRIPTION
Inspired by https://proandroiddev.com/saying-goodbye-to-snapshots-with-gradles-composite-builds-bc98751392f6 and https://galex.co.il/2017/09/12/The_Best_of_Two_worlds_with_Gradle_Composite_Builds.html.

This adds two new gradle tasks `enableLocalBuild` and `disableLocalBuild`. By running `enableLocalBuild` gradle will use the local copy of `purchases-hybrid-common` instead of the one dowloaded from maven.

Depends on github.com/RevenueCat/purchases-hybrid-common/pull/44