### PR TITLE
Update to 4.0.0 (Part 1): Rename customer info to purchaser info

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -41,7 +41,7 @@ import kotlin.UninitializedPropertyAccessException;
 public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler, ActivityAware {
     private String INVALID_ARGS_ERROR_CODE = "invalidArgs";
 
-    private static final String PURCHASER_INFO_UPDATED = "Purchases-PurchaserInfoUpdated";
+    private static final String CUSTOMER_INFO_UPDATED = "Purchases-CustomerInfoUpdated";
 
     // Only set registrar for v1 embedder.
     @SuppressWarnings("deprecation")
@@ -198,7 +198,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 String proxyURLString = call.argument("proxyURLString");
                 setProxyURLString(proxyURLString, result);
                 break;
-            case "getPurchaserInfo":
+            case "getCustomerInfo":
                 getPurchaserInfo(result);
                 break;
             case "syncPurchases":
@@ -217,7 +217,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 productIdentifiers = call.argument("productIdentifiers");
                 checkTrialOrIntroductoryPriceEligibility(productIdentifiers, result);
                 break;
-            case "invalidatePurchaserInfoCache":
+            case "invalidateCustomerInfoCache":
                 invalidatePurchaserInfoCache(result);
                 break;
             case "presentCodeRedemptionSheet":
@@ -325,12 +325,9 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
     }
 
     private void setupUpdatedPurchaserInfoListener() {
-        Purchases.getSharedInstance().setUpdatedPurchaserInfoListener(new UpdatedPurchaserInfoListener() {
-            @Override
-            public void onReceived(@NonNull PurchaserInfo purchaserInfo) {
-                if (channel != null) {
-                    channel.invokeMethod(PURCHASER_INFO_UPDATED, PurchaserInfoMapperKt.map(purchaserInfo));
-                }
+        Purchases.getSharedInstance().setUpdatedPurchaserInfoListener(purchaserInfo -> {
+            if (channel != null) {
+                channel.invokeMethod(CUSTOMER_INFO_UPDATED, PurchaserInfoMapperKt.map(purchaserInfo));
             }
         });
     }

--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -14,9 +14,8 @@
 @end
 
 
-NSString *PurchasesPurchaserInfoUpdatedEvent = @"Purchases-PurchaserInfoUpdated";
+NSString *PurchasesCustomerInfoUpdatedEvent = @"Purchases-CustomerInfoUpdated";
 NSString *PurchasesReadyForPromotedProductPurchaseEvent = @"Purchases-ReadyForPromotedProductPurchase";
-
 
 @implementation PurchasesFlutterPlugin
 
@@ -94,8 +93,8 @@ NSString *PurchasesReadyForPromotedProductPurchaseEvent = @"Purchases-ReadyForPr
         [self setSimulatesAskToBuyInSandbox:[arguments[@"enabled"] boolValue] result:result];
     } else if ([@"setProxyURLString" isEqualToString:call.method]) {
         [self setProxyURLString:arguments[@"proxyURLString"] result:result];
-    } else if ([@"getPurchaserInfo" isEqualToString:call.method]) {
-        [self getPurchaserInfoWithResult:result];
+    } else if ([@"getCustomerInfo" isEqualToString:call.method]) {
+        [self getCustomerInfoWithResult:result];
     } else if ([@"syncPurchases" isEqualToString:call.method]) {
         [self syncPurchasesWithResult:result];
     } else if ([@"setAutomaticAppleSearchAdsAttributionCollection" isEqualToString:call.method]) {
@@ -106,8 +105,8 @@ NSString *PurchasesReadyForPromotedProductPurchaseEvent = @"Purchases-ReadyForPr
         [self isConfiguredWithResult:result];
     } else if ([@"checkTrialOrIntroductoryPriceEligibility" isEqualToString:call.method]) {
         [self checkTrialOrIntroductoryPriceEligibility:arguments[@"productIdentifiers"] result:result];
-    } else if ([@"invalidatePurchaserInfoCache" isEqualToString:call.method]) {
-        [self invalidatePurchaserInfoCacheWithResult:result];
+    } else if ([@"invalidateCustomerInfoCache" isEqualToString:call.method]) {
+        [self invalidateCustomerInfoCacheWithResult:result];
     } else if ([@"presentCodeRedemptionSheet" isEqualToString:call.method]) {
         [self presentCodeRedemptionSheetWithResult:result];
     } else if ([@"setAttributes" isEqualToString:call.method]) {
@@ -322,8 +321,8 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
     result(nil);
 }
 
-- (void)getPurchaserInfoWithResult:(FlutterResult)result {
-    [RCCommonFunctionality getPurchaserInfoWithCompletionBlock:[self getResponseCompletionBlock:result]];
+- (void)getCustomerInfoWithResult:(FlutterResult)result {
+    [RCCommonFunctionality getCustomerInfoWithCompletionBlock:[self getResponseCompletionBlock:result]];
 }
 
 - (void)setAutomaticAppleSearchAdsAttributionCollection:(BOOL)enabled
@@ -348,8 +347,8 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
                                                     }];
 }
 
