### PR TITLE
suppress deprecation warnings for types from plugin versions pre-1.12

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -47,6 +47,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
     private static final String PURCHASER_INFO_UPDATED = "Purchases-PurchaserInfoUpdated";
 
     // Only set registrar for v1 embedder.
+    @SuppressWarnings("deprecation")
     private PluginRegistry.Registrar registrar;
     // Only set activity for v2 embedder. Always access activity from getActivity() method.
     @Nullable private Context applicationContext;
@@ -59,6 +60,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
     /**
      * Plugin registration.
      */
+    @SuppressWarnings("deprecation")
     public static void registerWith(Registrar registrar) {
         PurchasesFlutterPlugin instance = new PurchasesFlutterPlugin();
         instance.onAttachedToEngine(registrar.messenger(), registrar.context());
@@ -343,6 +345,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
         }
     }
 
+    @SuppressWarnings("deprecation")
     private void setAllowSharingAppStoreAccount(@Nullable Boolean allowSharingAppStoreAccount, Result result) {
         if (allowSharingAppStoreAccount != null) {
             CommonKt.setAllowSharingAppStoreAccount(allowSharingAppStoreAccount);
@@ -416,10 +419,12 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
         CommonKt.restoreTransactions(getOnResult(result));
     }
 
+    @SuppressWarnings("deprecation")
     private void reset(final Result result) {
         CommonKt.reset(getOnResult(result));
     }
 
+    @SuppressWarnings("deprecation")
     private void identify(String appUserID, final Result result) {
         CommonKt.identify(appUserID, getOnResult(result));
     }
@@ -432,6 +437,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
         CommonKt.logIn(appUserID, getOnResult(result));
     }
 
+    @SuppressWarnings("deprecation")
     private void createAlias(String newAppUserID, final Result result) {
         CommonKt.createAlias(newAppUserID, getOnResult(result));
     }


### PR DESCRIPTION
Flutter released a new format for plugins in version 1.12. 

We [upgraded to the new format back in June 2020](https://github.com/RevenueCat/purchases-flutter/commit/da374dae3c19a843c21cb77c5296d1c48e969655), however, Flutter recommends that we [keep the old methods around](https://flutter.dev/docs/development/packages-and-plugins/plugin-api-migration#upgrade-steps) for apps that use the v1 method of embedding. 

Having those references around produces deprecation warnings, though. So this PR suppresses the deprecation warnings, along with a couple coming from implementations of our own methods that are deprecated. 

This is also what Flutter itself is doing for their plugins, [see this example](https://github.com/flutter/plugins/blob/4383bb15d91384efb22dbe409c3fd58e4552267c/packages/battery/battery/android/src/main/java/io/flutter/plugins/battery/BatteryPlugin.java#L34). 

Addresses #213 
