### PR TITLE
Add back IntroductoryPrice.introPricePeriodUnit string

### DIFF
--- a/lib/models/introductory_price.dart
+++ b/lib/models/introductory_price.dart
@@ -42,7 +42,8 @@ class IntroductoryPrice with _$IntroductoryPrice {
     @JsonKey(name: 'periodNumberOfUnits') int periodNumberOfUnits,
   ) = _IntroductoryPrice;
 
-  /// Maps introPricePeriodUnit string to PeriodUnit enum type
+  /// Unit for the billing period of the introductory price, can be DAY, WEEK,
+  /// MONTH or YEAR.
   PeriodUnit get periodUnit {
     // ignore: deprecated_member_use_from_same_package
     switch (introPricePeriodUnit) {

--- a/lib/models/introductory_price.dart
+++ b/lib/models/introductory_price.dart
@@ -55,6 +55,29 @@ class IntroductoryPrice with _$IntroductoryPrice {
     }
   }
 
+  /// Introductory price of a subscription in the local currency.
+  @Deprecated('Use price instead.')
+  double get introPrice => price;
+
+  /// Formatted introductory price of a subscription, including
+  /// its currency sign, such as €3.99.
+  /// @Deprecated('Use priceString instead.')
+  String get introPriceString => priceString;
+
+  /// Billing period of the introductory price, specified in
+  /// ISO 8601 format.
+  @Deprecated('Use period instead.')
+  String get introPricePeriod => period;
+
+  /// Number of units for the billing period of the introductory price.
+  @Deprecated('Use periodNumberOfUnits instead.')
+  int get introPricePeriodNumberOfUnits => periodNumberOfUnits;
+
+  /// Number of subscription billing periods for which the
+  /// user will be given the introductory price, such as 3.
+  @Deprecated('Use cycles instead.')
+  int get introPriceCycles => cycles;
+
   factory IntroductoryPrice.fromJson(Map<String, dynamic> json) =>
       _$IntroductoryPriceFromJson(json);
 }

--- a/lib/models/introductory_price.dart
+++ b/lib/models/introductory_price.dart
@@ -3,14 +3,15 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 part 'introductory_price.freezed.dart';
 part 'introductory_price.g.dart';
 
+// TODO add back JsonValues fully removing introPricePeriodUnit
 enum PeriodUnit {
-  @JsonValue('DAY')
+  // @JsonValue('DAY')
   day,
-  @JsonValue('WEEK')
+  // @JsonValue('WEEK')
   week,
-  @JsonValue('MONTH')
+  // @JsonValue('MONTH')
   month,
-  @JsonValue('YEAR')
+  // @JsonValue('YEAR')
   year,
   unknown
 }
