### PR TITLE
Upgrade integration_test version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,10 +190,10 @@ workflows:
       - test
   android-integration-test:
     jobs:
-      - android-integration-test-build
+      - android-integration-test-build: *release-tags-and-branches
       - run-firebase-tests:
           requires:
             - android-integration-test-build
   ios-integration-test:
     jobs:
-      - ios-integration-test
+      - ios-integration-test: *release-tags-and-branches

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,10 +190,10 @@ workflows:
       - test
   android-integration-test:
     jobs:
-      - android-integration-test-build: *release-tags-and-branches
+      - android-integration-test-build
       - run-firebase-tests:
           requires:
             - android-integration-test-build
   ios-integration-test:
     jobs:
-      - ios-integration-test: *release-tags-and-branches
+      - ios-integration-test

--- a/revenuecat_examples/purchase_tester/pubspec.yaml
+++ b/revenuecat_examples/purchase_tester/pubspec.yaml
@@ -25,7 +25,8 @@ dev_dependencies:
     sdk: flutter
   test: any
   build_runner: ^1.0.0
-  integration_test: ^0.9.2+2
+  integration_test:
+    sdk: flutter
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec


### PR DESCRIPTION
Some jobs were failing https://app.circleci.com/pipelines/github/RevenueCat/purchases-flutter/326/workflows/372a458c-6378-4764-bc61-698f9ea475fc/jobs/1040 due to a dependency incompatibility between `integration_test` and `flutter_driver`.

`integration_test` has been updated to use the version included in the Flutter SDK, which is the new recommended way of adding it.