### PR TITLE
removes call to close in onDetachedToEngine and creates new close fun…

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -88,11 +88,6 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
 
     @Override
     public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
-        try {
-            Purchases.getSharedInstance().close();
-        } catch (UninitializedPropertyAccessException e) {
-            // there's no instance so all good
-        }
         if (channel != null) {
             channel.setMethodCallHandler(null);
         }
@@ -298,6 +293,9 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
             case "canMakePayments":
                 List<Integer> features = call.argument("features");
                 canMakePayments(features, result);
+                break;
+            case "close":
+                close(result);
                 break;
             default:
                 result.notImplemented();
@@ -574,6 +572,15 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                         reject(errorContainer, result);
                     }
                 });
+    }
+
+    private void close(final Result result) {
+        try {
+            Purchases.getSharedInstance().close();
+        } catch (UninitializedPropertyAccessException e) {
+            // there's no instance so all good
+        }
+        result.success(null);
     }
 
     @NotNull

--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -165,6 +165,8 @@ NSString *RNPurchasesPurchaserInfoUpdatedEvent = @"Purchases-PurchaserInfoUpdate
         [self paymentDiscountForProductIdentifier:productIdentifier
                                discountIdentifier:discountIdentifier
                                            result:result];
+    } else if ([@"close" isEqualToString:call.method]) {
+        [self closeWithResult:result];
     } else {
         result(FlutterMethodNotImplemented);
     }
@@ -453,6 +455,10 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
                                                        result(responseDictionary);
                                                    }
                                                }];
+}
+
+- (void)closeWithResult:(FlutterResult)result {
+    result(nil);
 }
 
 #pragma mark -

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -589,6 +589,12 @@ class Purchases {
     });
     return PaymentDiscount.fromJson(result);
   }
+
+  /// Android only. Call close when you are done with this instance of Purchases to disconnect
+  /// from the billing services and clean up resources
+  static Future<void> close() async {
+    await _channel.invokeMethod('close');
+  }
 }
 
 /// This class holds the information used when upgrading from another sku.


### PR DESCRIPTION
Should fix https://github.com/RevenueCat/purchases-flutter/issues/257
Should fix https://community.revenuecat.com/sdks-51/debugging-hanging-purchase-request-purchaseerrorcode-operationalreadyinprogress-615?postid=1891#post1891

`workmanager` plugin destroys the FlutterEngine, which would call `onDetachedFromEngine`. We were calling `close` in our instance. I've removed that call and instead created a `close` function that devs can call whenever they want. The iOS function doesn't do anything since we don't have a close function in iOS, we just clean up on `dealloc`