### PR TITLE
Migrates Flutter to null safety

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
   lint:
     description: "Run static analysis for Flutter"
     docker:
-      - image: cirrusci/flutter:stable
+      - image: cirrusci/flutter:beta
     steps:
       - checkout
       - build-flutter-project
@@ -84,7 +84,7 @@ jobs:
   test:
     description: "Run tests for Flutter"
     docker:
-      - image: cirrusci/flutter:stable
+      - image: cirrusci/flutter:beta
     steps:
       - checkout
       - build-flutter-project
@@ -95,7 +95,7 @@ jobs:
   android-integration-test-build:
     description: "Build Android Flutter integration tests"
     docker:
-      - image: cirrusci/flutter:stable
+      - image: cirrusci/flutter:beta
     steps:
       - checkout
       - replace-api-key

--- a/lib/entitlement_info_wrapper.dart
+++ b/lib/entitlement_info_wrapper.dart
@@ -23,7 +23,7 @@ class EntitlementInfo {
 
   /// The expiration date for the entitlement, can be `null` for lifetime access.
   /// If the `periodType` is `trial`, this is the trial expiration date.
-  final String expirationDate;
+  final String? expirationDate;
 
   /// The store where this entitlement was unlocked from
   /// Either: appStore, macAppStore, playStore, stripe, promotional, unknownStore
@@ -38,13 +38,13 @@ class EntitlementInfo {
   /// The date an unsubscribe was detected. Can be `null`.
   /// @note: Entitlement may still be active even if user has unsubscribed.
   /// Check the `isActive` property.
-  final String unsubscribeDetectedAt;
+  final String? unsubscribeDetectedAt;
 
   /// The date a billing issue was detected. Can be `nil` if there is no
   /// billing issue or an issue has been resolved.
   /// @note: Entitlement may still be active even if there is a billing issue.
   /// Check the `isActive` property.
-  final String billingIssueDetectedAt;
+  final String? billingIssueDetectedAt;
 
   /// Construct an EntitlementInfo
   EntitlementInfo(
@@ -63,8 +63,8 @@ class EntitlementInfo {
 
   /// Constructs an EntitlementInfo from a JSON object
   factory EntitlementInfo.fromJson(Map<dynamic, dynamic> json) {
-    var periodType;
-    switch (json["periodType"] as String) {
+    late var periodType;
+    switch (json["periodType"] as String?) {
       case "INTRO":
         periodType = PeriodType.intro;
         break;
@@ -75,8 +75,8 @@ class EntitlementInfo {
         periodType = PeriodType.trial;
         break;
     }
-    var store;
-    switch (json["store"] as String) {
+    late var store;
+    switch (json["store"] as String?) {
       case "APP_STORE":
         store = Store.appStore;
         break;
@@ -103,12 +103,12 @@ class EntitlementInfo {
         periodType,
         json["latestPurchaseDate"] as String,
         json["originalPurchaseDate"] as String,
-        json["expirationDate"] as String,
+        json["expirationDate"] as String?,
         store,
         json["productIdentifier"] as String,
         json["isSandbox"] as bool,
-        json["unsubscribeDetectedAt"] as String,
-        json["billingIssueDetectedAt"] as String);
+        json["unsubscribeDetectedAt"] as String?,
+        json["billingIssueDetectedAt"] as String?);
   }
 
   @override

--- a/lib/entitlement_info_wrapper.dart
+++ b/lib/entitlement_info_wrapper.dart
@@ -35,12 +35,13 @@ class EntitlementInfo {
   /// False if this entitlement is unlocked via a production purchase
   final bool isSandbox;
 
-  /// The date an unsubscribe was detected. Can be `null`.
+  /// The date an unsubscribe was detected. Can be `null` if it's still
+  /// subscribed or product is not a subscription.
   /// @note: Entitlement may still be active even if user has unsubscribed.
   /// Check the `isActive` property.
   final String? unsubscribeDetectedAt;
 
-  /// The date a billing issue was detected. Can be `nil` if there is no
+  /// The date a billing issue was detected. Can be `null` if there is no
   /// billing issue or an issue has been resolved.
   /// @note: Entitlement may still be active even if there is a billing issue.
   /// Check the `isActive` property.
@@ -74,6 +75,9 @@ class EntitlementInfo {
       case "TRIAL":
         periodType = PeriodType.trial;
         break;
+      default:
+        periodType = PeriodType.unknown;
+        break;
     }
     late var store;
     switch (json["store"] as String?) {
@@ -92,7 +96,7 @@ class EntitlementInfo {
       case "PROMOTIONAL":
         store = Store.promotional;
         break;
-      case "UNKNOWN_STORE":
+      default:
         store = Store.unknownStore;
         break;
     }
@@ -126,7 +130,11 @@ enum PeriodType {
   normal,
 
   /// If the entitlement is under a trial period.
-  trial
+  trial,
+
+  /// If the period type couldn't be determined.
+  unknown
+
 }
 
 /// Enum of supported stores

--- a/lib/offering_wrapper.dart
+++ b/lib/offering_wrapper.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart' show IterableExtension;
 import 'package:purchases_flutter/object_wrappers.dart';
 
 /// An offering is a collection of Packages (`Package`) available for the user
@@ -13,25 +14,25 @@ class Offering {
   final List<Package> availablePackages;
 
   /// Lifetime package type configured in the RevenueCat dashboard, if available.
-  final Package lifetime;
+  final Package? lifetime;
 
   /// Annual package type configured in the RevenueCat dashboard, if available.
-  final Package annual;
+  final Package? annual;
 
   /// Six month package type configured in the RevenueCat dashboard, if available.
-  final Package sixMonth;
+  final Package? sixMonth;
 
   /// Three month package type configured in the RevenueCat dashboard, if available.
-  final Package threeMonth;
+  final Package? threeMonth;
 
   /// Two month package type configured in the RevenueCat dashboard, if available.
-  final Package twoMonth;
+  final Package? twoMonth;
 
   /// Monthly package type configured in the RevenueCat dashboard, if available.
-  final Package monthly;
+  final Package? monthly;
 
   /// Weekly package type configured in the RevenueCat dashboard, if available.
-  final Package weekly;
+  final Package? weekly;
 
   /// Constructs an Offering from a JSON object.
   Offering.fromJson(Map<dynamic, dynamic> map)
@@ -56,10 +57,9 @@ class Offering {
 
   /// Retrieves a specific package by identifier, use this to access custom
   /// package types configured in the RevenueCat dashboard.
-  Package getPackage(String identifier) {
-    return availablePackages.firstWhere(
-        (package) => package.identifier == identifier,
-        orElse: () => null);
+  Package? getPackage(String identifier) {
+    return availablePackages.firstWhereOrNull(
+        (package) => package.identifier == identifier);
   }
 
   @override

--- a/lib/offerings_wrapper.dart
+++ b/lib/offerings_wrapper.dart
@@ -4,7 +4,7 @@ import 'package:purchases_flutter/object_wrappers.dart';
 /// For more info see https://docs.revenuecat.com/docs/entitlements
 class Offerings {
   /// Current offering configured in the RevenueCat dashboard.
-  final Offering current;
+  final Offering? current;
 
   /// Map of all Offerings [Offering] objects keyed by their identifier.
   final Map<String, Offering> all;
@@ -17,7 +17,7 @@ class Offerings {
             (key, value) => MapEntry(key as String, Offering.fromJson(value)));
 
   /// Retrieves an specific offering by its identifier.
-  Offering getOffering(String identifier) {
+  Offering? getOffering(String identifier) {
     return all[identifier];
   }
 

--- a/lib/product_wrapper.dart
+++ b/lib/product_wrapper.dart
@@ -21,10 +21,10 @@ class Product {
   final String currencyCode;
 
   /// Introductory price for product. Can be null.
-  final IntroductoryPrice introductoryPrice;
+  final IntroductoryPrice? introductoryPrice;
 
   /// Collection of discount offers for a product. Null for Android.
-  final List<Discount> discounts;
+  final List<Discount>? discounts;
 
   /// Constructs a Product from a JSON object.
   Product.fromJson(Map<dynamic, dynamic> json)

--- a/lib/purchaser_info_wrapper.dart
+++ b/lib/purchaser_info_wrapper.dart
@@ -7,10 +7,10 @@ class PurchaserInfo {
   final EntitlementInfos entitlements;
 
   /// The latest expiration date of all purchased skus
-  final String latestExpirationDate;
+  final String? latestExpirationDate;
 
   /// Map of skus to expiration dates
-  final Map<String, String> allExpirationDates;
+  final Map<String, String?> allExpirationDates;
 
   /// Map of skus to purchase dates
   final Map<String, String> allPurchaseDates;
@@ -36,7 +36,7 @@ class PurchaserInfo {
 
   /// Returns the purchase date for the version of the application when the user bought the app.
   /// Use this for grandfathering users when migrating to subscriptions.
-  final String originalPurchaseDate;
+  final String? originalPurchaseDate;
 
   /// Returns the version number for the version of the application when the
   /// user bought the app. Use this for grandfathering users when migrating
@@ -45,13 +45,13 @@ class PurchaserInfo {
   /// This corresponds to the value of CFBundleVersion (in iOS) in the
   /// Info.plist file when the purchase was originally made. This is always null
   /// in Android
-  final String originalApplicationVersion;
+  final String? originalApplicationVersion;
 
   /// URL to manage the active subscription of the user. If this user has an active iOS
   /// subscription, this will point to the App Store, if the user has an active Play Store subscription
   /// it will point there. If there are no active subscriptions it will be null.
   /// If there are multiple for different platforms, it will point to the device store.
-  final String managementURL;
+  final String? managementURL;
 
   /// Constructs a PurchaserInfo from a JSON object.
   PurchaserInfo.fromJson(Map<dynamic, dynamic> map)

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -157,12 +157,11 @@ class Purchases {
   /// PurchaseType.Subs by default. This parameter only has effect in Android.
   static Future<PurchaserInfo> purchaseProduct(String productIdentifier,
       {UpgradeInfo? upgradeInfo, PurchaseType type = PurchaseType.subs}) async {
+    final prorationMode = upgradeInfo?.prorationMode;
     final response = await _channel.invokeMethod('purchaseProduct', {
       'productIdentifier': productIdentifier,
-      'oldSKU': upgradeInfo != null ? upgradeInfo.oldSKU : null,
-      'prorationMode': upgradeInfo != null && upgradeInfo.prorationMode != null
-          ? upgradeInfo.prorationMode!.index
-          : null,
+      'oldSKU': upgradeInfo?.oldSKU,
+      'prorationMode': prorationMode != null ? prorationMode.index : null,
       'type': describeEnum(type)
     });
     return PurchaserInfo.fromJson(response["purchaserInfo"]);
@@ -180,13 +179,12 @@ class Purchases {
   /// containing the oldSKU and the optional prorationMode.
   static Future<PurchaserInfo> purchasePackage(Package packageToPurchase,
       {UpgradeInfo? upgradeInfo}) async {
+    final prorationMode = upgradeInfo?.prorationMode;
     final response = await _channel.invokeMethod('purchasePackage', {
       'packageIdentifier': packageToPurchase.identifier,
       'offeringIdentifier': packageToPurchase.offeringIdentifier,
-      'oldSKU': upgradeInfo != null ? upgradeInfo.oldSKU : null,
-      'prorationMode': upgradeInfo != null && upgradeInfo.prorationMode != null
-          ? upgradeInfo.prorationMode!.index
-          : null
+      'oldSKU': upgradeInfo?.oldSKU,
+      'prorationMode': prorationMode != null ? prorationMode.index : null
     });
     return PurchaserInfo.fromJson(response["purchaserInfo"]);
   }

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -120,7 +120,8 @@ class Purchases {
   ///
   /// Time is money.
   static Future<Offerings> getOfferings() async {
-    return Offerings.fromJson(await (_channel.invokeMethod('getOfferings') as FutureOr<Map<dynamic, dynamic>>));
+    var result = await _channel.invokeMethod('getOfferings');
+    return Offerings.fromJson(result);
   }
 
   /// Fetch the product info. Returns a list of products or throws an error if
@@ -134,8 +135,8 @@ class Purchases {
   /// PurchaseType.Subs by default. This parameter only has effect in Android.
   static Future<List<Product>> getProducts(List<String> productIdentifiers,
       {PurchaseType type = PurchaseType.subs}) async {
-    List<dynamic> result = await (_channel.invokeMethod('getProductInfo',
-        {'productIdentifiers': productIdentifiers, 'type': describeEnum(type)}) as FutureOr<List<dynamic>>);
+    final result = await _channel.invokeMethod('getProductInfo',
+        {'productIdentifiers': productIdentifiers, 'type': describeEnum(type)});
     return result.map((item) => Product.fromJson(item)).toList();
   }
 
@@ -156,7 +157,7 @@ class Purchases {
   /// PurchaseType.Subs by default. This parameter only has effect in Android.
   static Future<PurchaserInfo> purchaseProduct(String productIdentifier,
       {UpgradeInfo? upgradeInfo, PurchaseType type = PurchaseType.subs}) async {
-    var response = await _channel.invokeMethod('purchaseProduct', {
+    final response = await _channel.invokeMethod('purchaseProduct', {
       'productIdentifier': productIdentifier,
       'oldSKU': upgradeInfo != null ? upgradeInfo.oldSKU : null,
       'prorationMode': upgradeInfo != null && upgradeInfo.prorationMode != null
@@ -179,7 +180,7 @@ class Purchases {
   /// containing the oldSKU and the optional prorationMode.
   static Future<PurchaserInfo> purchasePackage(Package packageToPurchase,
       {UpgradeInfo? upgradeInfo}) async {
-    var response = await _channel.invokeMethod('purchasePackage', {
+    final response = await _channel.invokeMethod('purchasePackage', {
       'packageIdentifier': packageToPurchase.identifier,
       'offeringIdentifier': packageToPurchase.offeringIdentifier,
       'oldSKU': upgradeInfo != null ? upgradeInfo.oldSKU : null,
@@ -204,7 +205,7 @@ class Purchases {
   /// using [getPaymentDiscount].
   static Future<PurchaserInfo> purchaseDiscountedProduct(
       Product product, PaymentDiscount discount) async {
-    var response = await _channel.invokeMethod('purchaseProduct', {
+    final response = await _channel.invokeMethod('purchaseProduct', {
       'productIdentifier': product.identifier,
       'signedDiscountTimestamp': discount.timestamp.toString()
     });
@@ -225,7 +226,7 @@ class Purchases {
   /// using [getPaymentDiscount].
   static Future<PurchaserInfo> purchaseDiscountedPackage(
       Package packageToPurchase, PaymentDiscount discount) async {
-    var response = await _channel.invokeMethod('purchasePackage', {
+    final response = await _channel.invokeMethod('purchasePackage', {
       'packageIdentifier': packageToPurchase.identifier,
       'offeringIdentifier': packageToPurchase.offeringIdentifier,
       'signedDiscountTimestamp': discount.timestamp.toString()
@@ -239,8 +240,7 @@ class Purchases {
   /// Returns a [PurchaserInfo] object, or throws a [PlatformException] if there
   /// was a problem restoring transactions.
   static Future<PurchaserInfo> restoreTransactions() async {
-    Map<dynamic, dynamic> result =
-        await (_channel.invokeMethod('restoreTransactions') as FutureOr<Map<dynamic, dynamic>>);
+    final result = await _channel.invokeMethod('restoreTransactions');
     return PurchaserInfo.fromJson(result);
   }
 
@@ -257,8 +257,8 @@ class Purchases {
   /// [newAppUserID] The new appUserID that should be linked to the currently
   /// identified appUserID.
   static Future<PurchaserInfo> createAlias(String newAppUserID) async {
-    Map<dynamic, dynamic> result = await (_channel
-        .invokeMethod('createAlias', {'newAppUserID': newAppUserID}) as FutureOr<Map<dynamic, dynamic>>);
+    final result = await _channel
+        .invokeMethod('createAlias', {'newAppUserID': newAppUserID});
     return PurchaserInfo.fromJson(result);
   }
 
@@ -271,8 +271,8 @@ class Purchases {
   ///
   /// [newAppUserID] The appUserID that should be linked to the currently user
   static Future<PurchaserInfo> identify(String appUserID) async {
-    Map<dynamic, dynamic> result =
-        await (_channel.invokeMethod('identify', {'appUserID': appUserID}) as FutureOr<Map<dynamic, dynamic>>);
+    final result =
+        await _channel.invokeMethod('identify', {'appUserID': appUserID});
     return PurchaserInfo.fromJson(result);
   }
 
@@ -282,7 +282,7 @@ class Purchases {
   /// Returns a [PurchaserInfo] object, or throws a [PlatformException] if there
   /// was a problem restoring transactions.
   static Future<PurchaserInfo> reset() async {
-    Map<dynamic, dynamic> result = await (_channel.invokeMethod('reset') as FutureOr<Map<dynamic, dynamic>>);
+    final result = await _channel.invokeMethod('reset');
     return PurchaserInfo.fromJson(result);
   }
 
@@ -302,8 +302,7 @@ class Purchases {
 
   /// Gets current purchaser info, which will normally be cached.
   static Future<PurchaserInfo> getPurchaserInfo() async {
-    Map<dynamic, dynamic> result =
-        await (_channel.invokeMethod('getPurchaserInfo') as FutureOr<Map<dynamic, dynamic>>);
+    final result = await _channel.invokeMethod('getPurchaserInfo');
     return PurchaserInfo.fromJson(result);
   }
 
@@ -351,9 +350,9 @@ class Purchases {
   static Future<Map<String, IntroEligibility>>
       checkTrialOrIntroductoryPriceEligibility(
           List<String> productIdentifiers) async {
-    Map<dynamic, dynamic> eligibilityMap = await (_channel.invokeMethod(
+    final eligibilityMap = await _channel.invokeMethod(
         'checkTrialOrIntroductoryPriceEligibility',
-        {'productIdentifiers': productIdentifiers}) as FutureOr<Map<dynamic, dynamic>>);
+        {'productIdentifiers': productIdentifiers});
     return eligibilityMap.map((key, value) =>
         MapEntry(key as String, IntroEligibility.fromJson(value)));
   }
@@ -524,11 +523,10 @@ class Purchases {
   /// [discount] The `Discount` to apply to the product.
   static Future<PaymentDiscount> getPaymentDiscount(
       Product product, Discount discount) async {
-    Map<dynamic, dynamic> result =
-        await (_channel.invokeMethod('getPaymentDiscount', {
+    final result = await _channel.invokeMethod('getPaymentDiscount', {
       'productIdentifier': product.identifier,
       'discountIdentifier': discount.identifier
-    }) as FutureOr<Map<dynamic, dynamic>>);
+    });
     return PaymentDiscount.fromJson(result);
   }
 }

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -41,9 +41,9 @@ class Purchases {
   /// NSUserDefaults suite, otherwise it will use standardUserDefaults.
   /// Default is null, which will make the SDK use standardUserDefaults.
   static Future<void> setup(String apiKey,
-      {String appUserId,
+      {String? appUserId,
       bool observerMode = false,
-      String userDefaultsSuiteName}) async {
+      String? userDefaultsSuiteName}) async {
     return await _channel.invokeMethod('setupPurchases', {
       'apiKey': apiKey,
       'appUserId': appUserId,
@@ -102,7 +102,7 @@ class Purchases {
   @Deprecated("Use the set<NetworkId> functions instead.")
   static Future<void> addAttributionData(
       Map<String, Object> data, PurchasesAttributionNetwork network,
-      {String networkUserId}) async {
+      {String? networkUserId}) async {
     await _channel.invokeMethod('addAttributionData', {
       'data': data,
       'network': network.index,
@@ -120,7 +120,7 @@ class Purchases {
   ///
   /// Time is money.
   static Future<Offerings> getOfferings() async {
-    return Offerings.fromJson(await _channel.invokeMethod('getOfferings'));
+    return Offerings.fromJson(await (_channel.invokeMethod('getOfferings') as FutureOr<Map<dynamic, dynamic>>));
   }
 
   /// Fetch the product info. Returns a list of products or throws an error if
@@ -134,8 +134,8 @@ class Purchases {
   /// PurchaseType.Subs by default. This parameter only has effect in Android.
   static Future<List<Product>> getProducts(List<String> productIdentifiers,
       {PurchaseType type = PurchaseType.subs}) async {
-    List<dynamic> result = await _channel.invokeMethod('getProductInfo',
-        {'productIdentifiers': productIdentifiers, 'type': describeEnum(type)});
+    List<dynamic> result = await (_channel.invokeMethod('getProductInfo',
+        {'productIdentifiers': productIdentifiers, 'type': describeEnum(type)}) as FutureOr<List<dynamic>>);
     return result.map((item) => Product.fromJson(item)).toList();
   }
 
@@ -155,12 +155,12 @@ class Purchases {
   /// PurchaseType.INAPP otherwise the product won't be found.
   /// PurchaseType.Subs by default. This parameter only has effect in Android.
   static Future<PurchaserInfo> purchaseProduct(String productIdentifier,
-      {UpgradeInfo upgradeInfo, PurchaseType type = PurchaseType.subs}) async {
+      {UpgradeInfo? upgradeInfo, PurchaseType type = PurchaseType.subs}) async {
     var response = await _channel.invokeMethod('purchaseProduct', {
       'productIdentifier': productIdentifier,
       'oldSKU': upgradeInfo != null ? upgradeInfo.oldSKU : null,
       'prorationMode': upgradeInfo != null && upgradeInfo.prorationMode != null
-          ? upgradeInfo.prorationMode.index
+          ? upgradeInfo.prorationMode!.index
           : null,
       'type': describeEnum(type)
     });
@@ -178,13 +178,13 @@ class Purchases {
   /// [upgradeInfo] Android only. Optional UpgradeInfo you wish to upgrade from
   /// containing the oldSKU and the optional prorationMode.
   static Future<PurchaserInfo> purchasePackage(Package packageToPurchase,
-      {UpgradeInfo upgradeInfo}) async {
+      {UpgradeInfo? upgradeInfo}) async {
     var response = await _channel.invokeMethod('purchasePackage', {
       'packageIdentifier': packageToPurchase.identifier,
       'offeringIdentifier': packageToPurchase.offeringIdentifier,
       'oldSKU': upgradeInfo != null ? upgradeInfo.oldSKU : null,
       'prorationMode': upgradeInfo != null && upgradeInfo.prorationMode != null
-          ? upgradeInfo.prorationMode.index
+          ? upgradeInfo.prorationMode!.index
           : null
     });
     return PurchaserInfo.fromJson(response["purchaserInfo"]);
@@ -240,7 +240,7 @@ class Purchases {
   /// was a problem restoring transactions.
   static Future<PurchaserInfo> restoreTransactions() async {
     Map<dynamic, dynamic> result =
-        await _channel.invokeMethod('restoreTransactions');
+        await (_channel.invokeMethod('restoreTransactions') as FutureOr<Map<dynamic, dynamic>>);
     return PurchaserInfo.fromJson(result);
   }
 
@@ -257,8 +257,8 @@ class Purchases {
   /// [newAppUserID] The new appUserID that should be linked to the currently
   /// identified appUserID.
   static Future<PurchaserInfo> createAlias(String newAppUserID) async {
-    Map<dynamic, dynamic> result = await _channel
-        .invokeMethod('createAlias', {'newAppUserID': newAppUserID});
+    Map<dynamic, dynamic> result = await (_channel
+        .invokeMethod('createAlias', {'newAppUserID': newAppUserID}) as FutureOr<Map<dynamic, dynamic>>);
     return PurchaserInfo.fromJson(result);
   }
 
@@ -272,7 +272,7 @@ class Purchases {
   /// [newAppUserID] The appUserID that should be linked to the currently user
   static Future<PurchaserInfo> identify(String appUserID) async {
     Map<dynamic, dynamic> result =
-        await _channel.invokeMethod('identify', {'appUserID': appUserID});
+        await (_channel.invokeMethod('identify', {'appUserID': appUserID}) as FutureOr<Map<dynamic, dynamic>>);
     return PurchaserInfo.fromJson(result);
   }
 
@@ -282,7 +282,7 @@ class Purchases {
   /// Returns a [PurchaserInfo] object, or throws a [PlatformException] if there
   /// was a problem restoring transactions.
   static Future<PurchaserInfo> reset() async {
-    Map<dynamic, dynamic> result = await _channel.invokeMethod('reset');
+    Map<dynamic, dynamic> result = await (_channel.invokeMethod('reset') as FutureOr<Map<dynamic, dynamic>>);
     return PurchaserInfo.fromJson(result);
   }
 
@@ -303,7 +303,7 @@ class Purchases {
   /// Gets current purchaser info, which will normally be cached.
   static Future<PurchaserInfo> getPurchaserInfo() async {
     Map<dynamic, dynamic> result =
-        await _channel.invokeMethod('getPurchaserInfo');
+        await (_channel.invokeMethod('getPurchaserInfo') as FutureOr<Map<dynamic, dynamic>>);
     return PurchaserInfo.fromJson(result);
   }
 
@@ -351,9 +351,9 @@ class Purchases {
   static Future<Map<String, IntroEligibility>>
       checkTrialOrIntroductoryPriceEligibility(
           List<String> productIdentifiers) async {
-    Map<dynamic, dynamic> eligibilityMap = await _channel.invokeMethod(
+    Map<dynamic, dynamic> eligibilityMap = await (_channel.invokeMethod(
         'checkTrialOrIntroductoryPriceEligibility',
-        {'productIdentifiers': productIdentifiers});
+        {'productIdentifiers': productIdentifiers}) as FutureOr<Map<dynamic, dynamic>>);
     return eligibilityMap.map((key, value) =>
         MapEntry(key as String, IntroEligibility.fromJson(value)));
   }
@@ -525,10 +525,10 @@ class Purchases {
   static Future<PaymentDiscount> getPaymentDiscount(
       Product product, Discount discount) async {
     Map<dynamic, dynamic> result =
-        await _channel.invokeMethod('getPaymentDiscount', {
+        await (_channel.invokeMethod('getPaymentDiscount', {
       'productIdentifier': product.identifier,
       'discountIdentifier': discount.identifier
-    });
+    }) as FutureOr<Map<dynamic, dynamic>>);
     return PaymentDiscount.fromJson(result);
   }
 }
@@ -540,7 +540,7 @@ class UpgradeInfo {
   String oldSKU;
 
   /// The [ProrationMode] to use when upgrading the given oldSKU.
-  ProrationMode prorationMode;
+  ProrationMode? prorationMode;
 
   /// Constructs an UpgradeInfo
   UpgradeInfo(this.oldSKU, {this.prorationMode});

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
   build_runner: ^1.0.0
+  test: ^1.15.7
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,12 +7,13 @@ issue_tracker: https://github.com/RevenueCat/purchases-flutter/issues
 documentation: https://docs.revenuecat.com/docs
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: '>=2.12.0-259.12.beta <3.0.0'
   flutter: ">=1.12.13+hotfix.6 <2.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
+  collection: ^1.15.0-nullsafety.4
 
 dev_dependencies:
   pedantic: ^1.8.0

--- a/test/entitlement_info_test.dart
+++ b/test/entitlement_info_test.dart
@@ -1,0 +1,52 @@
+import 'package:purchases_flutter/entitlement_info_wrapper.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('unknown period if missing from json', () {
+    Map<dynamic, dynamic> entitlementInfoJson = {
+      "identifier": "almost_pro",
+      "isActive": true,
+      "willRenew": true,
+      "latestPurchaseDateMillis": 1.58759855E9,
+      "latestPurchaseDate": "2020-04-22T23:35:50.000Z",
+      "originalPurchaseDateMillis": 1.591725245E9,
+      "originalPurchaseDate": "2020-06-09T17:54:05.000Z",
+      "expirationDateMillis": null,
+      "expirationDate": null,
+      "store": "PLAY_STORE",
+      "productIdentifier": "consumable",
+      "isSandbox": true,
+      "unsubscribeDetectedAt": null,
+      "unsubscribeDetectedAtMillis": null,
+      "billingIssueDetectedAt": null,
+      "billingIssueDetectedAtMillis": null};
+    final entitlementInfo =
+        EntitlementInfo.fromJson(entitlementInfoJson);
+
+    expect(entitlementInfo.periodType, PeriodType.unknown);
+  });
+
+  test('unknown store if missing from json', () {
+    Map<dynamic, dynamic> entitlementInfoJson = {
+      "identifier": "almost_pro",
+      "isActive": true,
+      "willRenew": true,
+      "periodType": "NORMAL",
+      "latestPurchaseDateMillis": 1.58759855E9,
+      "latestPurchaseDate": "2020-04-22T23:35:50.000Z",
+      "originalPurchaseDateMillis": 1.591725245E9,
+      "originalPurchaseDate": "2020-06-09T17:54:05.000Z",
+      "expirationDateMillis": null,
+      "expirationDate": null,
+      "productIdentifier": "consumable",
+      "isSandbox": true,
+      "unsubscribeDetectedAt": null,
+      "unsubscribeDetectedAtMillis": null,
+      "billingIssueDetectedAt": null,
+      "billingIssueDetectedAtMillis": null};
+    final entitlementInfo =
+        EntitlementInfo.fromJson(entitlementInfoJson);
+
+    expect(entitlementInfo.store, Store.unknownStore);
+  });
+}


### PR DESCRIPTION
I followed the steps in https://dart.dev/null-safety/migration-guide#step3-analyze and this PR is the result of the automatic migration.

We can publish this as version 3.0.0 of the SDK and it will show as a preview until dart 2.12.0 is out of beta.

Depends on https://github.com/RevenueCat/purchases-flutter/pull/154