### PR TITLE
[CF-459] Flutter deferred purchases

### DIFF
--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -511,7 +511,7 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
     [self.defermentBlocks addObject:makeDeferredPurchase];
     NSInteger position = [self.defermentBlocks count] - 1;
     [self.channel invokeMethod:PurchasesStartDeferredPurchaseEvent
-                     arguments:[NSNumber numberWithInteger:position]];
+                     arguments:@{@"callbackID": [NSNumber numberWithInteger:position]}];
 }
 
 #pragma mark -

--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -172,9 +172,9 @@ NSString *PurchasesReadyForPromotedProductPurchaseEvent = @"Purchases-ReadyForPr
         [self paymentDiscountForProductIdentifier:productIdentifier
                                discountIdentifier:discountIdentifier
                                            result:result];
-    } else if ([@"startDeferredPurchase" isEqualToString:call.method]) {
+    } else if ([@"startPromotedProductPurchase" isEqualToString:call.method]) {
         NSNumber *callbackID = arguments[@"callbackID"];
-        [self startDeferredPurchase:callbackID
+        [self startPromotedProductPurchase:callbackID
                             result:result];
     } else if ([@"close" isEqualToString:call.method]) {
         [self closeWithResult:result];
@@ -477,18 +477,11 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
                                                }];
 }
 
-- (void)startDeferredPurchase:(NSNumber *)callbackID
+- (void)startPromotedProductPurchase:(NSNumber *)callbackID
                       result:(FlutterResult)result {
     RCDeferredPromotionalPurchaseBlock makePurchaseBlock = [self.startPurchaseBlocks objectAtIndex:[callbackID integerValue]];
     [RCCommonFunctionality makeDeferredPurchase:makePurchaseBlock
-                                completionBlock:^(NSDictionary * _Nullable responseDictionary,
-                                                  RCErrorContainer * _Nullable error) {
-                                                    if (error) {
-                                                        [self rejectWithResult:result error:error];
-                                                    } else {
-                                                        result(responseDictionary);
-                                                    }
-                                                }];;
+                                completionBlock:[self getResponseCompletionBlock:result]];
 }
 
 - (void)closeWithResult:(FlutterResult)result {

--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -497,9 +497,9 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
                      arguments:purchaserInfo.dictionary];
 }
 
-- (void)purchases:(RCPurchases *)purchases
+- (void)         purchases:(RCPurchases *)purchases
 shouldPurchasePromoProduct:(SKProduct *)product
-   defermentBlock:(RCDeferredPromotionalPurchaseBlock)makeDeferredPurchase {
+            defermentBlock:(RCDeferredPromotionalPurchaseBlock)makeDeferredPurchase {
     if (!self.startPurchaseBlocks) {
         self.startPurchaseBlocks = [NSMutableArray array];
     }

--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -15,7 +15,7 @@
 
 
 NSString *PurchasesPurchaserInfoUpdatedEvent = @"Purchases-PurchaserInfoUpdated";
-NSString *PurchasesReadyForPromotedProductEvent = @"Purchases-ReadyForPromotedProduct";
+NSString *PurchasesReadyForPromotedProductPurchaseEvent = @"Purchases-ReadyForPromotedProductPurchase";
 
 
 @implementation PurchasesFlutterPlugin
@@ -503,17 +503,17 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
                      arguments:purchaserInfo.dictionary];
 }
 
