### PR TITLE
[github] update issue templates with emojis, same feature request url

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ commands:
           name: Build
           command: |
             cd <<parameters.project>>
-            flutter packages pub run build_runner build
+            flutter packages pub run build_runner build --delete-conflicting-outputs
 
   gradle-dependencies:
     description: "Get Gradle dependencies"

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: Bug report
+name: 🐛 Bug report
 about: Filling a bug report
 title: ""
 labels: bug

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,23 +1,24 @@
 blank_issues_enabled: false
 contact_links:
-  - name: RevenueCat System Status
+  - name: 🚥 RevenueCat system status
     url: https://status.revenuecat.com
     about: Check RevenueCat's API status
-  - name: Our online community
+  - name: 🙋 Our online community
     url: https://community.revenuecat.com
-    about: Please ask and answer questions here
-  - name: Account or billing support
+    about: Please ask and answer questions at https://community.revenuecat.com
+  - name: 🧾 Account or billing support
     url: https://app.revenuecat.com/settings/support
     about: Get help from our support team
-  - name: Feature Request
+  - name: ✨ Feature request
     url: https://app.revenuecat.com/settings/support
     about: Please use the Contact Us form instead of opening an issue. This is best channel that allows us to keep track of feature requests.
-  - name: Offerings, products, or available packages are empty
+  - name: ❓ Offerings, products, or available packages are empty
     url: https://community.revenuecat.com/search?q=why_are_offerings_empty&content_type[0]=discussion
     about: Why are my products, offerings, or available packages empty?
-  - name: Invalid Play Store credentials errors
+  - name: ❓ Invalid Play Store credentials errors
     url: https://community.revenuecat.com/search?q=invalid_play_store_credentials&content_type%5B0%5D=discussion
     about: How to solve Play Store credentials errors
-  - name: Unable to connect to the App Store (STORE_PROBLEM) errors
+  - name: ❓ Unable to connect to the App Store (STORE_PROBLEM) errors
     url: https://community.revenuecat.com/search?q=store%20problem&content_type%5B0%5D=discussion
     about: Why I get STORE_PROBLEM errors
+    

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: Feature request
+name: ✨ Feature request
 about: Suggest an idea for this project
 title: ''
 labels: enhancement
@@ -7,4 +7,4 @@ assignees: ''
 
 ---
 
-Please use https://support.revenuecat.com/hc/en-us/articles/360046422033-Feature-Requests instead of opening an issue. That is the best channel that allows us to keep track of feature requests.
+Please use https://app.revenuecat.com/settings/support instead of opening an issue. That is the best channel that allows us to keep track of feature requests.

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -404,9 +404,8 @@ class Purchases {
       await _channel.invokeMethod('isAnonymous') as bool;
 
   /// Returns `true` if RevenueCat has already been intialized through `setup()`.
-  static Future<bool> get isConfigured async {
-    return await _channel.invokeMethod('isConfigured') as bool;
-  }
+  static Future<bool> get isConfigured async =>
+    await _channel.invokeMethod('isConfigured') as bool;
 
   /// iOS only. Computes whether or not a user is eligible for the introductory
   /// pricing period of a given product. You should use this method to determine
@@ -539,7 +538,7 @@ class Purchases {
   /// [airshipChannelID] Empty String or null will delete the subscriber attribute.
   static Future<void> setAirshipChannelID(String airshipChannelID) async {
     await _channel.invokeMethod(
-        'setAirshipChannelID', {'airshipChannelID': airshipChannelID});
+        'setAirshipChannelID', {'airshipChannelID': airshipChannelID},);
   }
 
   /// Subscriber attribute associated with the install media source for the user

--- a/revenuecat_examples/purchase_tester/analysis_options.yaml
+++ b/revenuecat_examples/purchase_tester/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: package:pedantic/analysis_options.1.8.0.yaml
+analyzer:
+  exclude:
+    # Ignore generated files
+    - '**/*.g.dart'
+    - 'lib/src/generated/*.dart'


### PR DESCRIPTION
Similar to https://github.com/RevenueCat/purchases-ios/pull/1088

## Motivation
Make issue templates fun and easy to scan with emojis that can help the user find the right item they are looking for 

## Description
- Prefixed issue templates with meaningful emojis
- Fixed capitalization scheme so everything is the same
- Updated all feature requests links to go to https://app.revenuecat.com/settings/support (after getting confirmation from support slack channel)

⚠️  This **also** has a fix for a failing CI that was happening for unknown reason
- added `--delete-conflicting-outputs` which seemed to be from some existing output that was there but I'm not really sure why 🤷‍♂️ 
- fixed lint error produced by `flutter analyze lib` 

PS - I've done as close to no flutter as possible so hopefully these fixes I made are okay 🙃 