### PR TITLE
Update to phc 3.0.0 (Part 3): Remove identity v2 and old attribution APIs

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -138,12 +138,6 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 Boolean allowSharing = call.argument("allowSharing");
                 setAllowSharingAppStoreAccount(allowSharing, result);
                 break;
-            case "addAttributionData":
-                Map<String, String> data = call.argument("data");
-                int network = call.argument("network") != null ? (int) call.argument("network") : -1;
-                String networkUserId = call.argument("networkUserId");
-                addAttributionData(data, network, networkUserId, result);
-                break;
             case "getOfferings":
                 getOfferings(result);
                 break;
@@ -171,17 +165,6 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 break;
             case "restorePurchases":
                 restoreTransactions(result);
-                break;
-            case "reset":
-                reset(result);
-                break;
-            case "identify":
-                String appUserID = call.argument("appUserID");
-                identify(appUserID, result);
-                break;
-            case "createAlias":
-                String newAppUserID = call.argument("newAppUserID");
-                createAlias(newAppUserID, result);
                 break;
             case "logIn":
                 String appUserIDToLogIn = call.argument("appUserID");
@@ -357,12 +340,6 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
         }
     }
 
-    private void addAttributionData(Map<String, String> data, int network,
-                                    @Nullable String networkUserId, Result result) {
-        SubscriberAttributesKt.addAttributionData(data, network, networkUserId);
-        result.success(null);
-    }
-
     private void getOfferings(final Result result) {
         CommonKt.getOfferings(getOnResult(result));
     }
@@ -418,27 +395,12 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
         CommonKt.restoreTransactions(getOnResult(result));
     }
 
-    @SuppressWarnings("deprecation")
-    private void reset(final Result result) {
-        CommonKt.reset(getOnResult(result));
-    }
-
-    @SuppressWarnings("deprecation")
-    private void identify(String appUserID, final Result result) {
-        CommonKt.identify(appUserID, getOnResult(result));
-    }
-
     private void logOut(final Result result) {
         CommonKt.logOut(getOnResult(result));
     }
 
     private void logIn(String appUserID, final Result result) {
         CommonKt.logIn(appUserID, getOnResult(result));
-    }
-
-    @SuppressWarnings("deprecation")
-    private void createAlias(String newAppUserID, final Result result) {
-        CommonKt.createAlias(newAppUserID, getOnResult(result));
     }
 
     private void setDebugLogsEnabled(boolean enabled, final Result result) {

--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -52,14 +52,6 @@ NSString *PurchasesReadyForPromotedProductPurchaseEvent = @"Purchases-ReadyForPr
         [self setAllowSharingStoreAccount:[arguments[@"allowSharing"] boolValue] result:result];
     } else if ([@"setFinishTransactions" isEqualToString:call.method]) {
         [self setFinishTransactions:[arguments[@"finishTransactions"] boolValue] result:result];
-    } else if ([@"addAttributionData" isEqualToString:call.method]) {
-        NSDictionary *data = arguments[@"data"];
-        NSInteger network = [arguments[@"network"] integerValue];
-        NSString *networkUserId = arguments[@"networkUserId"];
-        [self addAttributionData:data
-                     fromNetwork:(RCAttributionNetwork) network
-                forNetworkUserId:networkUserId
-                          result:result];
     } else if ([@"getOfferings" isEqualToString:call.method]) {
         [self getOfferingsWithResult:result];
     } else if ([@"getProductInfo" isEqualToString:call.method]) {
@@ -79,14 +71,8 @@ NSString *PurchasesReadyForPromotedProductPurchaseEvent = @"Purchases-ReadyForPr
         [self restorePurchasesWithResult:result];
     } else if ([@"logOut" isEqualToString:call.method]) {
         [self logOutWithResult:result];
-    } else if ([@"reset" isEqualToString:call.method]) {
-        [self resetWithResult:result];
     } else if ([@"logIn" isEqualToString:call.method]) {
         [self logInAppUserID:arguments[@"appUserID"] result:result];
-    } else if ([@"identify" isEqualToString:call.method]) {
-        [self identify:arguments[@"appUserID"] result:result];
-    } else if ([@"createAlias" isEqualToString:call.method]) {
-        [self createAlias:arguments[@"newAppUserID"] result:result];
     } else if ([@"setDebugLogsEnabled" isEqualToString:call.method]) {
         [self setDebugLogsEnabled:[arguments[@"enabled"] boolValue] result:result];
     } else if ([@"setSimulatesAskToBuyInSandbox" isEqualToString:call.method]) {
@@ -219,17 +205,6 @@ NSString *PurchasesReadyForPromotedProductPurchaseEvent = @"Purchases-ReadyForPr
     result(nil);
 }
 
-- (void)addAttributionData:(NSDictionary *)data
-               fromNetwork:(NSInteger)network
-          forNetworkUserId:(NSString * _Nullable)networkUserId
-                    result:(FlutterResult)result {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    [RCCommonFunctionality addAttributionData:data network:network networkUserId:networkUserId];
-    result(nil);
-#pragma GCC diagnostic pop
-}
-
 - (void)getOfferingsWithResult:(FlutterResult)result {
     [RCCommonFunctionality getOfferingsWithCompletionBlock:[self getResponseCompletionBlock:result]];
 }
@@ -271,32 +246,9 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
     result([RCCommonFunctionality appUserID]);
 }
 