-- (void)invalidatePurchaserInfoCacheWithResult:(FlutterResult)result {
-    [RCCommonFunctionality invalidatePurchaserInfoCache];
+- (void)invalidateCustomerInfoCacheWithResult:(FlutterResult)result {
+    [RCCommonFunctionality invalidateCustomerInfoCache];
     result(nil);
 }
 
@@ -492,9 +491,9 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
 #pragma mark -
 #pragma mark Delegate Methods
 
-- (void)purchases:(RCPurchases *)purchases didReceiveUpdatedPurchaserInfo:(RCPurchaserInfo *)purchaserInfo {
-    [self.channel invokeMethod:PurchasesPurchaserInfoUpdatedEvent
-                     arguments:purchaserInfo.dictionary];
+- (void)purchases:(RCPurchases *)purchases didReceiveUpdatedCustomerInfo:(RCCustomerInfo *)customerInfo {
+    [self.channel invokeMethod:PurchasesCustomerInfoUpdatedEvent
+                     arguments:customerInfo.dictionary];
 }
 
 - (void)         purchases:(RCPurchases *)purchases

--- a/lib/models/customer_info_wrapper.dart
+++ b/lib/models/customer_info_wrapper.dart
@@ -3,15 +3,15 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'entitlement_infos_wrapper.dart';
 import 'transaction.dart';
 
-part 'purchaser_info_wrapper.freezed.dart';
-part 'purchaser_info_wrapper.g.dart';
+part 'customer_info_wrapper.freezed.dart';
+part 'customer_info_wrapper.g.dart';
 
 @freezed
 
-/// Class containing all information regarding the purchaser
-class PurchaserInfo with _$PurchaserInfo {
-  const factory PurchaserInfo(
-    /// Entitlements attached to this purchaser info
+/// Class containing all information regarding the customer
+class CustomerInfo with _$CustomerInfo {
+  const factory CustomerInfo(
+    /// Entitlements attached to this customer info
     @JsonKey(name: 'entitlements') EntitlementInfos entitlements,
 
     /// Map of skus to purchase dates
@@ -66,8 +66,8 @@ class PurchaserInfo with _$PurchaserInfo {
     /// it will point there. If there are no active subscriptions it will be null.
     /// If there are multiple for different platforms, it will point to the device store.
     @JsonKey(name: 'managementURL') String? managementURL,
-  }) = _PurchaserInfo;
+  }) = _CustomerInfo;
 
-  factory PurchaserInfo.fromJson(Map<String, dynamic> json) =>
-      _$PurchaserInfoFromJson(json);
+  factory CustomerInfo.fromJson(Map<String, dynamic> json) =>
+      _$CustomerInfoFromJson(json);
 }

--- a/lib/models/customer_info_wrapper.freezed.dart
+++ b/lib/models/customer_info_wrapper.freezed.dart
@@ -3,7 +3,7 @@
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
 
-part of 'purchaser_info_wrapper.dart';
+part of 'customer_info_wrapper.dart';
 
 // **************************************************************************
 // FreezedGenerator
@@ -14,15 +14,15 @@ T _$identity<T>(T value) => value;
 final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
-PurchaserInfo _$PurchaserInfoFromJson(Map<String, dynamic> json) {
-  return _PurchaserInfo.fromJson(json);
+CustomerInfo _$CustomerInfoFromJson(Map<String, dynamic> json) {
+  return _CustomerInfo.fromJson(json);
 }
 
 /// @nodoc
-class _$PurchaserInfoTearOff {
-  const _$PurchaserInfoTearOff();
+class _$CustomerInfoTearOff {
+  const _$CustomerInfoTearOff();
 
-  _PurchaserInfo call(
+  _CustomerInfo call(
       @JsonKey(name: 'entitlements')
           EntitlementInfos entitlements,
       @JsonKey(name: 'allPurchaseDates')
@@ -49,7 +49,7 @@ class _$PurchaserInfoTearOff {
           String? originalApplicationVersion,
       @JsonKey(name: 'managementURL')
           String? managementURL}) {
-    return _PurchaserInfo(
+    return _CustomerInfo(
       entitlements,
       allPurchaseDates,
       activeSubscriptions,
@@ -66,17 +66,17 @@ class _$PurchaserInfoTearOff {
     );
   }
 
-  PurchaserInfo fromJson(Map<String, Object?> json) {
-    return PurchaserInfo.fromJson(json);
+  CustomerInfo fromJson(Map<String, Object?> json) {
+    return CustomerInfo.fromJson(json);
   }
 }
 
 /// @nodoc
-const $PurchaserInfo = _$PurchaserInfoTearOff();
+const $CustomerInfo = _$CustomerInfoTearOff();
 
 /// @nodoc
-mixin _$PurchaserInfo {
-  /// Entitlements attached to this purchaser info
+mixin _$CustomerInfo {
+  /// Entitlements attached to this customer info
   @JsonKey(name: 'entitlements')
   EntitlementInfos get entitlements => throw _privateConstructorUsedError;
 
@@ -145,15 +145,15 @@ mixin _$PurchaserInfo {
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
-  $PurchaserInfoCopyWith<PurchaserInfo> get copyWith =>
+  $CustomerInfoCopyWith<CustomerInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class $PurchaserInfoCopyWith<$Res> {
-  factory $PurchaserInfoCopyWith(
-          PurchaserInfo value, $Res Function(PurchaserInfo) then) =
-      _$PurchaserInfoCopyWithImpl<$Res>;
+abstract class $CustomerInfoCopyWith<$Res> {
+  factory $CustomerInfoCopyWith(
+          CustomerInfo value, $Res Function(CustomerInfo) then) =
+      _$CustomerInfoCopyWithImpl<$Res>;
   $Res call(
       {@JsonKey(name: 'entitlements')
           EntitlementInfos entitlements,
@@ -186,13 +186,12 @@ abstract class $PurchaserInfoCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$PurchaserInfoCopyWithImpl<$Res>
-    implements $PurchaserInfoCopyWith<$Res> {
-  _$PurchaserInfoCopyWithImpl(this._value, this._then);
+class _$CustomerInfoCopyWithImpl<$Res> implements $CustomerInfoCopyWith<$Res> {
+  _$CustomerInfoCopyWithImpl(this._value, this._then);
 
-  final PurchaserInfo _value;
+  final CustomerInfo _value;
   // ignore: unused_field
-  final $Res Function(PurchaserInfo) _then;
+  final $Res Function(CustomerInfo) _then;
 
   @override
   $Res call({
@@ -275,11 +274,11 @@ class _$PurchaserInfoCopyWithImpl<$Res>
 }
 
 /// @nodoc
-abstract class _$PurchaserInfoCopyWith<$Res>
-    implements $PurchaserInfoCopyWith<$Res> {
-  factory _$PurchaserInfoCopyWith(
-          _PurchaserInfo value, $Res Function(_PurchaserInfo) then) =
-      __$PurchaserInfoCopyWithImpl<$Res>;
+abstract class _$CustomerInfoCopyWith<$Res>
+    implements $CustomerInfoCopyWith<$Res> {
+  factory _$CustomerInfoCopyWith(
+          _CustomerInfo value, $Res Function(_CustomerInfo) then) =
+      __$CustomerInfoCopyWithImpl<$Res>;
   @override
   $Res call(
       {@JsonKey(name: 'entitlements')
@@ -314,15 +313,14 @@ abstract class _$PurchaserInfoCopyWith<$Res>
 }
 
 /// @nodoc
-class __$PurchaserInfoCopyWithImpl<$Res>
-    extends _$PurchaserInfoCopyWithImpl<$Res>
-    implements _$PurchaserInfoCopyWith<$Res> {
-  __$PurchaserInfoCopyWithImpl(
-      _PurchaserInfo _value, $Res Function(_PurchaserInfo) _then)
-      : super(_value, (v) => _then(v as _PurchaserInfo));
+class __$CustomerInfoCopyWithImpl<$Res> extends _$CustomerInfoCopyWithImpl<$Res>
+    implements _$CustomerInfoCopyWith<$Res> {
+  __$CustomerInfoCopyWithImpl(
+      _CustomerInfo _value, $Res Function(_CustomerInfo) _then)
+      : super(_value, (v) => _then(v as _CustomerInfo));
 
   @override
-  _PurchaserInfo get _value => super._value as _PurchaserInfo;
+  _CustomerInfo get _value => super._value as _CustomerInfo;
 
   @override
   $Res call({
@@ -340,7 +338,7 @@ class __$PurchaserInfoCopyWithImpl<$Res>
     Object? originalApplicationVersion = freezed,
     Object? managementURL = freezed,
   }) {
-    return _then(_PurchaserInfo(
+    return _then(_CustomerInfo(
       entitlements == freezed
           ? _value.entitlements
           : entitlements // ignore: cast_nullable_to_non_nullable
@@ -399,8 +397,8 @@ class __$PurchaserInfoCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$_PurchaserInfo implements _PurchaserInfo {
-  const _$_PurchaserInfo(
+class _$_CustomerInfo implements _CustomerInfo {
+  const _$_CustomerInfo(
       @JsonKey(name: 'entitlements')
           this.entitlements,
       @JsonKey(name: 'allPurchaseDates')
@@ -428,12 +426,12 @@ class _$_PurchaserInfo implements _PurchaserInfo {
       @JsonKey(name: 'managementURL')
           this.managementURL});
 
-  factory _$_PurchaserInfo.fromJson(Map<String, dynamic> json) =>
-      _$$_PurchaserInfoFromJson(json);
+  factory _$_CustomerInfo.fromJson(Map<String, dynamic> json) =>
+      _$$_CustomerInfoFromJson(json);
 
   @override
 
-  /// Entitlements attached to this purchaser info
+  /// Entitlements attached to this customer info
   @JsonKey(name: 'entitlements')
   final EntitlementInfos entitlements;
   @override
@@ -510,14 +508,14 @@ class _$_PurchaserInfo implements _PurchaserInfo {
 
   @override
   String toString() {
-    return 'PurchaserInfo(entitlements: $entitlements, allPurchaseDates: $allPurchaseDates, activeSubscriptions: $activeSubscriptions, allPurchasedProductIdentifiers: $allPurchasedProductIdentifiers, nonSubscriptionTransactions: $nonSubscriptionTransactions, firstSeen: $firstSeen, originalAppUserId: $originalAppUserId, allExpirationDates: $allExpirationDates, requestDate: $requestDate, latestExpirationDate: $latestExpirationDate, originalPurchaseDate: $originalPurchaseDate, originalApplicationVersion: $originalApplicationVersion, managementURL: $managementURL)';
+    return 'CustomerInfo(entitlements: $entitlements, allPurchaseDates: $allPurchaseDates, activeSubscriptions: $activeSubscriptions, allPurchasedProductIdentifiers: $allPurchasedProductIdentifiers, nonSubscriptionTransactions: $nonSubscriptionTransactions, firstSeen: $firstSeen, originalAppUserId: $originalAppUserId, allExpirationDates: $allExpirationDates, requestDate: $requestDate, latestExpirationDate: $latestExpirationDate, originalPurchaseDate: $originalPurchaseDate, originalApplicationVersion: $originalApplicationVersion, managementURL: $managementURL)';
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _PurchaserInfo &&
+            other is _CustomerInfo &&
             const DeepCollectionEquality()
                 .equals(other.entitlements, entitlements) &&
             const DeepCollectionEquality()
@@ -566,17 +564,17 @@ class _$_PurchaserInfo implements _PurchaserInfo {
 
   @JsonKey(ignore: true)
   @override
-  _$PurchaserInfoCopyWith<_PurchaserInfo> get copyWith =>
-      __$PurchaserInfoCopyWithImpl<_PurchaserInfo>(this, _$identity);
+  _$CustomerInfoCopyWith<_CustomerInfo> get copyWith =>
+      __$CustomerInfoCopyWithImpl<_CustomerInfo>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PurchaserInfoToJson(this);
+    return _$$_CustomerInfoToJson(this);
   }
 }
 
-abstract class _PurchaserInfo implements PurchaserInfo {
-  const factory _PurchaserInfo(
+abstract class _CustomerInfo implements CustomerInfo {
+  const factory _CustomerInfo(
       @JsonKey(name: 'entitlements')
           EntitlementInfos entitlements,
       @JsonKey(name: 'allPurchaseDates')
@@ -602,14 +600,14 @@ abstract class _PurchaserInfo implements PurchaserInfo {
       @JsonKey(name: 'originalApplicationVersion', nullable: true)
           String? originalApplicationVersion,
       @JsonKey(name: 'managementURL')
-          String? managementURL}) = _$_PurchaserInfo;
+          String? managementURL}) = _$_CustomerInfo;
 
-  factory _PurchaserInfo.fromJson(Map<String, dynamic> json) =
-      _$_PurchaserInfo.fromJson;
+  factory _CustomerInfo.fromJson(Map<String, dynamic> json) =
+      _$_CustomerInfo.fromJson;
 
   @override
 
-  /// Entitlements attached to this purchaser info
+  /// Entitlements attached to this customer info
   @JsonKey(name: 'entitlements')
   EntitlementInfos get entitlements;
   @override
@@ -685,6 +683,6 @@ abstract class _PurchaserInfo implements PurchaserInfo {
   String? get managementURL;
   @override
   @JsonKey(ignore: true)
-  _$PurchaserInfoCopyWith<_PurchaserInfo> get copyWith =>
+  _$CustomerInfoCopyWith<_CustomerInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/models/customer_info_wrapper.g.dart
+++ b/lib/models/customer_info_wrapper.g.dart
@@ -1,12 +1,12 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'purchaser_info_wrapper.dart';
+part of 'customer_info_wrapper.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PurchaserInfo _$$_PurchaserInfoFromJson(Map json) => _$_PurchaserInfo(
+_$_CustomerInfo _$$_CustomerInfoFromJson(Map json) => _$_CustomerInfo(
       EntitlementInfos.fromJson(
           Map<String, dynamic>.from(json['entitlements'] as Map)),
       Map<String, String>.from(json['allPurchaseDates'] as Map),
@@ -29,7 +29,7 @@ _$_PurchaserInfo _$$_PurchaserInfoFromJson(Map json) => _$_PurchaserInfo(
       managementURL: json['managementURL'] as String?,
     );
 
-Map<String, dynamic> _$$_PurchaserInfoToJson(_$_PurchaserInfo instance) =>
+Map<String, dynamic> _$$_CustomerInfoToJson(_$_CustomerInfo instance) =>
     <String, dynamic>{
       'entitlements': instance.entitlements.toJson(),
       'allPurchaseDates': instance.allPurchaseDates,

--- a/lib/object_wrappers.dart
+++ b/lib/object_wrappers.dart
@@ -1,4 +1,5 @@
 export 'errors.dart';
+export 'models/customer_info_wrapper.dart';
 export 'models/discount.dart';
 export 'models/entitlement_info_wrapper.dart';
 export 'models/entitlement_infos_wrapper.dart';
@@ -8,4 +9,3 @@ export 'models/offerings_wrapper.dart';
 export 'models/package_wrapper.dart';
 export 'models/payment_discount.dart';
 export 'models/product_wrapper.dart';
-export 'models/purchaser_info_wrapper.dart';

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -57,8 +57,10 @@ class Purchases {
             final args = Map<String, dynamic>.from(call.arguments);
             final callbackID = args['callbackID'];
             final productIdentifier = args['productID'];
-            listener(productIdentifier,
-                () => _startPromotedProductPurchase(callbackID),);
+            listener(
+              productIdentifier,
+              () => _startPromotedProductPurchase(callbackID),
+            );
           }
           break;
       }
@@ -366,7 +368,8 @@ class Purchases {
     final result =
         await _channel.invokeMethod('logIn', {'appUserID': appUserID});
     final customerInfo = CustomerInfo.fromJson(
-      Map<String, dynamic>.from(result['customerInfo']),
+      // TODO: update dictionary key to customerInfo
+      Map<String, dynamic>.from(result['purchaserInfo']),
     );
     final bool created = result['created'];
 
@@ -696,7 +699,8 @@ class Purchases {
       },
     );
     final customerInfo = CustomerInfo.fromJson(
-      Map<String, dynamic>.from(result['customerInfo']),
+      // TODO: update dictionary key to customerInfo
+      Map<String, dynamic>.from(result['purchaserInfo']),
     );
     final productIdentifier = result['productIdentifier'];
     return PromotedPurchaseResult(
@@ -719,7 +723,8 @@ class Purchases {
   static Map<String, dynamic> _getCustomerInfoJsonFromMap(
     Map<String, dynamic> response,
   ) =>
-      Map<String, dynamic>.from(response['customerInfo']);
+      // TODO: update dictionary key to customerInfo
+      Map<String, dynamic>.from(response['purchaserInfo']);
 
   static Future<Map<String, dynamic>> _invokeReturningMap(String method,
       // ignore: require_trailing_commas

--- a/revenuecat_examples/MagicWeather/lib/src/views/home.dart
+++ b/revenuecat_examples/MagicWeather/lib/src/views/home.dart
@@ -39,12 +39,12 @@ class AppContainerState extends State<AppContainer> {
 
     appData.appUserID = await Purchases.appUserID;
 
-    Purchases.addPurchaserInfoUpdateListener((purchaserInfo) async {
+    Purchases.addCustomerInfoUpdateListener((customerInfo) async {
       appData.appUserID = await Purchases.appUserID;
 
-      PurchaserInfo purchaserInfo = await Purchases.getPurchaserInfo();
-      (purchaserInfo.entitlements.all[entitlementID] != null &&
-              purchaserInfo.entitlements.all[entitlementID].isActive)
+      CustomerInfo customerInfo = await Purchases.getCustomerInfo();
+      (customerInfo.entitlements.all[entitlementID] != null &&
+              customerInfo.entitlements.all[entitlementID].isActive)
           ? appData.entitlementIsActive = true
           : appData.entitlementIsActive = false;
 

--- a/revenuecat_examples/MagicWeather/lib/src/views/paywall.dart
+++ b/revenuecat_examples/MagicWeather/lib/src/views/paywall.dart
@@ -51,10 +51,10 @@ class _PaywallState extends State<Paywall> {
                   child: ListTile(
                       onTap: () async {
                         try {
-                          PurchaserInfo purchaserInfo =
+                          CustomerInfo customerInfo =
                               await Purchases.purchasePackage(
                                   myProductList[index]);
-                          appData.entitlementIsActive = purchaserInfo
+                          appData.entitlementIsActive = customerInfo
                               .entitlements.all[entitlementID].isActive;
                         } catch (e) {
                           print(e);

--- a/revenuecat_examples/MagicWeather/lib/src/views/weather.dart
+++ b/revenuecat_examples/MagicWeather/lib/src/views/weather.dart
@@ -29,10 +29,10 @@ class _WeatherScreenState extends State<WeatherScreen> {
       _isLoading = true;
     });
 
-    PurchaserInfo purchaserInfo = await Purchases.getPurchaserInfo();
+    CustomerInfo customerInfo = await Purchases.getCustomerInfo();
 
-    if (purchaserInfo.entitlements.all[entitlementID] != null &&
-        purchaserInfo.entitlements.all[entitlementID].isActive == true) {
+    if (customerInfo.entitlements.all[entitlementID] != null &&
+        customerInfo.entitlements.all[entitlementID].isActive == true) {
       appData.currentData = WeatherData.generateData();
 
       setState(() {

--- a/revenuecat_examples/purchase_tester/integration_test/app_test.dart
+++ b/revenuecat_examples/purchase_tester/integration_test/app_test.dart
@@ -20,8 +20,8 @@ void main() {
   testWidgets('Purchaser info fetched successfully',
       (WidgetTester tester) async {
     try {
-      final purchaserInfo = await Purchases.getPurchaserInfo();
-      expect(purchaserInfo != null, true);
+      final customerInfo = await Purchases.getCustomerInfo();
+      expect(customerInfo != null, true);
     } on PlatformException catch (e) {
       fail('there was an exception ' + e.toString());
     }

--- a/revenuecat_examples/purchase_tester/lib/main.dart
+++ b/revenuecat_examples/purchase_tester/lib/main.dart
@@ -20,7 +20,7 @@ class InitialScreen extends StatefulWidget {
 }
 
 class _MyAppState extends State<InitialScreen> {
-  PurchaserInfo _purchaserInfo;
+  CustomerInfo _customerInfo;
 
   @override
   void initState() {
@@ -33,7 +33,7 @@ class _MyAppState extends State<InitialScreen> {
     await Purchases.setDebugLogsEnabled(true);
     await Purchases.setup('api_key');
 
-    final purchaserInfo = await Purchases.getPurchaserInfo();
+    final customerInfo = await Purchases.getCustomerInfo();
 
     Purchases.addReadyForPromotedProductPurchaseListener(
         (productID, startPurchase) async {
@@ -44,8 +44,8 @@ class _MyAppState extends State<InitialScreen> {
         final purchaseResult = await startPurchase.call();
         print('Promoted purchase for productID '
             '${purchaseResult.productIdentifier} completed, or product was'
-            'already purchased. purchaserInfo returned is:'
-            ' ${purchaseResult.purchaserInfo}');
+            'already purchased. customerInfo returned is:'
+            ' ${purchaseResult.customerInfo}');
       } on PlatformException catch (e) {
         print('Error purchasing promoted product: ${e.message}');
       }
@@ -57,13 +57,13 @@ class _MyAppState extends State<InitialScreen> {
     if (!mounted) return;
 
     setState(() {
-      _purchaserInfo = purchaserInfo;
+      _customerInfo = customerInfo;
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    if (_purchaserInfo == null) {
+    if (_customerInfo == null) {
       return Scaffold(
         appBar: AppBar(title: const Text('RevenueCat Sample App')),
         body: const Center(
@@ -71,7 +71,7 @@ class _MyAppState extends State<InitialScreen> {
         ),
       );
     } else {
-      final isPro = _purchaserInfo.entitlements.active.containsKey('pro_cat');
+      final isPro = _customerInfo.entitlements.active.containsKey('pro_cat');
       if (isPro) {
         return const CatsScreen();
       } else {
@@ -192,8 +192,8 @@ class _PurchaseButton extends StatelessWidget {
   Widget build(BuildContext context) => ElevatedButton(
         onPressed: () async {
           try {
-            final purchaserInfo = await Purchases.purchasePackage(package);
-            final isPro = purchaserInfo.entitlements.all['pro_cat'].isActive;
+            final customerInfo = await Purchases.purchasePackage(package);
+            final isPro = customerInfo.entitlements.all['pro_cat'].isActive;
             if (isPro) {
               return const CatsScreen();
             }

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -12,7 +12,7 @@ void main() {
   final log = <MethodCall>[];
   dynamic response;
   final randomGenerator = Random(DateTime.now().microsecondsSinceEpoch);
-  final mockPurchaserInfoResponse = {
+  final mockCustomerInfoResponse = {
     'originalAppUserId': 'pepe',
     'entitlements': {'all': {}, 'active': {}},
     'activeSubscriptions': [],
@@ -172,12 +172,12 @@ void main() {
       final mockCreated = randomGenerator.nextBool();
       response = {
         'created': mockCreated,
-        'purchaserInfo': mockPurchaserInfoResponse
+        'customerInfo': mockCustomerInfoResponse
       };
       final logInResult = await Purchases.logIn('appUserID');
       expect(
-        logInResult.purchaserInfo,
-        PurchaserInfo.fromJson(mockPurchaserInfoResponse),
+        logInResult.customerInfo,
+        CustomerInfo.fromJson(mockCustomerInfoResponse),
       );
       expect(logInResult.created, mockCreated);
     } on PlatformException catch (e) {
@@ -187,11 +187,11 @@ void main() {
 
   test('logOut calls successfully', () async {
     try {
-      response = mockPurchaserInfoResponse;
-      final purchaserInfo = await Purchases.logOut();
+      response = mockCustomerInfoResponse;
+      final customerInfo = await Purchases.logOut();
       expect(
-        purchaserInfo,
-        PurchaserInfo.fromJson(mockPurchaserInfoResponse),
+        customerInfo,
+        CustomerInfo.fromJson(mockCustomerInfoResponse),
       );
     } on PlatformException catch (e) {
       fail('there was an exception ' + e.toString());
@@ -337,7 +337,7 @@ void main() {
     try {
       response = {
         'productIdentifier': 'product.identifier',
-        'purchaserInfo': mockPurchaserInfoResponse
+        'customerInfo': mockCustomerInfoResponse
       };
       const mockProduct = Product(
         'com.revenuecat.lifetime',
@@ -357,7 +357,7 @@ void main() {
           await Purchases.purchasePackage(mockPackage);
       expect(
         purchasePackageResult,
-        PurchaserInfo.fromJson(mockPurchaserInfoResponse),
+        CustomerInfo.fromJson(mockCustomerInfoResponse),
       );
     } on PlatformException catch (e) {
       fail('there was an exception ' + e.toString());
@@ -368,7 +368,7 @@ void main() {
     try {
       response = {
         'productIdentifier': 'product.identifier',
-        'purchaserInfo': mockPurchaserInfoResponse
+        'customerInfo': mockCustomerInfoResponse
       };
       const mockProduct = Product(
         'com.revenuecat.lifetime',
@@ -397,7 +397,7 @@ void main() {
       );
       expect(
         purchasePackageResult,
-        PurchaserInfo.fromJson(mockPurchaserInfoResponse),
+        CustomerInfo.fromJson(mockCustomerInfoResponse),
       );
     } on PlatformException catch (e) {
       fail('there was an exception ' + e.toString());
@@ -408,7 +408,7 @@ void main() {
     try {
       response = {
         'productIdentifier': 'product.identifier',
-        'purchaserInfo': mockPurchaserInfoResponse
+        'customerInfo': mockCustomerInfoResponse
       };
       const mockProduct = Product(
         'com.revenuecat.lifetime',
@@ -422,7 +422,7 @@ void main() {
           await Purchases.purchaseProduct(mockProduct.identifier);
       expect(
         purchasePackageResult,
-        PurchaserInfo.fromJson(mockPurchaserInfoResponse),
+        CustomerInfo.fromJson(mockCustomerInfoResponse),
       );
     } on PlatformException catch (e) {
       fail('there was an exception ' + e.toString());
@@ -433,7 +433,7 @@ void main() {
     try {
       response = {
         'productIdentifier': 'product.identifier',
-        'purchaserInfo': mockPurchaserInfoResponse
+        'customerInfo': mockCustomerInfoResponse
       };
       const mockProduct = Product(
         'com.revenuecat.lifetime',
@@ -456,7 +456,7 @@ void main() {
       );
       expect(
         purchasePackageResult,
-        PurchaserInfo.fromJson(mockPurchaserInfoResponse),
+        CustomerInfo.fromJson(mockCustomerInfoResponse),
       );
     } on PlatformException catch (e) {
       fail('there was an exception ' + e.toString());

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -172,7 +172,7 @@ void main() {
       final mockCreated = randomGenerator.nextBool();
       response = {
         'created': mockCreated,
-        'customerInfo': mockCustomerInfoResponse
+        'purchaserInfo': mockCustomerInfoResponse
       };
       final logInResult = await Purchases.logIn('appUserID');
       expect(
@@ -337,7 +337,7 @@ void main() {
     try {
       response = {
         'productIdentifier': 'product.identifier',
-        'customerInfo': mockCustomerInfoResponse
+        'purchaserInfo': mockCustomerInfoResponse
       };
       const mockProduct = Product(
         'com.revenuecat.lifetime',
@@ -368,7 +368,7 @@ void main() {
     try {
       response = {
         'productIdentifier': 'product.identifier',
-        'customerInfo': mockCustomerInfoResponse
+        'purchaserInfo': mockCustomerInfoResponse
       };
       const mockProduct = Product(
         'com.revenuecat.lifetime',
@@ -408,7 +408,7 @@ void main() {
     try {
       response = {
         'productIdentifier': 'product.identifier',
-        'customerInfo': mockCustomerInfoResponse
+        'purchaserInfo': mockCustomerInfoResponse
       };
       const mockProduct = Product(
         'com.revenuecat.lifetime',
@@ -433,7 +433,7 @@ void main() {
     try {
       response = {
         'productIdentifier': 'product.identifier',
-        'customerInfo': mockCustomerInfoResponse
+        'purchaserInfo': mockCustomerInfoResponse
       };
       const mockProduct = Product(
         'com.revenuecat.lifetime',


### PR DESCRIPTION
Extracted from https://github.com/RevenueCat/purchases-flutter/pull/328

Renames purchaser to customer 

Comparing against release/4.0.0 so we don't break main