-- (void)purchases:(RCPurchases *)purchases
-shouldPurchasePromoProduct:(nonnull SKProduct *)product
-   defermentBlock:(nonnull RCDeferredPromotionalPurchaseBlock)startPurchaseBlock {
+-(void) purchases:(RCPurchases *)purchases shouldPurchasePromoProduct:(SKProduct *)product defermentBlock:(RCDeferredPromotionalPurchaseBlock)makeDeferredPurchase {
     if (!self.startPurchaseBlocks) {
             self.startPurchaseBlocks = [NSMutableArray array];
     }
 
-    [self.startPurchaseBlocks addObject:startPurchaseBlock];
+    [self.startPurchaseBlocks addObject:makeDeferredPurchase];
     NSInteger position = [self.startPurchaseBlocks count] - 1;
-    [self.channel invokeMethod:PurchasesReadyForPromotedProductEvent
-                     arguments:@{@"callbackID": [NSNumber numberWithInteger:position]}];
+    [self.channel invokeMethod:PurchasesReadyForPromotedProductPurchaseEvent
+                     arguments:@{@"callbackID": [NSNumber numberWithInteger:position],
+                                 @"productID": product.productIdentifier
+                               }];
 }
 
 #pragma mark -

--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -175,7 +175,7 @@ NSString *PurchasesReadyForPromotedProductPurchaseEvent = @"Purchases-ReadyForPr
     } else if ([@"startPromotedProductPurchase" isEqualToString:call.method]) {
         NSNumber *callbackID = arguments[@"callbackID"];
         [self startPromotedProductPurchase:callbackID
-                            result:result];
+                                    result:result];
     } else if ([@"close" isEqualToString:call.method]) {
         [self closeWithResult:result];
     } else {
@@ -478,8 +478,9 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
 }
 
 - (void)startPromotedProductPurchase:(NSNumber *)callbackID
-                      result:(FlutterResult)result {
-    RCDeferredPromotionalPurchaseBlock makePurchaseBlock = [self.startPurchaseBlocks objectAtIndex:[callbackID integerValue]];
+                              result:(FlutterResult)result {
+    RCDeferredPromotionalPurchaseBlock makePurchaseBlock =
+        [self.startPurchaseBlocks objectAtIndex:[callbackID integerValue]];
     [RCCommonFunctionality makeDeferredPurchase:makePurchaseBlock
                                 completionBlock:[self getResponseCompletionBlock:result]];
 }
@@ -496,15 +497,17 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
                      arguments:purchaserInfo.dictionary];
 }
 
--(void) purchases:(RCPurchases *)purchases shouldPurchasePromoProduct:(SKProduct *)product defermentBlock:(RCDeferredPromotionalPurchaseBlock)makeDeferredPurchase {
+- (void)purchases:(RCPurchases *)purchases
+shouldPurchasePromoProduct:(SKProduct *)product
+   defermentBlock:(RCDeferredPromotionalPurchaseBlock)makeDeferredPurchase {
     if (!self.startPurchaseBlocks) {
-            self.startPurchaseBlocks = [NSMutableArray array];
+        self.startPurchaseBlocks = [NSMutableArray array];
     }
 
     [self.startPurchaseBlocks addObject:makeDeferredPurchase];
     NSInteger position = [self.startPurchaseBlocks count] - 1;
     [self.channel invokeMethod:PurchasesReadyForPromotedProductPurchaseEvent
-                     arguments:@{@"callbackID": [NSNumber numberWithInteger:position],
+                     arguments:@{@"callbackID": @(position),
                                  @"productID": product.productIdentifier
                                }];
 }

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -64,22 +64,6 @@ class Purchases {
       }
     });
 
-  static Future<StartDeferredPurchaseResult> _startDeferredPurchase(int callbackID) async {
-    final result = await _channel.invokeMethod(
-      'startDeferredPurchase',
-      {
-        'callbackID': callbackID,
-      },
-    );
-    final purchaserInfo = PurchaserInfo.fromJson(
-      Map<String, dynamic>.from(result['purchaserInfo']),
-    );
-    final productIdentifier = result['productIdentifier'];
-    return StartDeferredPurchaseResult(
-        productIdentifier: productIdentifier,
-        purchaserInfo: purchaserInfo,
-    );
-  }
   /// Sets up Purchases with your API key and an app user id.
   ///
   /// [apiKey] RevenueCat API Key.
@@ -157,16 +141,21 @@ class Purchases {
   ) =>
       _purchaserInfoUpdateListeners.remove(listenerToRemove);
 
-  /// TODO docs
+  /// iOS only
+  /// Sets a listener to be called when a user initiates a promoted in-app
+  /// purchase from the App Store.
+  ///
+  /// [listener] ReadyForPromotedProductPurchaseListener to be added
   static void addReadyForPromotedProductPurchaseListener(
       ReadyForPromotedProductPurchaseListener listener,
       ) {
-    print('adding listener');
     _readyForPromotedProductPurchaseListeners.add(listener);
   }
 
