### PR TITLE
Fix: error codes mismap

### DIFF
--- a/lib/errors.dart
+++ b/lib/errors.dart
@@ -41,6 +41,9 @@ enum PurchasesErrorCode {
   /// Received malformed response from the backend.
   unexpectedBackendResponseError,
 
+  /// There is already another active subscriber using the same receipt.
+  receiptInUseByOtherSubscriberError,
+
   /// The app user id is not valid.
   invalidAppUserIdError,
 
@@ -66,16 +69,17 @@ enum PurchasesErrorCode {
   paymentPendingError,
 
   /// One or more of the attributes sent could not be saved.
-  invalidSubscriberAttributesError
+  invalidSubscriberAttributesError,
 
   /// Called logOut but the current user is anonymous.
   logOutWithAnonymousUserError,
 
   /// There is an issue with your configuration. Check the underlying error for more details.
-  configurationError
+  configurationError,
 
-  ///  There was a problem with the operation. Looks like we doesn't support that yet. Check the underlying error for more details.
-  UnsupportedError
+  /// There was a problem with the operation. Looks like we doesn't support that yet.
+  /// Check the underlying error for more details.
+  unsupportedError,
 }
 
 /// Helper to convert from PlatformExceptions to PurchasesErrorCodes

--- a/lib/errors.dart
+++ b/lib/errors.dart
@@ -41,9 +41,6 @@ enum PurchasesErrorCode {
   /// Received malformed response from the backend.
   unexpectedBackendResponseError,
 
-  /// There is already another active subscriber using the same receipt.
-  receiptInUseByOtherSubscriberError,
-
   /// The app user id is not valid.
   invalidAppUserIdError,
 
@@ -70,6 +67,15 @@ enum PurchasesErrorCode {
 
   /// One or more of the attributes sent could not be saved.
   invalidSubscriberAttributesError
+
+  /// Called logOut but the current user is anonymous.
+  logOutWithAnonymousUserError,
+
+  /// There is an issue with your configuration. Check the underlying error for more details.
+  configurationError
+
+  ///  There was a problem with the operation. Looks like we doesn't support that yet. Check the underlying error for more details.
+  UnsupportedError
 }
 
 /// Helper to convert from PlatformExceptions to PurchasesErrorCodes

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -175,4 +175,32 @@ void main() {
       fail("there was an exception " + e.toString());
     }
   });
+
+  test('errors are mapped correctly', () { 
+    assert(PurchasesErrorCode.unknownError.index == 0);
+    assert(PurchasesErrorCode.purchaseCancelledError.index == 1);
+    assert(PurchasesErrorCode.storeProblemError.index == 2);
+    assert(PurchasesErrorCode.purchaseNotAllowedError.index == 3);
+    assert(PurchasesErrorCode.purchaseInvalidError.index == 4);
+    assert(PurchasesErrorCode.productNotAvailableForPurchaseError.index == 5);
+    assert(PurchasesErrorCode.productAlreadyPurchasedError.index == 6);
+    assert(PurchasesErrorCode.receiptAlreadyInUseError.index == 7);
+    assert(PurchasesErrorCode.invalidReceiptError.index == 8);
+    assert(PurchasesErrorCode.missingReceiptFileError.index == 9);
+    assert(PurchasesErrorCode.networkError.index == 10);
+    assert(PurchasesErrorCode.invalidCredentialsError.index == 11);
+    assert(PurchasesErrorCode.unexpectedBackendResponseError.index == 12);
+    assert(PurchasesErrorCode.receiptInUseByOtherSubscriberError.index == 13);
+    assert(PurchasesErrorCode.invalidAppUserIdError.index == 14);
+    assert(PurchasesErrorCode.operationAlreadyInProgressError.index == 15);
+    assert(PurchasesErrorCode.unknownBackendError.index == 16);
+    assert(PurchasesErrorCode.invalidAppleSubscriptionKeyError.index == 17);
+    assert(PurchasesErrorCode.ineligibleError.index == 18);
+    assert(PurchasesErrorCode.insufficientPermissionsError.index == 19);
+    assert(PurchasesErrorCode.paymentPendingError.index == 20);
+    assert(PurchasesErrorCode.invalidSubscriberAttributesError.index == 21);
+    assert(PurchasesErrorCode.logOutWithAnonymousUserError.index == 22);
+    assert(PurchasesErrorCode.configurationError.index == 23);
+    assert(PurchasesErrorCode.unsupportedError.index == 24);
+  })
 }

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -230,5 +230,6 @@ void main() {
     expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '22')), PurchasesErrorCode.logOutWithAnonymousUserError);
     expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '23')), PurchasesErrorCode.configurationError);
     expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '24')), PurchasesErrorCode.unsupportedError);
+    expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '25')), PurchasesErrorCode.unknownError);
   });
 }

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -176,31 +176,59 @@ void main() {
     }
   });
 
