### PR TITLE
Fix getproducts and checkTrialOrIntroductoryPriceEligibility

### DIFF
--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -120,8 +120,7 @@ class Purchases {
   ///
   /// Time is money.
   static Future<Offerings> getOfferings() async {
-    var result = await _channel.invokeMethod('getOfferings');
-    return Offerings.fromJson(result);
+    return Offerings.fromJson(await _channel.invokeMethod('getOfferings'));
   }
 
   /// Fetch the product info. Returns a list of products or throws an error if
@@ -135,10 +134,8 @@ class Purchases {
   /// PurchaseType.Subs by default. This parameter only has effect in Android.
   static Future<List<Product>> getProducts(List<String> productIdentifiers,
       {PurchaseType type = PurchaseType.subs}) async {
-    final List<dynamic> result = await _channel.invokeMethod('getProductInfo', {
-      'productIdentifiers': productIdentifiers,
-      'type': describeEnum(type)
-    });
+    final List<dynamic> result = await _channel.invokeMethod('getProductInfo',
+        {'productIdentifiers': productIdentifiers, 'type': describeEnum(type)});
     return result.map<Product>((item) => Product.fromJson(item)).toList();
   }
 
@@ -257,7 +254,7 @@ class Purchases {
   /// [newAppUserID] The new appUserID that should be linked to the currently
   /// identified appUserID.
   static Future<PurchaserInfo> createAlias(String newAppUserID) async {
-    final result = await _channel
+    Map<dynamic, dynamic> result = await _channel
         .invokeMethod('createAlias', {'newAppUserID': newAppUserID});
     return PurchaserInfo.fromJson(result);
   }
@@ -271,7 +268,7 @@ class Purchases {
   ///
   /// [newAppUserID] The appUserID that should be linked to the currently user
   static Future<PurchaserInfo> identify(String appUserID) async {
-    final result =
+    Map<dynamic, dynamic> result =
         await _channel.invokeMethod('identify', {'appUserID': appUserID});
     return PurchaserInfo.fromJson(result);
   }
@@ -282,7 +279,7 @@ class Purchases {
   /// Returns a [PurchaserInfo] object, or throws a [PlatformException] if there
   /// was a problem restoring transactions.
   static Future<PurchaserInfo> reset() async {
-    final result = await _channel.invokeMethod('reset');
+    Map<dynamic, dynamic> result = await _channel.invokeMethod('reset');
     return PurchaserInfo.fromJson(result);
   }
 
@@ -302,7 +299,8 @@ class Purchases {
 
   /// Gets current purchaser info, which will normally be cached.
   static Future<PurchaserInfo> getPurchaserInfo() async {
-    final result = await _channel.invokeMethod('getPurchaserInfo');
+    Map<dynamic, dynamic> result =
+        await _channel.invokeMethod('getPurchaserInfo');
     return PurchaserInfo.fromJson(result);
   }
 
@@ -350,7 +348,7 @@ class Purchases {
   static Future<Map<String, IntroEligibility>>
       checkTrialOrIntroductoryPriceEligibility(
           List<String> productIdentifiers) async {
-    final eligibilityMap = await _channel.invokeMethod(
+    Map<dynamic, dynamic> eligibilityMap = await _channel.invokeMethod(
         'checkTrialOrIntroductoryPriceEligibility',
         {'productIdentifiers': productIdentifiers});
     return eligibilityMap.map((key, value) =>
@@ -523,7 +521,8 @@ class Purchases {
   /// [discount] The `Discount` to apply to the product.
   static Future<PaymentDiscount> getPaymentDiscount(
       Product product, Discount discount) async {
-    final result = await _channel.invokeMethod('getPaymentDiscount', {
+    Map<dynamic, dynamic> result =
+        await _channel.invokeMethod('getPaymentDiscount', {
       'productIdentifier': product.identifier,
       'discountIdentifier': discount.identifier
     });

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -135,9 +135,11 @@ class Purchases {
   /// PurchaseType.Subs by default. This parameter only has effect in Android.
   static Future<List<Product>> getProducts(List<String> productIdentifiers,
       {PurchaseType type = PurchaseType.subs}) async {
-    final result = await _channel.invokeMethod('getProductInfo',
-        {'productIdentifiers': productIdentifiers, 'type': describeEnum(type)});
-    return result.map((item) => Product.fromJson(item)).toList();
+    final List<dynamic> result = await _channel.invokeMethod('getProductInfo', {
+      'productIdentifiers': productIdentifiers,
+      'type': describeEnum(type)
+    });
+    return result.map<Product>((item) => Product.fromJson(item)).toList();
   }
 
   /// Makes a purchase. Returns a [PurchaserInfo] object. Throws a

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -41,30 +41,45 @@ void main() {
   });
 
   test('getProductsList returns list of products', () async {
-    response = [{
-      "identifier": "monthly_intro_pricing_one_week",
-      "description": "Monthly Product Intro Pricing One Week",
-      "title": "Monthly Product Intro Pricing One Week (PurchasesSample)",
-      "price": 4.99,
-      "price_string": "\$4.99",
-      "currency_code": "USD",
-      "introPrice": {
-        "price": 0,
-        "priceString": "\$0.00",
-        "period": "P1W",
-        "cycles": 1,
-        "periodUnit": "DAY",
-        "periodNumberOfUnits": 7
-      },
-      "discounts": null,
-      "intro_price": 0,
-      "intro_price_string": "\$0.00",
-      "intro_price_period": "P1W",
-      "intro_price_cycles": 1,
-      "intro_price_period_unit": "DAY",
-      "intro_price_period_number_of_units": 7
-    }];
+    response = [
+      {
+        "identifier": "monthly_intro_pricing_one_week",
+        "description": "Monthly Product Intro Pricing One Week",
+        "title": "Monthly Product Intro Pricing One Week (PurchasesSample)",
+        "price": 4.99,
+        "price_string": "\$4.99",
+        "currency_code": "USD",
+        "introPrice": {
+          "price": 0,
+          "priceString": "\$0.00",
+          "period": "P1W",
+          "cycles": 1,
+          "periodUnit": "DAY",
+          "periodNumberOfUnits": 7
+        },
+        "discounts": null,
+        "intro_price": 0,
+        "intro_price_string": "\$0.00",
+        "intro_price_period": "P1W",
+        "intro_price_cycles": 1,
+        "intro_price_period_unit": "DAY",
+        "intro_price_period_number_of_units": 7
+      }
+    ];
     var list = await Purchases.getProducts(['sku_a']);
+    expect(list.length, 1);
+  });
+
+  test('checkTrialOrIntroductoryPriceEligibility returns eligibility map',
+      () async {
+    response = {
+      "monthly_intro_pricing_one_week": {
+        "status": 0,
+        "description": "Status indeterminate."
+      }
+    };
+    var list = await Purchases.checkTrialOrIntroductoryPriceEligibility(
+        ['monthly_intro_pricing_one_week']);
     expect(list.length, 1);
   });
 }

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -39,4 +39,32 @@ void main() {
       ],
     );
   });
+
+  test('getProductsList returns list of products', () async {
+    response = [{
+      "identifier": "monthly_intro_pricing_one_week",
+      "description": "Monthly Product Intro Pricing One Week",
+      "title": "Monthly Product Intro Pricing One Week (PurchasesSample)",
+      "price": 4.99,
+      "price_string": "\$4.99",
+      "currency_code": "USD",
+      "introPrice": {
+        "price": 0,
+        "priceString": "\$0.00",
+        "period": "P1W",
+        "cycles": 1,
+        "periodUnit": "DAY",
+        "periodNumberOfUnits": 7
+      },
+      "discounts": null,
+      "intro_price": 0,
+      "intro_price_string": "\$0.00",
+      "intro_price_period": "P1W",
+      "intro_price_cycles": 1,
+      "intro_price_period_unit": "DAY",
+      "intro_price_period_number_of_units": 7
+    }];
+    var list = await Purchases.getProducts(['sku_a']);
+    expect(list.length, 1);
+  });
 }


### PR DESCRIPTION
Should fix https://github.com/RevenueCat/purchases-flutter/issues/163

I removed some explicit types when preparing the release 3.0.0. These changes broke `getProducts` and `checkTrialOrIntroductoryPriceEligibility`.

Followup tasks on this PR should be:
1. Write tests for all functions, this PR only adds tests for the broken ones.
1. Add rule to linter to disable implicit dynamic. 

I have created Clubhouse tasks for both