-
-  /// TODO docs
+  /// iOS only
+  /// Removes a given ReadyForPromotedProductPurchaseListener
+  ///
+  /// [listener] ReadyForPromotedProductPurchaseListener to be removed
   static void removeReadyForPromotedProductPurchaseListener(
       ReadyForPromotedProductPurchaseListener listenerToRemove,
       ) =>
@@ -697,6 +686,27 @@ class Purchases {
   /// Android only. Call close when you are done with this instance of Purchases to disconnect
   /// from the billing services and clean up resources
   static Future<void> close() => _channel.invokeMethod('close');
+
+  /// iOS only. Starts the purchase flow associated with the callback at
+  /// `callbackID` index in PurchasesFlutterPlugin.m's `startPurchaseBlocks`
+  /// array.
+  static Future<StartDeferredPurchaseResult> _startDeferredPurchase(
+      int callbackID,) async {
+    final result = await _channel.invokeMethod(
+      'startDeferredPurchase',
+      {
+        'callbackID': callbackID,
+      },
+    );
+    final purchaserInfo = PurchaserInfo.fromJson(
+      Map<String, dynamic>.from(result['purchaserInfo']),
+    );
+    final productIdentifier = result['productIdentifier'];
+    return StartDeferredPurchaseResult(
+      productIdentifier: productIdentifier,
+      purchaserInfo: purchaserInfo,
+    );
+  }
 
   static Future<PurchaserInfo> _invokeReturningPurchaserInfo(String method,
       // ignore: require_trailing_commas

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -14,9 +14,7 @@ typedef PurchaserInfoUpdateListener = void Function(
 );
 
 /// TODO docs
-typedef StartPromotedProductPurchaseListener = void Function(
-    Future<MakePurchaseResult> Function()
-    );
+typedef StartPromotedProductPurchaseListener = void Function(Future<MakePurchaseResult> Function());
 
 /// Entry point for Purchases.
 class Purchases {
@@ -36,12 +34,9 @@ class Purchases {
           }
           break;
         case 'Purchases-MakeDeferredPurchase':
-          print("received methodchannel call");
           for (final listener in _startPromotedProductPurchaseListeners) {
             final args = Map<String, dynamic>.from(call.arguments);
             final callbackID = args['callbackID'];
-            print("received methodchannel call - in for loop for callback ID $callbackID");
-            // final result = await makeDeferredPurchase(callbackID);
             listener(() => makeDeferredPurchase(callbackID));
           }
           break;
@@ -49,12 +44,19 @@ class Purchases {
     });
 
   static Future<MakePurchaseResult> makeDeferredPurchase(int callbackID) async {
-    print("in makeDeferredPurchase");
-    return await _channel.invokeMethod(
+    final result = await _channel.invokeMethod(
       'makeDeferredPurchase',
       {
         'callbackID': callbackID,
       },
+    );
+    final purchaserInfo = PurchaserInfo.fromJson(
+      Map<String, dynamic>.from(result['purchaserInfo']),
+    );
+    final productIdentifier = result['productIdentifier'];
+    return MakePurchaseResult(
+        productIdentifier: productIdentifier,
+        purchaserInfo: purchaserInfo,
     );
   }
   /// Sets up Purchases with your API key and an app user id.
@@ -139,7 +141,6 @@ class Purchases {
       StartPromotedProductPurchaseListener listener,
       ) {
     _startPromotedProductPurchaseListeners.add(listener);
-    print("adding promotedproductpurchaselistener");
   }
 
 

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -13,9 +13,17 @@ typedef PurchaserInfoUpdateListener = void Function(
   PurchaserInfo purchaserInfo,
 );
 
+/// TODO docs
+typedef StartPromotedProductPurchaseListener = void Function(
+    Future<MakePurchaseResult> Function()
+    );
+
 /// Entry point for Purchases.
 class Purchases {
   static final Set<PurchaserInfoUpdateListener> _purchaserInfoUpdateListeners =
+      {};
+
+  static final Set<StartPromotedProductPurchaseListener> _startPromotedProductPurchaseListeners =
       {};
 
   static final _channel = const MethodChannel('purchases_flutter')
@@ -27,9 +35,28 @@ class Purchases {
             listener(PurchaserInfo.fromJson(args));
           }
           break;
+        case 'Purchases-MakeDeferredPurchase':
+          print("received methodchannel call");
+          for (final listener in _startPromotedProductPurchaseListeners) {
+            final args = Map<String, dynamic>.from(call.arguments);
+            final callbackID = args['callbackID'];
+            print("received methodchannel call - in for loop for callback ID $callbackID");
+            // final result = await makeDeferredPurchase(callbackID);
+            listener(() => makeDeferredPurchase(callbackID));
+          }
+          break;
       }
     });
 
+  static Future<MakePurchaseResult> makeDeferredPurchase(int callbackID) async {
+    print("in makeDeferredPurchase");
+    return await _channel.invokeMethod(
+      'makeDeferredPurchase',
+      {
+        'callbackID': callbackID,
+      },
+    );
+  }
   /// Sets up Purchases with your API key and an app user id.
   ///
   /// [apiKey] RevenueCat API Key.
@@ -106,6 +133,21 @@ class Purchases {
     PurchaserInfoUpdateListener listenerToRemove,
   ) =>
       _purchaserInfoUpdateListeners.remove(listenerToRemove);
+
+  /// TODO docs
+  static void addShouldPurchasePromoProductListener(
+      StartPromotedProductPurchaseListener listener,
+      ) {
+    _startPromotedProductPurchaseListeners.add(listener);
+    print("adding promotedproductpurchaselistener");
+  }
+
+
+  /// TODO docs
+  static void removeShouldPurchasePromoProductListener(
+      StartPromotedProductPurchaseListener listenerToRemove,
+      ) =>
+      _startPromotedProductPurchaseListeners.remove(listenerToRemove);
 
   /// Deprecated in favor of set<NetworkId> functions.
   /// Add a dict of attribution information
@@ -788,4 +830,16 @@ class LogInResult {
 
   /// Constructs a LogInResult with its properties
   LogInResult({required this.created, required this.purchaserInfo});
+}
+
+/// TODO docs
+class MakePurchaseResult {
+  /// TODO docs
+  final String productIdentifier;
+
+  /// the purchaserInfo associated to the logged in user
+  final PurchaserInfo purchaserInfo;
+
+  /// Constructs a LogInResult with its properties
+  MakePurchaseResult({required this.productIdentifier, required this.purchaserInfo});
 }

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -32,7 +32,7 @@ typedef PurchaserInfoUpdateListener = void Function(
 /// - [Apple Documentation](https://rev.cat/testing-promoted-in-app-purchases)
 typedef ReadyForPromotedProductPurchaseListener = void Function(
     String productIdentifier,
-    Future<StartDeferredPurchaseResult> Function() startPurchase,
+    Future<PromotedPurchaseResult> Function() startPurchase,
 );
 
 /// Entry point for Purchases.
@@ -54,11 +54,10 @@ class Purchases {
           break;
         case 'Purchases-ReadyForPromotedProductPurchase':
           for (final listener in _readyForPromotedProductPurchaseListeners) {
-            print('in listener loop');
             final args = Map<String, dynamic>.from(call.arguments);
             final callbackID = args['callbackID'];
             final productIdentifier = args['productID'];
-            listener(productIdentifier, () => _startDeferredPurchase(callbackID));
+            listener(productIdentifier, () => _startPromotedProductPurchase(callbackID));
           }
           break;
       }
@@ -690,10 +689,10 @@ class Purchases {
   /// iOS only. Starts the purchase flow associated with the callback at
   /// `callbackID` index in PurchasesFlutterPlugin.m's `startPurchaseBlocks`
   /// array.
-  static Future<StartDeferredPurchaseResult> _startDeferredPurchase(
+  static Future<PromotedPurchaseResult> _startPromotedProductPurchase(
       int callbackID,) async {
     final result = await _channel.invokeMethod(
-      'startDeferredPurchase',
+      'startPromotedProductPurchase',
       {
         'callbackID': callbackID,
       },
@@ -702,7 +701,7 @@ class Purchases {
       Map<String, dynamic>.from(result['purchaserInfo']),
     );
     final productIdentifier = result['productIdentifier'];
-    return StartDeferredPurchaseResult(
+    return PromotedPurchaseResult(
       productIdentifier: productIdentifier,
       purchaserInfo: purchaserInfo,
     );
@@ -865,16 +864,16 @@ class LogInResult {
   LogInResult({required this.created, required this.purchaserInfo});
 }
 
-/// Class used to hold the result of the startDeferredPurchase method
-class StartDeferredPurchaseResult {
-  /// the productIdentifier associated with the deferred purchase
+/// Class used to hold the result of the startPromotedPurchase method
+class PromotedPurchaseResult {
+  /// the productIdentifier associated with the promoted purchase
   final String productIdentifier;
 
-  /// the purchaserInfo associated with the deferred purchase
+  /// the purchaserInfo associated with the promoted purchase
   final PurchaserInfo purchaserInfo;
 
-  /// Constructs a StartDeferredPurchaseResult with its properties
-  StartDeferredPurchaseResult({
+  /// Constructs a PromotedPurchaseResult with its properties
+  PromotedPurchaseResult({
         required this.productIdentifier,
         required this.purchaserInfo,
   });

--- a/revenuecat_examples/purchase_tester/lib/main.dart
+++ b/revenuecat_examples/purchase_tester/lib/main.dart
@@ -43,8 +43,9 @@ class _MyAppState extends State<InitialScreen> {
       try {
         final purchaseResult = await startPurchase.call();
         print('Promoted purchase for productID '
-            '${purchaseResult.productIdentifier} successful. New '
-            'purchaserInfo: ${purchaseResult.purchaserInfo}');
+            '${purchaseResult.productIdentifier} completed, or product was'
+            'already purchased. purchaserInfo returned is:'
+            ' ${purchaseResult.purchaserInfo}');
       } on PlatformException catch (e) {
         print('Error purchasing promoted product: ${e.message}');
       }

--- a/revenuecat_examples/purchase_tester/lib/main.dart
+++ b/revenuecat_examples/purchase_tester/lib/main.dart
@@ -35,6 +35,11 @@ class _MyAppState extends State<InitialScreen> {
 
     final purchaserInfo = await Purchases.getPurchaserInfo();
 
+    Purchases.addShouldPurchasePromoProductListener((makePurchase) async {
+      final purchaseResult = await makePurchase.call();
+      print(purchaseResult.purchaserInfo);
+    });
+
     // If the widget was removed from the tree while the asynchronous platform
     // message was in flight, we want to discard the reply rather than calling
     // setState to update our non-existent appearance.

--- a/revenuecat_examples/purchase_tester/lib/main.dart
+++ b/revenuecat_examples/purchase_tester/lib/main.dart
@@ -35,9 +35,19 @@ class _MyAppState extends State<InitialScreen> {
 
     final purchaserInfo = await Purchases.getPurchaserInfo();
 
-    Purchases.addShouldPurchasePromoProductListener((makePurchase) async {
-      final purchaseResult = await makePurchase.call();
-      print(purchaseResult.purchaserInfo);
+    Purchases.addReadyForPromotedProductPurchaseListener(
+            (productID, startPurchase) async {
+      print('Received readyForPromotedProductPurchase event for '
+          'productID: $productID');
+
+      try {
+        final purchaseResult = await startPurchase.call();
+        print('Promoted purchase for productID '
+            '${purchaseResult.productIdentifier} successful. New '
+            'purchaserInfo: ${purchaseResult.purchaserInfo}');
+      } on PlatformException catch (e) {
+        print('Error purchasing promoted product: ${e.message}');
+      }
     });
 
     // If the widget was removed from the tree while the asynchronous platform


### PR DESCRIPTION
Adds functionality for promoted purchases 

I had trouble unit testing this, since we don't currently have a way of mocking the ios -> flutter method channel communication... and the method we could test in purchases_flutter is the _startPromotedProductPurchase, but that's private. Open to any ideas. We don't have any tests for the purchaserInfoUpdatedListener either, not sure if anyone has context on whether we tried for that?

To manually test in purchase tester, use:
itms-services://?action=purchaseIntent&bundleId=com.revenuecat.sampleapp&productIdentifier=com.revenuecat.monthly_4.99.1_week_intro


One thing I've noticed that might be broken/could be improved (though probably out of the scope of this PR): If you've already purchased the product, purchases-hybrid-common still returns a purchaserInfo and productIdentifier. There's no error or indication that the purchase didn't successfully go through. I am going to investigate whether that's information we can pass along somehow... 