### PR TITLE
Remove excluded architectures from simulator build

### DIFF
--- a/ios/purchases_flutter.podspec
+++ b/ios/purchases_flutter.podspec
@@ -19,10 +19,8 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '9.0'
   s.swift_version         = '5.0'
 
-  # Flutter.framework does not contain a i386 slice.
-  s.pod_target_xcconfig = { 
+  s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
-    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
     'OTHER_LDFLAGS' => '-framework Purchases'
    }
 


### PR DESCRIPTION
The removed instruction was preventing me from building for the
simulator on an x86 mac.

```
    ld: warning: Could not find or use auto-linked framework 'PurchasesCoreSwift'
    Undefined symbols for architecture arm64:
      "_OBJC_CLASS_$_RCCommonFunctionality", referenced from:
          objc-class-ref in PurchasesFlutterPlugin.o
      "_OBJC_CLASS_$_RCPurchases", referenced from:
          objc-class-ref in PurchasesFlutterPlugin.o
    ld: symbol(s) not found for architecture arm64
```

My own Podfile requires a different and apparently conflicting
instruction:

```rb
post_install do |installer|
  installer.pods_project.build_configurations.each do |config|
    config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
  end
end
```

It's sad that we need these hacks at all, but it's better to keep the
hack outside the framework since your downstream users may need a
different hack depending on their system architecture.
