### PR TITLE
Add ownershipType to entitlementInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-- Adds ownershipType to the EntitlementInfo wrapper
-
 ## 3.7.0
 
 - Bump`purchases-hybrid-common` to `1.11.0` [Changelog here](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/1.11.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Adds ownershipType to the EntitlementInfo wrapper
+
 ## 3.7.0
 
 - Bump`purchases-hybrid-common` to `1.11.0` [Changelog here](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/1.11.0)

--- a/lib/entitlement_info_wrapper.dart
+++ b/lib/entitlement_info_wrapper.dart
@@ -112,8 +112,8 @@ class EntitlementInfo {
       case "PURCHASED":
         ownershipType = OwnershipType.purchased;
         break;
-      case "FAMILY_SHARING":
-        ownershipType = OwnershipType.familySharing;
+      case "FAMILY_SHARED":
+        ownershipType = OwnershipType.familyShared;
         break;
       default:
         ownershipType = OwnershipType.unknown;
@@ -198,13 +198,12 @@ enum Store {
 
 /// Enum of ownership types
 enum OwnershipType {
-  /// For ownership when a user made the purchase themselves
+  /// The purchase was made directly by this user.
   purchased,
 
-  /// For ownership when a user has been shared the purchase via family sharing
-  familySharing,
+  /// The purchase has been shared to this user by a family member.
+  familyShared,
 
-  /// For when the ownership type is unknown. Maybe there is no purchase.
-  /// Maybe it came from a store which doesn't publish this information
+  /// The purchase has no or an unknown ownership type.
   unknown
 }

--- a/lib/entitlement_info_wrapper.dart
+++ b/lib/entitlement_info_wrapper.dart
@@ -47,6 +47,12 @@ class EntitlementInfo {
   /// Check the `isActive` property.
   final String? billingIssueDetectedAt;
 
+  /// Use this property to determine whether a purchase was made by the current
+  /// user or shared to them by a family member. This can be useful for
+  /// onboarding users who have had an entitlement shared with them, but might
+  /// not be entirely aware of the benefits they now have.
+  final OwnershipType ownershipType;
+
   /// Construct an EntitlementInfo
   EntitlementInfo(
       this.identifier,
@@ -60,7 +66,8 @@ class EntitlementInfo {
       this.productIdentifier,
       this.isSandbox,
       this.unsubscribeDetectedAt,
-      this.billingIssueDetectedAt);
+      this.billingIssueDetectedAt,
+      this.ownershipType);
 
   /// Constructs an EntitlementInfo from a JSON object
   factory EntitlementInfo.fromJson(Map<dynamic, dynamic> json) {
@@ -100,6 +107,17 @@ class EntitlementInfo {
         store = Store.unknownStore;
         break;
     }
+    late var ownershipType;
+    switch (json["ownershipType"]) {
+      case "PURCHASED":
+        ownershipType = OwnershipType.purchased;
+        break;
+      case "FAMILY_SHARING":
+        ownershipType = OwnershipType.familySharing;
+        break;
+      default:
+        ownershipType = OwnershipType.unknown;
+    }
     return EntitlementInfo(
         json["identifier"] as String,
         json["isActive"] as bool,
@@ -112,12 +130,13 @@ class EntitlementInfo {
         json["productIdentifier"] as String,
         json["isSandbox"] as bool,
         json["unsubscribeDetectedAt"] as String?,
-        json["billingIssueDetectedAt"] as String?);
+        json["billingIssueDetectedAt"] as String?,
+        ownershipType);
   }
 
   @override
   String toString() {
-    return 'EntitlementInfo{identifier: $identifier, isActive: $isActive, willRenew: $willRenew, periodType: $periodType, latestPurchaseDate: $latestPurchaseDate, originalPurchaseDate: $originalPurchaseDate, expirationDate: $expirationDate, store: $store, productIdentifier: $productIdentifier, isSandbox: $isSandbox, unsubscribeDetectedAt: $unsubscribeDetectedAt, billingIssueDetectedAt: $billingIssueDetectedAt}';
+    return 'EntitlementInfo{identifier: $identifier, isActive: $isActive, willRenew: $willRenew, periodType: $periodType, latestPurchaseDate: $latestPurchaseDate, originalPurchaseDate: $originalPurchaseDate, expirationDate: $expirationDate, store: $store, productIdentifier: $productIdentifier, isSandbox: $isSandbox, unsubscribeDetectedAt: $unsubscribeDetectedAt, billingIssueDetectedAt: $billingIssueDetectedAt, ownershipType: $ownershipType}';
   }
 
   @override
@@ -136,7 +155,8 @@ class EntitlementInfo {
         this.productIdentifier == other.productIdentifier &&
         this.isSandbox == other.isSandbox &&
         this.unsubscribeDetectedAt == other.unsubscribeDetectedAt &&
-        this.billingIssueDetectedAt == other.billingIssueDetectedAt);
+        this.billingIssueDetectedAt == other.billingIssueDetectedAt &&
+        this.ownershipType == other.ownershipType);
   }
 }
 
@@ -174,4 +194,17 @@ enum Store {
 
   /// For entitlements granted via an unknown store.
   unknownStore
+}
+
+/// Enum of ownership types
+enum OwnershipType {
+  /// For ownership when a user made the purchase themselves
+  purchased,
+
+  /// For ownership when a user has been shared the purchase via family sharing
+  familySharing,
+
+  /// For when the ownership type is unknown. Maybe there is no purchase.
+  /// Maybe it came from a store which doesn't publish this information
+  unknown
 }

--- a/test/entitlement_info_test.dart
+++ b/test/entitlement_info_test.dart
@@ -49,4 +49,68 @@ void main() {
 
     expect(entitlementInfo.store, Store.unknownStore);
   });
