### PR TITLE
add missing parameter when calling setup with amazon

### DIFF
--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -45,6 +45,7 @@ NSString *RNPurchasesPurchaserInfoUpdatedEvent = @"Purchases-PurchaserInfoUpdate
         [self setupPurchases:apiKey
                    appUserID:appUserID
                 observerMode:observerMode
+                   useAmazon:YES
        userDefaultsSuiteName:userDefaultsSuiteName
                       result:result];
     } else if ([@"setAllowSharingStoreAccount" isEqualToString:call.method]) {


### PR DESCRIPTION
We had the parameter in the method signature but not at the callsite