### PR TITLE
removed duplicated entry in changelog

### DIFF
--- a/CHANGELOG-LATEST.md
+++ b/CHANGELOG-LATEST.md
@@ -2,8 +2,6 @@
 
 - Fixed an issue that would cause an error saying `type 'Null' is not a subtype of type 'String' in type cast` in `allExpirationDates` when null-safety is enabled.
     https://github.com/RevenueCat/purchases-flutter/pull/177
-- iOS:
-    - Added a new property `simulateAsksToBuyInSandbox`, that allows developers to test deferred purchases easily.
 - Bumped purchases-hybrid-common to 1.6.2 [Changelog here](https://github.com/RevenueCat/purchases-hybrid-common/releases/1.6.2)
 - Bumped purchases-ios to 3.10.7 [Changelog here](https://github.com/RevenueCat/purchases-ios/releases/3.10.7)
 - Bumped purchases-android to 4.0.5 [Changelog here](https://github.com/RevenueCat/purchases-hybrid-common/releases/4.0.5)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 - Fixed an issue that would cause an error saying `type 'Null' is not a subtype of type 'String' in type cast` in `allExpirationDates` when null-safety is enabled.
     https://github.com/RevenueCat/purchases-flutter/pull/177
-- iOS:
-    - Added a new property `simulateAsksToBuyInSandbox`, that allows developers to test deferred purchases easily.
 - Bumped purchases-hybrid-common to 1.6.2 [Changelog here](https://github.com/RevenueCat/purchases-hybrid-common/releases/1.6.2)
 - Bumped purchases-ios to 3.10.7 [Changelog here](https://github.com/RevenueCat/purchases-ios/releases/3.10.7)
 - Bumped purchases-android to 4.0.5 [Changelog here](https://github.com/RevenueCat/purchases-hybrid-common/releases/4.0.5)


### PR DESCRIPTION
I just realized that there was a duplicate entry in the changelog bullet points, in 3.1.0 and 3.1.1. 
This PR removes it, and I've removed it from the release notes. 