### PR TITLE
Add Amazon consumer proguard rules to plugin and prepare alpha.3 release

### DIFF
--- a/AMAZON-INSTRUCTIONS.md
+++ b/AMAZON-INSTRUCTIONS.md
@@ -1,11 +1,15 @@
-Adds initial Amazon store support. In order to use please point to this tag in your `pubspec.yaml` like this:
+⚠️ ⚠️ ⚠️
+This version doesn't support Amazon Store in [observer mode](https://docs.revenuecat.com/docs/observer-mode).
+⚠️ ⚠️ ⚠️
+
+Adds initial Amazon Store support. In order to use please point to this tag in your `pubspec.yaml` like this:
 
 ```
 dependencies:
   purchases_flutter:
     git:
       url: git://github.com/revenuecat/purchases-flutter.git
-      ref: amazon.alpha.2
+      ref: amazon.alpha.3
 ```
 
 Then configure the package using your **RevenueCat API key specific for Amazon** and passing `useAmazon: true`:

--- a/CHANGELOG-LATEST.md
+++ b/CHANGELOG-LATEST.md
@@ -1,5 +1,3 @@
-## 3.4.5
+## 4.0.0-amazon.alpha.3
 
-- Bumped purchases-android to 4.3.1 [Changelog here](https://github.com/RevenueCat/purchases-android/releases/4.3.1),
-which fixes canMakePayments not returning (see related issue: https://github.com/RevenueCat/purchases-unity/issues/61)
-- Bumped purchases-hybrid-common to 1.9.1 [Changelog here](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/1.9.1)
+- Automatically adds Amazon Proguard rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0-amazon.alpha.3
+
+- Automatically adds Amazon Proguard rules
+
 ## 3.4.5
 
 - Bumped purchases-android to 4.3.1 [Changelog here](https://github.com/RevenueCat/purchases-android/releases/4.3.1),

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,6 +35,11 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+    buildTypes {
+        release {
+            consumerProguardFiles 'proguard-rules.pro'
+        }
+    }
 }
 
 dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.revenuecat.purchases_flutter'
-version '4.0.0-amazon.alpha.2'
+version '4.0.0-amazon.alpha.3'
 
 buildscript {
     ext.kotlin_version = '1.3.72'

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,0 +1,3 @@
+-dontwarn com.amazon.**
+-keep class com.amazon.** {*;}
+-keepattributes *Annotation*

--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -53,7 +53,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
     @Nullable private Activity activity;
 
     private static final String PLATFORM_NAME = "flutter";
-    private static final String PLUGIN_VERSION = "4.0.0-amazon.alpha.2";
+    private static final String PLUGIN_VERSION = "4.0.0-amazon.alpha.3";
 
     /**
      * Plugin registration.

--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -488,7 +488,7 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
 }
 
 - (NSString *)platformFlavorVersion { 
-    return @"4.0.0-amazon.alpha.2";
+    return @"4.0.0-amazon.alpha.3";
 }
 
 @end

--- a/ios/purchases_flutter.podspec
+++ b/ios/purchases_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'purchases_flutter'
-  s.version          = '4.0.0-amazon.alpha.2'
+  s.version          = '4.0.0-amazon.alpha.3'
   s.summary          = 'Cross-platform subscriptions framework for Flutter.'
   s.description      = <<-DESC
   Client for the RevenueCat subscription and purchase tracking system, making implementing in-app subscriptions in Flutter easy - receipt validation and status tracking included!

--- a/macos/purchases_flutter.podspec
+++ b/macos/purchases_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'purchases_flutter'
-  s.version          = '4.0.0-amazon.alpha.2'
+  s.version          = '4.0.0-amazon.alpha.3'
   s.summary          = 'Cross-platform subscriptions framework for Flutter.'
   s.description      = <<-DESC
   Client for the RevenueCat subscription and purchase tracking system, making implementing in-app subscriptions in Flutter easy - receipt validation and status tracking included!

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: purchases_flutter
 description: A Flutter plugin that makes it simple to add and manage in-app purchases (IAP) and subscriptions. Supports Android, iOS, macOS, iPadOS, and watchOS.
-version: 4.0.0-amazon.alpha.2
+version: 4.0.0-amazon.alpha.3
 homepage: https://www.revenuecat.com/
 repository: https://github.com/RevenueCat/purchases-flutter
 issue_tracker: https://github.com/RevenueCat/purchases-flutter/issues

--- a/revenuecat_examples/MagicWeather/lib/src/views/weather.dart
+++ b/revenuecat_examples/MagicWeather/lib/src/views/weather.dart
@@ -4,7 +4,6 @@ import 'package:magic_weather_flutter/src/components/top_bar.dart';
 import 'package:magic_weather_flutter/src/model/singletons_data.dart';
 import 'package:magic_weather_flutter/src/model/styles.dart';
 import 'package:magic_weather_flutter/src/model/weather_data.dart';
-import 'package:purchases_flutter/object_wrappers.dart';
 import 'package:modal_progress_hud/modal_progress_hud.dart';
 import 'package:flutter/services.dart';
 import 'package:purchases_flutter/purchases_flutter.dart';


### PR DESCRIPTION
[CF-236]

Adds consumer proguard rules so they get added automatically to apps. Also prepares alpha.3 version.

There have been several reports of installation problems in Flutter due to missing Proguard rules. We need to do a release on top of the latest `amazon.alpha.2` version that adds these rules automatically. 

When we are ready to update purchases-flutter to Android v5, these will get automatically added via purchases-android but until then, let's add them to our purchases-flutter plugin.

[CF-236]: https://revenuecats.atlassian.net/browse/CF-236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