-- (void)createAlias:(NSString * _Nullable)newAppUserID
-             result:(FlutterResult)result {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    [RCCommonFunctionality createAlias:newAppUserID completionBlock:[self getResponseCompletionBlock:result]];
-#pragma GCC diagnostic pop
-}
-
 - (void)logInAppUserID:(NSString * _Nullable)appUserID
                 result:(FlutterResult)result {
     [RCCommonFunctionality logInWithAppUserID:appUserID completionBlock:[self getResponseCompletionBlock:result]];
-}
-
-- (void)identify:(NSString * _Nullable)appUserID
-          result:(FlutterResult)result {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    [RCCommonFunctionality identify:appUserID completionBlock:[self getResponseCompletionBlock:result]];
-#pragma GCC diagnostic pop
-}
-
-- (void)resetWithResult:(FlutterResult)result {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    [RCCommonFunctionality resetWithCompletionBlock:[self getResponseCompletionBlock:result]];
-#pragma GCC diagnostic pop
 }
 
 - (void)logOutWithResult:(FlutterResult)result {

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -163,26 +163,6 @@ class Purchases {
   ) =>
       _readyForPromotedProductPurchaseListeners.remove(listenerToRemove);
 
-  /// Deprecated in favor of set<NetworkId> functions.
-  /// Add a dict of attribution information
-  ///
-  /// [data] Attribution data from any of the [PurchasesAttributionNetwork].
-  ///
-  /// [network] Which network, see [PurchasesAttributionNetwork].
-  ///
-  /// [networkUserId] An optional unique id for identifying the user.
-  @Deprecated('Use the set<NetworkId> functions instead.')
-  static Future<void> addAttributionData(
-    Map<String, Object> data,
-    PurchasesAttributionNetwork network, {
-    String? networkUserId,
-  }) =>
-      _channel.invokeMethod('addAttributionData', {
-        'data': data,
-        'network': network.index,
-        'networkUserId': networkUserId
-      });
-
   /// Fetch the configured offerings for this users. Offerings allows you to
   /// configure your in-app products via RevenueCat and greatly simplifies
   /// management. See [the guide](https://docs.revenuecat.com/offerings) for
@@ -340,21 +320,6 @@ class Purchases {
   static Future<String> get appUserID async =>
       await _channel.invokeMethod('getAppUserID') as String;
 
-  /// Deprecated in favor of logIn.
-  /// This function will alias two appUserIDs together.
-  ///
-  /// Returns a [PurchaserInfo] object, or throws a [PlatformException] if there
-  /// was a problem restoring transactions.
-  ///
-  /// [newAppUserID] The new appUserID that should be linked to the currently
-  /// identified appUserID.
-  @Deprecated('Use logIn instead.')
-  static Future<CustomerInfo> createAlias(String newAppUserID) async {
-    final result = await _channel
-        .invokeMethod('createAlias', {'newAppUserID': newAppUserID});
-    return CustomerInfo.fromJson(Map<String, dynamic>.from(result));
-  }
-
   /// This function will logIn the current user with an appUserID.
   /// Typically this would be used after logging in a user to identify them without
   /// calling configure
@@ -376,22 +341,6 @@ class Purchases {
     return LogInResult(customerInfo: customerInfo, created: created);
   }
 
-  /// Deprecated in favor of logIn.
-  /// This function will identify the current user with an appUserID.
-  /// Typically this would be used after a logout to identify a new user without
-  /// calling configure
-  ///
-  /// Returns a [CustomerInfo] object, or throws a [PlatformException] if there
-  /// was a problem restoring transactions.
-  ///
-  /// [newAppUserID] The appUserID that should be linked to the currently user
-  @Deprecated('Use logIn instead.')
-  static Future<CustomerInfo> identify(String appUserID) async {
-    final result =
-        await _channel.invokeMethod('identify', {'appUserID': appUserID});
-    return CustomerInfo.fromJson(Map<String, dynamic>.from(result));
-  }
-
   /// Logs out the  Purchases client, clearing the saved appUserID. This will
   /// generate a random user id and save it in the cache.
   ///
@@ -400,18 +349,6 @@ class Purchases {
   /// current user is anonymous.
   static Future<CustomerInfo> logOut() async {
     final result = await _channel.invokeMethod('logOut');
-    return CustomerInfo.fromJson(Map<String, dynamic>.from(result));
-  }
-
-  /// Deprecated in favor of logOut.
-  /// Resets the Purchases client clearing the saved appUserID. This will
-  /// generate a random user id and save it in the cache.
-  ///
-  /// Returns a [CustomerInfo] object, or throws a [PlatformException] if there
-  /// was a problem restoring transactions.
-  @Deprecated('Use logOut instead.')
-  static Future<CustomerInfo> reset() async {
-    final result = await _channel.invokeMethod('reset');
     return CustomerInfo.fromJson(Map<String, dynamic>.from(result));
   }
 
@@ -804,27 +741,6 @@ enum BillingFeature {
   /// [https://developer.android.com/reference/com/android/
   /// billingclient/api/BillingClient.FeatureType#PRICE_CHANGE_CONFIRMATION]
   priceChangeConfirmation
-}
-
-/// Supported Attribution networks.
-enum PurchasesAttributionNetwork {
-  /// [https://searchads.apple.com/]
-  appleSearchAds,
-
-  /// [https://www.adjust.com/]
-  adjust,
-
-  /// [https://www.appsflyer.com/]
-  appsflyer,
-
-  /// [http://branch.io/]
-  branch,
-
-  /// [http://tenjin.io/]
-  tenjin,
-
-  /// [https://developers.facebook.com/]
-  facebook
 }
 
 /// Possible IntroEligibility status.


### PR DESCRIPTION
Removed `createAlias`, `identify`, `reset` and `addAttributionData` along with `PurchasesAttributionNetwork`