### PR TITLE
Made some clarifications on the type parameter in getProducts and purchaseProduct

### DIFF
--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -126,8 +126,9 @@ class Purchases {
   ///
   /// [productIdentifiers] Array of product identifiers
   ///
-  /// [type] Optional type of products to fetch, can be PurchaseType.INAPP
-  /// or PurchaseType.SUBS. Subs by default
+  /// [type] If the products are Android INAPPs, this needs to be
+  /// PurchaseType.INAPP otherwise the products won't be found.
+  /// PurchaseType.Subs by default. This parameter only has effect in Android.
   static Future<List<Product>> getProducts(List<String> productIdentifiers,
       {PurchaseType type = PurchaseType.subs}) async {
     List<dynamic> result = await _channel.invokeMethod('getProductInfo',
@@ -158,8 +159,9 @@ class Purchases {
   /// [upgradeInfo] Android only. Optional UpgradeInfo you wish to upgrade from
   /// containing the oldSKU and the optional prorationMode.
   ///
-  /// [type] Android only. Optional type of product, can be PurchaseType.INAPP
-  /// or PurchaseType.SUBS. Subs by default.
+  /// [type] If the product is an Android INAPP, this needs to be
+  /// PurchaseType.INAPP otherwise the product won't be found.
+  /// PurchaseType.Subs by default. This parameter only has effect in Android.
   static Future<PurchaserInfo> purchaseProduct(String productIdentifier,
       {UpgradeInfo upgradeInfo, PurchaseType type = PurchaseType.subs}) async {
     var response = await _channel.invokeMethod('purchaseProduct', {


### PR DESCRIPTION
This `type` parameter is very confusing and a lot of people don't realize they have to set it to `INAPP` if they are purchasing/getting an Android INAPP.

Examples:
https://github.com/RevenueCat/purchases-flutter/issues/42
https://github.com/RevenueCat/purchases-flutter/issues/80

A better solution for this would be to change the function on `purchases-hybrid-common` to not require a type and basically try our best to find the product by first assuming it is a SUBS, and if the subscription can't be found, try to fetch it as an INAPP. The only edge case it has is that it's possible to set a SUB and an INAPP with the same product ID, but I doubt someone is doing that, and it's also fixable by whoever is doing it but just giving different names. 