+
+  test('unknown ownership type if missing from json', () {
+    Map<dynamic, dynamic> entitlementInfoJson = {
+      "identifier": "almost_pro",
+      "isActive": true,
+      "willRenew": true,
+      "latestPurchaseDateMillis": 1.58759855E9,
+      "latestPurchaseDate": "2020-04-22T23:35:50.000Z",
+      "originalPurchaseDateMillis": 1.591725245E9,
+      "originalPurchaseDate": "2020-06-09T17:54:05.000Z",
+      "expirationDateMillis": null,
+      "expirationDate": null,
+      "store": "PLAY_STORE",
+      "productIdentifier": "consumable",
+      "isSandbox": true,
+      "unsubscribeDetectedAt": null,
+      "unsubscribeDetectedAtMillis": null,
+      "billingIssueDetectedAt": null,
+      "billingIssueDetectedAtMillis": null
+    };
+    final entitlementInfo = EntitlementInfo.fromJson(entitlementInfoJson);
+
+    expect(entitlementInfo.ownershipType, OwnershipType.unknown);
+  });
+
+  test('ownership type parsed from json', () {
+    Map<dynamic, dynamic> entitlementInfoJson = {
+      "identifier": "almost_pro",
+      "isActive": true,
+      "willRenew": true,
+      "latestPurchaseDateMillis": 1.58759855E9,
+      "latestPurchaseDate": "2020-04-22T23:35:50.000Z",
+      "originalPurchaseDateMillis": 1.591725245E9,
+      "originalPurchaseDate": "2020-06-09T17:54:05.000Z",
+      "expirationDateMillis": null,
+      "expirationDate": null,
+      "store": "PLAY_STORE",
+      "productIdentifier": "consumable",
+      "isSandbox": true,
+      "unsubscribeDetectedAt": null,
+      "unsubscribeDetectedAtMillis": null,
+      "billingIssueDetectedAt": null,
+      "billingIssueDetectedAtMillis": null
+    };
+    entitlementInfoJson["ownershipType"] = "PURCHASED";
+    var entitlementInfo = EntitlementInfo.fromJson(entitlementInfoJson);
+
+    expect(entitlementInfo.ownershipType, OwnershipType.purchased);
+
+    entitlementInfoJson["ownershipType"] = "FAMILY_SHARED";
+    entitlementInfo = EntitlementInfo.fromJson(entitlementInfoJson);
+
+    expect(entitlementInfo.ownershipType, OwnershipType.familyShared);
+
+    entitlementInfoJson["ownershipType"] = "UNKNOWN";
+    entitlementInfo = EntitlementInfo.fromJson(entitlementInfoJson);
+
+    expect(entitlementInfo.ownershipType, OwnershipType.unknown);
+
+    entitlementInfoJson["ownershipType"] = "AN_UNKNOWN_OWNERSHIP_TYPE";
+    entitlementInfo = EntitlementInfo.fromJson(entitlementInfoJson);
+
+    expect(entitlementInfo.ownershipType, OwnershipType.unknown);
+  });
 }


### PR DESCRIPTION
Description:

This PR exposes `ownershipType` on `EntitlementInfo` as, while it had been added to `purchases-hybrid-common`, it was unavailable in the flutter SDK itself.

`purchases-android` PR: https://github.com/RevenueCat/purchases-android/pull/382
`purchases-hybrid-common` PR: https://github.com/RevenueCat/purchases-hybrid-common/pull/103

  - [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

Related to Zendesk ticket: 12668

  - [x] If applicable, unit tests.
