### PR TITLE
Prep for release 3.9.3

### DIFF
--- a/CHANGELOG-LATEST.md
+++ b/CHANGELOG-LATEST.md
@@ -1,7 +1,3 @@
-## 3.9.2
+## 3.9.3
 
-- Fix `purchasePackage`, `purchaseProduct`, `purchaseDiscountedPackage` and `purchaseDiscountedProduct` crashes due to a wrong type.
-- Added missing freezed files.
-    https://github.com/RevenueCat/purchases-flutter/pull/301
-- CI fail if missing freezed files
-    https://github.com/RevenueCat/purchases-flutter/pull/302
+- Fix missing IntroductoryPrice export (https://github.com/RevenueCat/purchases-flutter/pull/310)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.9.3
+
+- Fix missing IntroductoryPrice export (https://github.com/RevenueCat/purchases-flutter/pull/310)
+
 ## 3.9.2
 
 - Fix `purchasePackage`, `purchaseProduct`, `purchaseDiscountedPackage` and `purchaseDiscountedProduct` crashes due to a wrong type.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GEM
     artifactory (3.0.15)
     atomos (0.1.3)
     aws-eventstream (1.2.0)
-    aws-partitions (1.549.0)
-    aws-sdk-core (3.125.3)
+    aws-partitions (1.551.0)
+    aws-sdk-core (3.125.5)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
       aws-sigv4 (~> 1.1)
@@ -17,7 +17,7 @@ GEM
     aws-sdk-kms (1.53.0)
       aws-sdk-core (~> 3, >= 3.125.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.111.1)
+    aws-sdk-s3 (1.111.3)
       aws-sdk-core (~> 3, >= 3.125.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.4)
@@ -66,7 +66,7 @@ GEM
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
     fastimage (2.2.6)
-    fastlane (2.200.0)
+    fastlane (2.203.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)
@@ -108,7 +108,7 @@ GEM
     gh_inspector (1.1.3)
     google-apis-androidpublisher_v3 (0.15.0)
       google-apis-core (>= 0.4, < 2.a)
-    google-apis-core (0.4.1)
+    google-apis-core (0.4.2)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.16.2, < 2.a)
       httpclient (>= 2.8.1, < 3.a)
@@ -216,4 +216,4 @@ DEPENDENCIES
   fastlane
 
 BUNDLED WITH
-   2.2.26
+   2.2.27

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.revenuecat.purchases_flutter'
-version '3.9.2'
+version '3.9.3'
 
 buildscript {
     ext.kotlin_version = '1.3.72'

--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -52,7 +52,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
     @Nullable private Activity activity;
 
     private static final String PLATFORM_NAME = "flutter";
-    private static final String PLUGIN_VERSION = "3.9.2";
+    private static final String PLUGIN_VERSION = "3.9.3";
 
     /**
      * Plugin registration.

--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -507,7 +507,7 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
 }
 
 - (NSString *)platformFlavorVersion { 
-    return @"3.9.2";
+    return @"3.9.3";
 }
 
 @end

--- a/ios/purchases_flutter.podspec
+++ b/ios/purchases_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'purchases_flutter'
-  s.version          = '3.9.2'
+  s.version          = '3.9.3'
   s.summary          = 'Cross-platform subscriptions framework for Flutter.'
   s.description      = <<-DESC
   Client for the RevenueCat subscription and purchase tracking system, making implementing in-app subscriptions in Flutter easy - receipt validation and status tracking included!

--- a/macos/purchases_flutter.podspec
+++ b/macos/purchases_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'purchases_flutter'
-  s.version          = '3.9.2'
+  s.version          = '3.9.3'
   s.summary          = 'Cross-platform subscriptions framework for Flutter.'
   s.description      = <<-DESC
   Client for the RevenueCat subscription and purchase tracking system, making implementing in-app subscriptions in Flutter easy - receipt validation and status tracking included!

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: purchases_flutter
 description: A Flutter plugin that makes it simple to add and manage in-app
   purchases (IAP) and subscriptions. Supports Android, iOS, macOS, iPadOS, and
   watchOS.
-version: 3.9.2
+version: 3.9.3
 homepage: https://www.revenuecat.com/
 repository: https://github.com/RevenueCat/purchases-flutter
 issue_tracker: https://github.com/RevenueCat/purchases-flutter/issues


### PR DESCRIPTION
## 3.9.3

- Fix missing IntroductoryPrice export (https://github.com/RevenueCat/purchases-flutter/pull/310)