-  test('errors are mapped correctly', () { 
-    assert(PurchasesErrorCode.unknownError.index == 0);
-    assert(PurchasesErrorCode.purchaseCancelledError.index == 1);
-    assert(PurchasesErrorCode.storeProblemError.index == 2);
-    assert(PurchasesErrorCode.purchaseNotAllowedError.index == 3);
-    assert(PurchasesErrorCode.purchaseInvalidError.index == 4);
-    assert(PurchasesErrorCode.productNotAvailableForPurchaseError.index == 5);
-    assert(PurchasesErrorCode.productAlreadyPurchasedError.index == 6);
-    assert(PurchasesErrorCode.receiptAlreadyInUseError.index == 7);
-    assert(PurchasesErrorCode.invalidReceiptError.index == 8);
-    assert(PurchasesErrorCode.missingReceiptFileError.index == 9);
-    assert(PurchasesErrorCode.networkError.index == 10);
-    assert(PurchasesErrorCode.invalidCredentialsError.index == 11);
-    assert(PurchasesErrorCode.unexpectedBackendResponseError.index == 12);
-    assert(PurchasesErrorCode.receiptInUseByOtherSubscriberError.index == 13);
-    assert(PurchasesErrorCode.invalidAppUserIdError.index == 14);
-    assert(PurchasesErrorCode.operationAlreadyInProgressError.index == 15);
-    assert(PurchasesErrorCode.unknownBackendError.index == 16);
-    assert(PurchasesErrorCode.invalidAppleSubscriptionKeyError.index == 17);
-    assert(PurchasesErrorCode.ineligibleError.index == 18);
-    assert(PurchasesErrorCode.insufficientPermissionsError.index == 19);
-    assert(PurchasesErrorCode.paymentPendingError.index == 20);
-    assert(PurchasesErrorCode.invalidSubscriberAttributesError.index == 21);
-    assert(PurchasesErrorCode.logOutWithAnonymousUserError.index == 22);
-    assert(PurchasesErrorCode.configurationError.index == 23);
-    assert(PurchasesErrorCode.unsupportedError.index == 24);
-  })
+  test('errors are mapped correctly', () {
+    expect(PurchasesErrorCode.unknownError.index, 0);
+    expect(PurchasesErrorCode.purchaseCancelledError.index, 1);
+    expect(PurchasesErrorCode.storeProblemError.index, 2);
+    expect(PurchasesErrorCode.purchaseNotAllowedError.index, 3);
+    expect(PurchasesErrorCode.purchaseInvalidError.index, 4);
+    expect(PurchasesErrorCode.productNotAvailableForPurchaseError.index, 5);
+    expect(PurchasesErrorCode.productAlreadyPurchasedError.index, 6);
+    expect(PurchasesErrorCode.receiptAlreadyInUseError.index, 7);
+    expect(PurchasesErrorCode.invalidReceiptError.index, 8);
+    expect(PurchasesErrorCode.missingReceiptFileError.index, 9);
+    expect(PurchasesErrorCode.networkError.index, 10);
+    expect(PurchasesErrorCode.invalidCredentialsError.index, 11);
+    expect(PurchasesErrorCode.unexpectedBackendResponseError.index, 12);
+    expect(PurchasesErrorCode.receiptInUseByOtherSubscriberError.index, 13);
+    expect(PurchasesErrorCode.invalidAppUserIdError.index, 14);
+    expect(PurchasesErrorCode.operationAlreadyInProgressError.index, 15);
+    expect(PurchasesErrorCode.unknownBackendError.index, 16);
+    expect(PurchasesErrorCode.invalidAppleSubscriptionKeyError.index, 17);
+    expect(PurchasesErrorCode.ineligibleError.index, 18);
+    expect(PurchasesErrorCode.insufficientPermissionsError.index, 19);
+    expect(PurchasesErrorCode.paymentPendingError.index, 20);
+    expect(PurchasesErrorCode.invalidSubscriberAttributesError.index, 21);
+    expect(PurchasesErrorCode.logOutWithAnonymousUserError.index, 22);
+    expect(PurchasesErrorCode.configurationError.index, 23);
+    expect(PurchasesErrorCode.unsupportedError.index, 24);
+  });
+
+  test('PurchasesErrorHelper maps errors correctly', () {
+    expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '0')), PurchasesErrorCode.unknownError);
+    expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '1')), PurchasesErrorCode.purchaseCancelledError);
+    expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '2')), PurchasesErrorCode.storeProblemError);
+    expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '3')), PurchasesErrorCode.purchaseNotAllowedError);
+    expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '4')), PurchasesErrorCode.purchaseInvalidError);
+    expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '5')), PurchasesErrorCode.productNotAvailableForPurchaseError);
+    expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '6')), PurchasesErrorCode.productAlreadyPurchasedError);
+    expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '7')), PurchasesErrorCode.receiptAlreadyInUseError);
+    expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '8')), PurchasesErrorCode.invalidReceiptError);
+    expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '9')), PurchasesErrorCode.missingReceiptFileError);
+    expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '10')), PurchasesErrorCode.networkError);
+    expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '11')), PurchasesErrorCode.invalidCredentialsError);
+    expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '12')), PurchasesErrorCode.unexpectedBackendResponseError);
+    expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '13')), PurchasesErrorCode.receiptInUseByOtherSubscriberError);
+    expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '14')), PurchasesErrorCode.invalidAppUserIdError);
+    expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '15')), PurchasesErrorCode.operationAlreadyInProgressError);
+    expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '16')), PurchasesErrorCode.unknownBackendError);
+    expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '17')), PurchasesErrorCode.invalidAppleSubscriptionKeyError);
+    expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '18')), PurchasesErrorCode.ineligibleError);
+    expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '19')), PurchasesErrorCode.insufficientPermissionsError);
+    expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '20')), PurchasesErrorCode.paymentPendingError);
+    expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '21')), PurchasesErrorCode.invalidSubscriberAttributesError);
+    expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '22')), PurchasesErrorCode.logOutWithAnonymousUserError);
+    expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '23')), PurchasesErrorCode.configurationError);
+    expect(PurchasesErrorHelper.getErrorCode(PlatformException(code: '24')), PurchasesErrorCode.unsupportedError);
+  });
 }


### PR DESCRIPTION
adds a couple of error codes that were missing + tests. 
I don't think this fully addresses the issue in #220, since the error displayed there _is_ the correct one for code `19`, so the bug is probably in the assignment of the error code, not the translation of it. 