@@ -19,6 +20,9 @@ enum PeriodUnit {
 
 /// Contains all the introductory information associated with a [Product]
 class IntroductoryPrice with _$IntroductoryPrice {
+  // TODO remove this ctor when fully removing introPricePeriodUnit string
+  const IntroductoryPrice._();
+
   const factory IntroductoryPrice(
     /// Introductory price of a subscription in the local currency.
     @JsonKey(name: 'price') double price,
@@ -35,14 +39,32 @@ class IntroductoryPrice with _$IntroductoryPrice {
     /// user will be given the introductory price, such as 3.
     @JsonKey(name: 'cycles') int cycles,
 
-    /// Unit for the billing period of the introductory price, can be DAY, WEEK,
-    /// MONTH or YEAR.
-    @JsonKey(name: 'periodUnit', unknownEnumValue: PeriodUnit.unknown)
-        PeriodUnit periodUnit,
+   /// TODO add back when fully removing introPricePeriodUnit
+    // /// Unit for the billing period of the introductory price, can be DAY, WEEK,
+    // /// MONTH or YEAR.
+    // @JsonKey(name: 'periodUnit', unknownEnumValue: PeriodUnit.unknown)
+    // PeriodUnit periodUnit = getPeriodUnit(introPricePeriodUnit),
+
+    /// String representation of unit for the billing period of the introductory
+    /// price, can be DAY, WEEK, MONTH or YEAR.
+    @Deprecated('Use periodUnit property of type PeriodUnit instead.')
+    @JsonKey(name: 'periodUnit') String introPricePeriodUnit,
 
     /// Number of units for the billing period of the introductory price.
     @JsonKey(name: 'periodNumberOfUnits') int periodNumberOfUnits,
   ) = _IntroductoryPrice;
+
+  /// TODO remove this method when fully removing introPricePeriodUnit string
+  /// Maps introPricePeriodUnit string to PeriodUnit enum type
+  PeriodUnit get periodUnit {
+    switch (introPricePeriodUnit) {
+      case 'DAY': { return PeriodUnit.day; }
+      case 'WEEK': { return PeriodUnit.week; }
+      case 'MONTH': { return PeriodUnit.month; }
+      case 'YEAR': { return PeriodUnit.year; }
+      default: { return PeriodUnit.unknown; }
+    }
+  }
 
   factory IntroductoryPrice.fromJson(Map<String, dynamic> json) =>
       _$IntroductoryPriceFromJson(json);

--- a/lib/models/introductory_price.dart
+++ b/lib/models/introductory_price.dart
@@ -61,7 +61,7 @@ class IntroductoryPrice with _$IntroductoryPrice {
 
   /// Formatted introductory price of a subscription, including
   /// its currency sign, such as €3.99.
-  /// @Deprecated('Use priceString instead.')
+  @Deprecated('Use priceString instead.')
   String get introPriceString => priceString;
 
   /// Billing period of the introductory price, specified in

--- a/lib/models/introductory_price.dart
+++ b/lib/models/introductory_price.dart
@@ -44,6 +44,7 @@ class IntroductoryPrice with _$IntroductoryPrice {
 
   /// Maps introPricePeriodUnit string to PeriodUnit enum type
   PeriodUnit get periodUnit {
+    // ignore: deprecated_member_use_from_same_package
     switch (introPricePeriodUnit) {
       case 'DAY': { return PeriodUnit.day; }
       case 'WEEK': { return PeriodUnit.week; }

--- a/lib/models/introductory_price.dart
+++ b/lib/models/introductory_price.dart
@@ -3,15 +3,10 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 part 'introductory_price.freezed.dart';
 part 'introductory_price.g.dart';
 
-// TODO add back JsonValues fully removing introPricePeriodUnit
 enum PeriodUnit {
-  // @JsonValue('DAY')
   day,
-  // @JsonValue('WEEK')
   week,
-  // @JsonValue('MONTH')
   month,
-  // @JsonValue('YEAR')
   year,
   unknown
 }
@@ -20,7 +15,6 @@ enum PeriodUnit {
 
 /// Contains all the introductory information associated with a [Product]
 class IntroductoryPrice with _$IntroductoryPrice {
-  // TODO remove this ctor when fully removing introPricePeriodUnit string
   const IntroductoryPrice._();
 
   const factory IntroductoryPrice(
@@ -39,12 +33,6 @@ class IntroductoryPrice with _$IntroductoryPrice {
     /// user will be given the introductory price, such as 3.
     @JsonKey(name: 'cycles') int cycles,
 
-   /// TODO add back when fully removing introPricePeriodUnit
-    // /// Unit for the billing period of the introductory price, can be DAY, WEEK,
-    // /// MONTH or YEAR.
-    // @JsonKey(name: 'periodUnit', unknownEnumValue: PeriodUnit.unknown)
-    // PeriodUnit periodUnit = getPeriodUnit(introPricePeriodUnit),
-
     /// String representation of unit for the billing period of the introductory
     /// price, can be DAY, WEEK, MONTH or YEAR.
     @Deprecated('Use periodUnit property of type PeriodUnit instead.')
@@ -54,7 +42,6 @@ class IntroductoryPrice with _$IntroductoryPrice {
     @JsonKey(name: 'periodNumberOfUnits') int periodNumberOfUnits,
   ) = _IntroductoryPrice;
 
-  /// TODO remove this method when fully removing introPricePeriodUnit string
   /// Maps introPricePeriodUnit string to PeriodUnit enum type
   PeriodUnit get periodUnit {
     switch (introPricePeriodUnit) {

--- a/lib/models/introductory_price.freezed.dart
+++ b/lib/models/introductory_price.freezed.dart
@@ -31,7 +31,7 @@ class _$IntroductoryPriceTearOff {
           String period,
       @JsonKey(name: 'cycles')
           int cycles,
-      @Deprecated('Use periodUnit property of type PeriodUnit enum instead.')
+      @Deprecated('Use periodUnit property of type PeriodUnit instead.')
       @JsonKey(name: 'periodUnit')
           String introPricePeriodUnit,
       @JsonKey(name: 'periodNumberOfUnits')
@@ -73,15 +73,16 @@ mixin _$IntroductoryPrice {
   /// Number of subscription billing periods for which the
   /// user will be given the introductory price, such as 3.
   @JsonKey(name: 'cycles')
-  int get cycles =>
-      throw _privateConstructorUsedError; // TODO add back when fully removing introPricePeriodUnit
+  int get cycles => throw _privateConstructorUsedError;
+
+  /// TODO add back when fully removing introPricePeriodUnit
 // /// Unit for the billing period of the introductory price, can be DAY, WEEK,
 // /// MONTH or YEAR.
 // @JsonKey(name: 'periodUnit', unknownEnumValue: PeriodUnit.unknown)
 // PeriodUnit periodUnit = getPeriodUnit(introPricePeriodUnit),
   /// String representation of unit for the billing period of the introductory
   /// price, can be DAY, WEEK, MONTH or YEAR.
-  @Deprecated('Use periodUnit property of type PeriodUnit enum instead.')
+  @Deprecated('Use periodUnit property of type PeriodUnit instead.')
   @JsonKey(name: 'periodUnit')
   String get introPricePeriodUnit => throw _privateConstructorUsedError;
 
@@ -109,7 +110,7 @@ abstract class $IntroductoryPriceCopyWith<$Res> {
           String period,
       @JsonKey(name: 'cycles')
           int cycles,
-      @Deprecated('Use periodUnit property of type PeriodUnit enum instead.')
+      @Deprecated('Use periodUnit property of type PeriodUnit instead.')
       @JsonKey(name: 'periodUnit')
           String introPricePeriodUnit,
       @JsonKey(name: 'periodNumberOfUnits')
@@ -179,7 +180,7 @@ abstract class _$IntroductoryPriceCopyWith<$Res>
           String period,
       @JsonKey(name: 'cycles')
           int cycles,
-      @Deprecated('Use periodUnit property of type PeriodUnit enum instead.')
+      @Deprecated('Use periodUnit property of type PeriodUnit instead.')
       @JsonKey(name: 'periodUnit')
           String introPricePeriodUnit,
       @JsonKey(name: 'periodNumberOfUnits')
@@ -247,7 +248,7 @@ class _$_IntroductoryPrice extends _IntroductoryPrice {
           this.period,
       @JsonKey(name: 'cycles')
           this.cycles,
-      @Deprecated('Use periodUnit property of type PeriodUnit enum instead.')
+      @Deprecated('Use periodUnit property of type PeriodUnit instead.')
       @JsonKey(name: 'periodUnit')
           this.introPricePeriodUnit,
       @JsonKey(name: 'periodNumberOfUnits')
@@ -280,14 +281,16 @@ class _$_IntroductoryPrice extends _IntroductoryPrice {
   /// user will be given the introductory price, such as 3.
   @JsonKey(name: 'cycles')
   final int cycles;
-  @override // TODO add back when fully removing introPricePeriodUnit
+  @override
+
+  /// TODO add back when fully removing introPricePeriodUnit
 // /// Unit for the billing period of the introductory price, can be DAY, WEEK,
 // /// MONTH or YEAR.
 // @JsonKey(name: 'periodUnit', unknownEnumValue: PeriodUnit.unknown)
 // PeriodUnit periodUnit = getPeriodUnit(introPricePeriodUnit),
   /// String representation of unit for the billing period of the introductory
   /// price, can be DAY, WEEK, MONTH or YEAR.
-  @Deprecated('Use periodUnit property of type PeriodUnit enum instead.')
+  @Deprecated('Use periodUnit property of type PeriodUnit instead.')
   @JsonKey(name: 'periodUnit')
   final String introPricePeriodUnit;
   @override
@@ -348,7 +351,7 @@ abstract class _IntroductoryPrice extends IntroductoryPrice {
           String period,
       @JsonKey(name: 'cycles')
           int cycles,
-      @Deprecated('Use periodUnit property of type PeriodUnit enum instead.')
+      @Deprecated('Use periodUnit property of type PeriodUnit instead.')
       @JsonKey(name: 'periodUnit')
           String introPricePeriodUnit,
       @JsonKey(name: 'periodNumberOfUnits')
@@ -381,14 +384,16 @@ abstract class _IntroductoryPrice extends IntroductoryPrice {
   /// user will be given the introductory price, such as 3.
   @JsonKey(name: 'cycles')
   int get cycles;
-  @override // TODO add back when fully removing introPricePeriodUnit
+  @override
+
+  /// TODO add back when fully removing introPricePeriodUnit
 // /// Unit for the billing period of the introductory price, can be DAY, WEEK,
 // /// MONTH or YEAR.
 // @JsonKey(name: 'periodUnit', unknownEnumValue: PeriodUnit.unknown)
 // PeriodUnit periodUnit = getPeriodUnit(introPricePeriodUnit),
   /// String representation of unit for the billing period of the introductory
   /// price, can be DAY, WEEK, MONTH or YEAR.
-  @Deprecated('Use periodUnit property of type PeriodUnit enum instead.')
+  @Deprecated('Use periodUnit property of type PeriodUnit instead.')
   @JsonKey(name: 'periodUnit')
   String get introPricePeriodUnit;
   @override

--- a/lib/models/introductory_price.freezed.dart
+++ b/lib/models/introductory_price.freezed.dart
@@ -75,11 +75,6 @@ mixin _$IntroductoryPrice {
   @JsonKey(name: 'cycles')
   int get cycles => throw _privateConstructorUsedError;
 
-  /// TODO add back when fully removing introPricePeriodUnit
-// /// Unit for the billing period of the introductory price, can be DAY, WEEK,
-// /// MONTH or YEAR.
-// @JsonKey(name: 'periodUnit', unknownEnumValue: PeriodUnit.unknown)
-// PeriodUnit periodUnit = getPeriodUnit(introPricePeriodUnit),
   /// String representation of unit for the billing period of the introductory
   /// price, can be DAY, WEEK, MONTH or YEAR.
   @Deprecated('Use periodUnit property of type PeriodUnit instead.')
@@ -283,11 +278,6 @@ class _$_IntroductoryPrice extends _IntroductoryPrice {
   final int cycles;
   @override
 
-  /// TODO add back when fully removing introPricePeriodUnit
-// /// Unit for the billing period of the introductory price, can be DAY, WEEK,
-// /// MONTH or YEAR.
-// @JsonKey(name: 'periodUnit', unknownEnumValue: PeriodUnit.unknown)
-// PeriodUnit periodUnit = getPeriodUnit(introPricePeriodUnit),
   /// String representation of unit for the billing period of the introductory
   /// price, can be DAY, WEEK, MONTH or YEAR.
   @Deprecated('Use periodUnit property of type PeriodUnit instead.')
@@ -386,11 +376,6 @@ abstract class _IntroductoryPrice extends IntroductoryPrice {
   int get cycles;
   @override
 
-  /// TODO add back when fully removing introPricePeriodUnit
-// /// Unit for the billing period of the introductory price, can be DAY, WEEK,
-// /// MONTH or YEAR.
-// @JsonKey(name: 'periodUnit', unknownEnumValue: PeriodUnit.unknown)
-// PeriodUnit periodUnit = getPeriodUnit(introPricePeriodUnit),
   /// String representation of unit for the billing period of the introductory
   /// price, can be DAY, WEEK, MONTH or YEAR.
   @Deprecated('Use periodUnit property of type PeriodUnit instead.')

--- a/lib/models/introductory_price.freezed.dart
+++ b/lib/models/introductory_price.freezed.dart
@@ -31,8 +31,9 @@ class _$IntroductoryPriceTearOff {
           String period,
       @JsonKey(name: 'cycles')
           int cycles,
-      @JsonKey(name: 'periodUnit', unknownEnumValue: PeriodUnit.unknown)
-          PeriodUnit periodUnit,
+      @Deprecated('Use periodUnit property of type PeriodUnit enum instead.')
+      @JsonKey(name: 'periodUnit')
+          String introPricePeriodUnit,
       @JsonKey(name: 'periodNumberOfUnits')
           int periodNumberOfUnits) {
     return _IntroductoryPrice(
@@ -40,7 +41,7 @@ class _$IntroductoryPriceTearOff {
       priceString,
       period,
       cycles,
-      periodUnit,
+      introPricePeriodUnit,
       periodNumberOfUnits,
     );
   }
@@ -72,12 +73,17 @@ mixin _$IntroductoryPrice {
   /// Number of subscription billing periods for which the
   /// user will be given the introductory price, such as 3.
   @JsonKey(name: 'cycles')
-  int get cycles => throw _privateConstructorUsedError;
-
-  /// Unit for the billing period of the introductory price, can be DAY, WEEK,
-  /// MONTH or YEAR.
-  @JsonKey(name: 'periodUnit', unknownEnumValue: PeriodUnit.unknown)
-  PeriodUnit get periodUnit => throw _privateConstructorUsedError;
+  int get cycles =>
+      throw _privateConstructorUsedError; // TODO add back when fully removing introPricePeriodUnit
+// /// Unit for the billing period of the introductory price, can be DAY, WEEK,
+// /// MONTH or YEAR.
+// @JsonKey(name: 'periodUnit', unknownEnumValue: PeriodUnit.unknown)
+// PeriodUnit periodUnit = getPeriodUnit(introPricePeriodUnit),
+  /// String representation of unit for the billing period of the introductory
+  /// price, can be DAY, WEEK, MONTH or YEAR.
+  @Deprecated('Use periodUnit property of type PeriodUnit enum instead.')
+  @JsonKey(name: 'periodUnit')
+  String get introPricePeriodUnit => throw _privateConstructorUsedError;
 
   /// Number of units for the billing period of the introductory price.
   @JsonKey(name: 'periodNumberOfUnits')
@@ -103,8 +109,9 @@ abstract class $IntroductoryPriceCopyWith<$Res> {
           String period,
       @JsonKey(name: 'cycles')
           int cycles,
-      @JsonKey(name: 'periodUnit', unknownEnumValue: PeriodUnit.unknown)
-          PeriodUnit periodUnit,
+      @Deprecated('Use periodUnit property of type PeriodUnit enum instead.')
+      @JsonKey(name: 'periodUnit')
+          String introPricePeriodUnit,
       @JsonKey(name: 'periodNumberOfUnits')
           int periodNumberOfUnits});
 }
@@ -124,7 +131,7 @@ class _$IntroductoryPriceCopyWithImpl<$Res>
     Object? priceString = freezed,
     Object? period = freezed,
     Object? cycles = freezed,
-    Object? periodUnit = freezed,
+    Object? introPricePeriodUnit = freezed,
     Object? periodNumberOfUnits = freezed,
   }) {
     return _then(_value.copyWith(
@@ -144,10 +151,10 @@ class _$IntroductoryPriceCopyWithImpl<$Res>
           ? _value.cycles
           : cycles // ignore: cast_nullable_to_non_nullable
               as int,
-      periodUnit: periodUnit == freezed
-          ? _value.periodUnit
-          : periodUnit // ignore: cast_nullable_to_non_nullable
-              as PeriodUnit,
+      introPricePeriodUnit: introPricePeriodUnit == freezed
+          ? _value.introPricePeriodUnit
+          : introPricePeriodUnit // ignore: cast_nullable_to_non_nullable
+              as String,
       periodNumberOfUnits: periodNumberOfUnits == freezed
           ? _value.periodNumberOfUnits
           : periodNumberOfUnits // ignore: cast_nullable_to_non_nullable
@@ -172,8 +179,9 @@ abstract class _$IntroductoryPriceCopyWith<$Res>
           String period,
       @JsonKey(name: 'cycles')
           int cycles,
-      @JsonKey(name: 'periodUnit', unknownEnumValue: PeriodUnit.unknown)
-          PeriodUnit periodUnit,
+      @Deprecated('Use periodUnit property of type PeriodUnit enum instead.')
+      @JsonKey(name: 'periodUnit')
+          String introPricePeriodUnit,
       @JsonKey(name: 'periodNumberOfUnits')
           int periodNumberOfUnits});
 }
@@ -195,7 +203,7 @@ class __$IntroductoryPriceCopyWithImpl<$Res>
     Object? priceString = freezed,
     Object? period = freezed,
     Object? cycles = freezed,
-    Object? periodUnit = freezed,
+    Object? introPricePeriodUnit = freezed,
     Object? periodNumberOfUnits = freezed,
   }) {
     return _then(_IntroductoryPrice(
@@ -215,10 +223,10 @@ class __$IntroductoryPriceCopyWithImpl<$Res>
           ? _value.cycles
           : cycles // ignore: cast_nullable_to_non_nullable
               as int,
-      periodUnit == freezed
-          ? _value.periodUnit
-          : periodUnit // ignore: cast_nullable_to_non_nullable
-              as PeriodUnit,
+      introPricePeriodUnit == freezed
+          ? _value.introPricePeriodUnit
+          : introPricePeriodUnit // ignore: cast_nullable_to_non_nullable
+              as String,
       periodNumberOfUnits == freezed
           ? _value.periodNumberOfUnits
           : periodNumberOfUnits // ignore: cast_nullable_to_non_nullable
@@ -229,7 +237,7 @@ class __$IntroductoryPriceCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$_IntroductoryPrice implements _IntroductoryPrice {
+class _$_IntroductoryPrice extends _IntroductoryPrice {
   const _$_IntroductoryPrice(
       @JsonKey(name: 'price')
           this.price,
@@ -239,10 +247,12 @@ class _$_IntroductoryPrice implements _IntroductoryPrice {
           this.period,
       @JsonKey(name: 'cycles')
           this.cycles,
-      @JsonKey(name: 'periodUnit', unknownEnumValue: PeriodUnit.unknown)
-          this.periodUnit,
+      @Deprecated('Use periodUnit property of type PeriodUnit enum instead.')
+      @JsonKey(name: 'periodUnit')
+          this.introPricePeriodUnit,
       @JsonKey(name: 'periodNumberOfUnits')
-          this.periodNumberOfUnits);
+          this.periodNumberOfUnits)
+      : super._();
 
   factory _$_IntroductoryPrice.fromJson(Map<String, dynamic> json) =>
       _$$_IntroductoryPriceFromJson(json);
@@ -270,12 +280,16 @@ class _$_IntroductoryPrice implements _IntroductoryPrice {
   /// user will be given the introductory price, such as 3.
   @JsonKey(name: 'cycles')
   final int cycles;
-  @override
-
-  /// Unit for the billing period of the introductory price, can be DAY, WEEK,
-  /// MONTH or YEAR.
-  @JsonKey(name: 'periodUnit', unknownEnumValue: PeriodUnit.unknown)
-  final PeriodUnit periodUnit;
+  @override // TODO add back when fully removing introPricePeriodUnit
+// /// Unit for the billing period of the introductory price, can be DAY, WEEK,
+// /// MONTH or YEAR.
+// @JsonKey(name: 'periodUnit', unknownEnumValue: PeriodUnit.unknown)
+// PeriodUnit periodUnit = getPeriodUnit(introPricePeriodUnit),
+  /// String representation of unit for the billing period of the introductory
+  /// price, can be DAY, WEEK, MONTH or YEAR.
+  @Deprecated('Use periodUnit property of type PeriodUnit enum instead.')
+  @JsonKey(name: 'periodUnit')
+  final String introPricePeriodUnit;
   @override
 
   /// Number of units for the billing period of the introductory price.
@@ -284,7 +298,7 @@ class _$_IntroductoryPrice implements _IntroductoryPrice {
 
   @override
   String toString() {
-    return 'IntroductoryPrice(price: $price, priceString: $priceString, period: $period, cycles: $cycles, periodUnit: $periodUnit, periodNumberOfUnits: $periodNumberOfUnits)';
+    return 'IntroductoryPrice(price: $price, priceString: $priceString, period: $period, cycles: $cycles, introPricePeriodUnit: $introPricePeriodUnit, periodNumberOfUnits: $periodNumberOfUnits)';
   }
 
   @override
@@ -298,7 +312,7 @@ class _$_IntroductoryPrice implements _IntroductoryPrice {
             const DeepCollectionEquality().equals(other.period, period) &&
             const DeepCollectionEquality().equals(other.cycles, cycles) &&
             const DeepCollectionEquality()
-                .equals(other.periodUnit, periodUnit) &&
+                .equals(other.introPricePeriodUnit, introPricePeriodUnit) &&
             const DeepCollectionEquality()
                 .equals(other.periodNumberOfUnits, periodNumberOfUnits));
   }
@@ -310,7 +324,7 @@ class _$_IntroductoryPrice implements _IntroductoryPrice {
       const DeepCollectionEquality().hash(priceString),
       const DeepCollectionEquality().hash(period),
       const DeepCollectionEquality().hash(cycles),
-      const DeepCollectionEquality().hash(periodUnit),
+      const DeepCollectionEquality().hash(introPricePeriodUnit),
       const DeepCollectionEquality().hash(periodNumberOfUnits));
 
   @JsonKey(ignore: true)
@@ -324,7 +338,7 @@ class _$_IntroductoryPrice implements _IntroductoryPrice {
   }
 }
 
-abstract class _IntroductoryPrice implements IntroductoryPrice {
+abstract class _IntroductoryPrice extends IntroductoryPrice {
   const factory _IntroductoryPrice(
       @JsonKey(name: 'price')
           double price,
@@ -334,10 +348,12 @@ abstract class _IntroductoryPrice implements IntroductoryPrice {
           String period,
       @JsonKey(name: 'cycles')
           int cycles,
-      @JsonKey(name: 'periodUnit', unknownEnumValue: PeriodUnit.unknown)
-          PeriodUnit periodUnit,
+      @Deprecated('Use periodUnit property of type PeriodUnit enum instead.')
+      @JsonKey(name: 'periodUnit')
+          String introPricePeriodUnit,
       @JsonKey(name: 'periodNumberOfUnits')
           int periodNumberOfUnits) = _$_IntroductoryPrice;
+  const _IntroductoryPrice._() : super._();
 
   factory _IntroductoryPrice.fromJson(Map<String, dynamic> json) =
       _$_IntroductoryPrice.fromJson;
@@ -365,12 +381,16 @@ abstract class _IntroductoryPrice implements IntroductoryPrice {
   /// user will be given the introductory price, such as 3.
   @JsonKey(name: 'cycles')
   int get cycles;
-  @override
-
-  /// Unit for the billing period of the introductory price, can be DAY, WEEK,
-  /// MONTH or YEAR.
-  @JsonKey(name: 'periodUnit', unknownEnumValue: PeriodUnit.unknown)
-  PeriodUnit get periodUnit;
+  @override // TODO add back when fully removing introPricePeriodUnit
+// /// Unit for the billing period of the introductory price, can be DAY, WEEK,
+// /// MONTH or YEAR.
+// @JsonKey(name: 'periodUnit', unknownEnumValue: PeriodUnit.unknown)
+// PeriodUnit periodUnit = getPeriodUnit(introPricePeriodUnit),
+  /// String representation of unit for the billing period of the introductory
+  /// price, can be DAY, WEEK, MONTH or YEAR.
+  @Deprecated('Use periodUnit property of type PeriodUnit enum instead.')
+  @JsonKey(name: 'periodUnit')
+  String get introPricePeriodUnit;
   @override
 
   /// Number of units for the billing period of the introductory price.

--- a/lib/models/introductory_price.g.dart
+++ b/lib/models/introductory_price.g.dart
@@ -12,8 +12,7 @@ _$_IntroductoryPrice _$$_IntroductoryPriceFromJson(Map json) =>
       json['priceString'] as String,
       json['period'] as String,
       json['cycles'] as int,
-      $enumDecode(_$PeriodUnitEnumMap, json['periodUnit'],
-          unknownValue: PeriodUnit.unknown),
+      json['periodUnit'] as String,
       json['periodNumberOfUnits'] as int,
     );
 
@@ -24,14 +23,6 @@ Map<String, dynamic> _$$_IntroductoryPriceToJson(
       'priceString': instance.priceString,
       'period': instance.period,
       'cycles': instance.cycles,
-      'periodUnit': _$PeriodUnitEnumMap[instance.periodUnit],
+      'periodUnit': instance.introPricePeriodUnit,
       'periodNumberOfUnits': instance.periodNumberOfUnits,
     };
-
-const _$PeriodUnitEnumMap = {
-  PeriodUnit.day: 'DAY',
-  PeriodUnit.week: 'WEEK',
-  PeriodUnit.month: 'MONTH',
-  PeriodUnit.year: 'YEAR',
-  PeriodUnit.unknown: 'unknown',
-};

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
   freezed_annotation: ^1.1.0
-  json_annotation: ^4.3.0
+  json_annotation: ^4.4.0
 
 dev_dependencies:
   build_runner: ^2.1.4

--- a/revenuecat_examples/purchase_tester/lib/main.dart
+++ b/revenuecat_examples/purchase_tester/lib/main.dart
@@ -149,8 +149,8 @@ class _UpsellScreenState extends State<UpsellScreen> {
     final String introPriceString = introPrice.introPriceString;
     // ignore: deprecated_member_use
     final String introPricePeriod = introPrice.introPricePeriod;
-    // ignore: deprecated_member_use
     final int introPricePeriodNumberOfUnits =
+        // ignore: deprecated_member_use
         introPrice.introPricePeriodNumberOfUnits;
     // ignore: deprecated_member_use
     final int introPriceCycles = introPrice.introPriceCycles;
@@ -164,7 +164,7 @@ class _UpsellScreenState extends State<UpsellScreen> {
             'introPriceString: $introPriceString, introPricePeriod: '
             '$introPricePeriod, introPricePeriodNumberOfUnits: '
             '$introPricePeriodNumberOfUnits, introPriceCycles: '
-            '$introPriceCycles');
+            '$introPriceCycles, introPricePrice: $introPricePrice.toString()');
 
   }
 }

--- a/revenuecat_examples/purchase_tester/lib/main.dart
+++ b/revenuecat_examples/purchase_tester/lib/main.dart
@@ -134,18 +134,38 @@ class _UpsellScreenState extends State<UpsellScreen> {
   }
 
   void apiTestIntroductoryPrice(IntroductoryPrice introPrice) {
-    // ignore: deprecated_member_use
-    final String introPricePeriodUnit = introPrice.introPricePeriodUnit;
-    final PeriodUnit introPeriodUnit = introPrice.periodUnit;
+    final PeriodUnit periodUnit = introPrice.periodUnit;
     final double price = introPrice.price;
     final String priceString = introPrice.priceString;
     final int cycles = introPrice.cycles;
     final int periodNumberOfUnits = introPrice.periodNumberOfUnits;
+
+    /// deprecated properties
+    // ignore: deprecated_member_use
+    final String introPricePeriodUnit = introPrice.introPricePeriodUnit;
+    // ignore: deprecated_member_use
+    final double introPricePrice = introPrice.introPrice;
+    // ignore: deprecated_member_use
+    final String introPriceString = introPrice.introPriceString;
+    // ignore: deprecated_member_use
+    final String introPricePeriod = introPrice.introPricePeriod;
+    // ignore: deprecated_member_use
+    final int introPricePeriodNumberOfUnits =
+        introPrice.introPricePeriodNumberOfUnits;
+    // ignore: deprecated_member_use
+    final int introPriceCycles = introPrice.introPriceCycles;
+
+
     print(
-        'introPricePeriodUnit: $introPricePeriodUnit, introPeriodUnit: '
-            '$introPeriodUnit, price: $price.toString(), priceString: '
+        'introPricePeriodUnit: $introPricePeriodUnit, periodUnit: '
+            '$periodUnit, price: $price.toString(), priceString: '
             '$priceString, cycles: $cycles.toString(), periodNumberOfUnits: '
-            '$periodNumberOfUnits');
+            '$periodNumberOfUnits, introPrice: $introPrice.toString(), '
+            'introPriceString: $introPriceString, introPricePeriod: '
+            '$introPricePeriod, introPricePeriodNumberOfUnits: '
+            '$introPricePeriodNumberOfUnits, introPriceCycles: '
+            '$introPriceCycles');
+
   }
 }
 

--- a/revenuecat_examples/purchase_tester/lib/main.dart
+++ b/revenuecat_examples/purchase_tester/lib/main.dart
@@ -104,6 +104,12 @@ class _UpsellScreenState extends State<UpsellScreen> {
       if (offering != null) {
         final monthly = offering.monthly;
         final lifetime = offering.lifetime;
+
+        if (monthly.product.introductoryPrice != null) {
+          apiTestIntroductoryPrice(monthly.product.introductoryPrice);
+        }
+
+
         if (monthly != null && lifetime != null) {
           return Scaffold(
             appBar: AppBar(title: const Text('Upsell Screen')),
@@ -126,6 +132,15 @@ class _UpsellScreenState extends State<UpsellScreen> {
         child: Text('Loading...'),
       ),
     );
+  }
+
+  void apiTestIntroductoryPrice(IntroductoryPrice introPrice) {
+    final String introPricePeriodUnit = introPrice.introPricePeriodUnit;
+    final PeriodUnit introPeriodUnit = introPrice.periodUnit;
+    final double price = introPrice.price;
+    final String priceString = introPrice.priceString;
+    final int cycles = introPrice.cycles;
+    final int periodNumberOfUnits = introPrice.periodNumberOfUnits;
   }
 }
 

--- a/revenuecat_examples/purchase_tester/lib/main.dart
+++ b/revenuecat_examples/purchase_tester/lib/main.dart
@@ -134,6 +134,8 @@ class _UpsellScreenState extends State<UpsellScreen> {
     );
   }
 
+  // ignore: deprecated
+  // ignore: unused_local_variable
   void apiTestIntroductoryPrice(IntroductoryPrice introPrice) {
     final String introPricePeriodUnit = introPrice.introPricePeriodUnit;
     final PeriodUnit introPeriodUnit = introPrice.periodUnit;

--- a/revenuecat_examples/purchase_tester/lib/main.dart
+++ b/revenuecat_examples/purchase_tester/lib/main.dart
@@ -109,7 +109,6 @@ class _UpsellScreenState extends State<UpsellScreen> {
           apiTestIntroductoryPrice(monthly.product.introductoryPrice);
         }
 
-
         if (monthly != null && lifetime != null) {
           return Scaffold(
             appBar: AppBar(title: const Text('Upsell Screen')),
@@ -134,15 +133,19 @@ class _UpsellScreenState extends State<UpsellScreen> {
     );
   }
 
-  // ignore: deprecated
-  // ignore: unused_local_variable
   void apiTestIntroductoryPrice(IntroductoryPrice introPrice) {
+    // ignore: deprecated_member_use
     final String introPricePeriodUnit = introPrice.introPricePeriodUnit;
     final PeriodUnit introPeriodUnit = introPrice.periodUnit;
     final double price = introPrice.price;
     final String priceString = introPrice.priceString;
     final int cycles = introPrice.cycles;
     final int periodNumberOfUnits = introPrice.periodNumberOfUnits;
+    print(
+        'introPricePeriodUnit: $introPricePeriodUnit, introPeriodUnit: '
+            '$introPeriodUnit, price: $price.toString(), priceString: '
+            '$priceString, cycles: $cycles.toString(), periodNumberOfUnits: '
+            '$periodNumberOfUnits');
   }
 }
 

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -464,9 +464,10 @@ void main() {
 
   test('IntroductoryPrice has both PeriodUnit enum and periodUnit string', () async {
     final mockIntroductoryPrice = IntroductoryPrice.fromJson(
-        mockIntroductoryPriceJson
+        mockIntroductoryPriceJson,
     );
     expect(mockIntroductoryPrice.periodUnit, PeriodUnit.day);
+    // ignore: deprecated_member_use_from_same_package
     expect(mockIntroductoryPrice.introPricePeriodUnit, 'DAY');
   });
 
@@ -491,6 +492,4 @@ void main() {
     const introPricePeriodUnitUnknown = IntroductoryPrice(0.0, '\$0.00', 'P2W', 1, 'sadf', 14);
     expect(introPricePeriodUnitUnknown.periodUnit, PeriodUnit.unknown);
 });
-
-
 }

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -472,23 +472,23 @@ void main() {
 
   test('IntroductoryPrice PeriodUnit maps correctly', () async {
     /// test day
-    const introPricePeriodUnitDay = IntroductoryPrice(0.0, "\$0.00", 'P2W', 1, 'DAY', 14);
+    const introPricePeriodUnitDay = IntroductoryPrice(0.0, '\$0.00', 'P2W', 1, 'DAY', 14);
     expect(introPricePeriodUnitDay.periodUnit, PeriodUnit.day);
 
     /// test week
-    const introPricePeriodUnitWeek = IntroductoryPrice(0.0, "\$0.00", 'P2W', 1, 'WEEK', 14);
+    const introPricePeriodUnitWeek = IntroductoryPrice(0.0, '\$0.00', 'P2W', 1, 'WEEK', 14);
     expect(introPricePeriodUnitWeek.periodUnit, PeriodUnit.week);
 
     /// test month
-    const introPricePeriodUnitMonth = IntroductoryPrice(0.0, "\$0.00", 'P2W', 1, 'MONTH', 14);
+    const introPricePeriodUnitMonth = IntroductoryPrice(0.0, '\$0.00', 'P2W', 1, 'MONTH', 14);
     expect(introPricePeriodUnitMonth.periodUnit, PeriodUnit.month);
 
     /// test year
-    const introPricePeriodUnitYear = IntroductoryPrice(0.0, "\$0.00", 'P2W', 1, 'YEAR', 14);
+    const introPricePeriodUnitYear = IntroductoryPrice(0.0, '\$0.00', 'P2W', 1, 'YEAR', 14);
     expect(introPricePeriodUnitYear.periodUnit, PeriodUnit.year);
 
     /// test unknown
-    const introPricePeriodUnitUnknown = IntroductoryPrice(0.0, "\$0.00", 'P2W', 1, 'sadf', 14);
+    const introPricePeriodUnitUnknown = IntroductoryPrice(0.0, '\$0.00', 'P2W', 1, 'sadf', 14);
     expect(introPricePeriodUnitUnknown.periodUnit, PeriodUnit.unknown);
 });
 

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -469,4 +469,28 @@ void main() {
     expect(mockIntroductoryPrice.periodUnit, PeriodUnit.day);
     expect(mockIntroductoryPrice.introPricePeriodUnit, 'DAY');
   });
+
+  test('IntroductoryPrice PeriodUnit maps correctly', () async {
+    /// test day
+    const introPricePeriodUnitDay = IntroductoryPrice(0.0, "\$0.00", 'P2W', 1, 'DAY', 14);
+    expect(introPricePeriodUnitDay.periodUnit, PeriodUnit.day);
+
+    /// test week
+    const introPricePeriodUnitWeek = IntroductoryPrice(0.0, "\$0.00", 'P2W', 1, 'WEEK', 14);
+    expect(introPricePeriodUnitWeek.periodUnit, PeriodUnit.week);
+
+    /// test month
+    const introPricePeriodUnitMonth = IntroductoryPrice(0.0, "\$0.00", 'P2W', 1, 'MONTH', 14);
+    expect(introPricePeriodUnitMonth.periodUnit, PeriodUnit.month);
+
+    /// test year
+    const introPricePeriodUnitYear = IntroductoryPrice(0.0, "\$0.00", 'P2W', 1, 'YEAR', 14);
+    expect(introPricePeriodUnitYear.periodUnit, PeriodUnit.year);
+
+    /// test unknown
+    const introPricePeriodUnitUnknown = IntroductoryPrice(0.0, "\$0.00", 'P2W', 1, 'sadf', 14);
+    expect(introPricePeriodUnitUnknown.periodUnit, PeriodUnit.unknown);
+});
+
+
 }

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:purchases_flutter/purchases_flutter.dart';
 
+// ignore_for_file: deprecated_member_use_from_same_package
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -467,7 +468,6 @@ void main() {
         mockIntroductoryPriceJson,
     );
     expect(mockIntroductoryPrice.periodUnit, PeriodUnit.day);
-    // ignore: deprecated_member_use_from_same_package
     expect(mockIntroductoryPrice.introPricePeriodUnit, 'DAY');
   });
 
@@ -479,7 +479,7 @@ void main() {
     expect(mockIntroPrice.priceString, mockIntroPrice.introPriceString);
     expect(mockIntroPrice.period, mockIntroPrice.introPricePeriod);
     expect(mockIntroPrice.periodNumberOfUnits,
-        mockIntroPrice.introPricePeriodNumberOfUnits);
+        mockIntroPrice.introPricePeriodNumberOfUnits,);
     expect(mockIntroPrice.cycles, mockIntroPrice.introPriceCycles);
   });
 

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -471,6 +471,18 @@ void main() {
     expect(mockIntroductoryPrice.introPricePeriodUnit, 'DAY');
   });
 
+  test('IntroductoryPrice deprecated properties contain same values', () async {
+    final mockIntroPrice = IntroductoryPrice.fromJson(
+      mockIntroductoryPriceJson,
+    );
+    expect(mockIntroPrice.price, mockIntroPrice.introPrice);
+    expect(mockIntroPrice.priceString, mockIntroPrice.introPriceString);
+    expect(mockIntroPrice.period, mockIntroPrice.introPricePeriod);
+    expect(mockIntroPrice.periodNumberOfUnits,
+        mockIntroPrice.introPricePeriodNumberOfUnits);
+    expect(mockIntroPrice.cycles, mockIntroPrice.introPriceCycles);
+  });
+
   test('IntroductoryPrice PeriodUnit maps correctly', () async {
     /// test day
     const introPricePeriodUnitDay = IntroductoryPrice(0.0, '\$0.00', 'P2W', 1, 'DAY', 14);

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -25,6 +25,15 @@ void main() {
     'nonSubscriptionTransactions': []
   };
 
+  final mockIntroductoryPriceJson = {
+    'price': 0.0,
+    'priceString': '\$0.00',
+    'period': 'P2W',
+    'cycles': 1,
+    'periodUnit': 'DAY',
+    'periodNumberOfUnits': 14,
+  };
+
   setUp(() {
     channel.setMockMethodCallHandler((call) async {
       log.add(call);
@@ -451,5 +460,13 @@ void main() {
     } on PlatformException catch (e) {
       fail('there was an exception ' + e.toString());
     }
+  });
+
+  test('IntroductoryPrice has both PeriodUnit enum and periodUnit string', () async {
+    final mockIntroductoryPrice = IntroductoryPrice.fromJson(
+        mockIntroductoryPriceJson
+    );
+    expect(mockIntroductoryPrice.periodUnit, PeriodUnit.day);
+    expect(mockIntroductoryPrice.introPricePeriodUnit, 'DAY');
   });
 }


### PR DESCRIPTION
In https://github.com/RevenueCat/purchases-flutter/pull/270/files#diff-31ad10b1074cdc6e6c82c3cc2ab3221a117afbaaee017193b6b189d7f34bc769R40 we changed periodUnit from a string to a PeriodUnit enum. An [issue](https://github.com/RevenueCat/purchases-flutter/issues/318) was opened indicating we released this change without reflecting it in the changelog and did a minor instead of a major.

This fix adds back the string type and deprecates it. We can leave the PeriodUnit enum type since the properties have different names. 

Also:
* added unit tests to confirm the IntroductoryPrice values are set properly from the original JSON
*  added a little "api test" method to our current sample app which simply accesses each property, ensuring the types are correct. This issue highlights our need for a full API tester in purchases-flutter, but this is a quicker api test
* created a [follow-up ticket](https://app.shortcut.com/revenuecat/story/13290/remove-intropriceperiodunit) for eventually removing introPricePeriodUnit, since some of the changes required aren't obviously attributed to the property

We will release a 3.9.4 with this fix.

[sc-13246]