### PR TITLE
Update to phc 3.0.0 (Part 6): Fixes for local development and purchase tester

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,6 +42,7 @@ android {
         // purchases-hybrid-common has two variants, but this library doesn't have any
         // Gradle doesn't know which variant of purchases-hybrid-common to use when using
         // includeBuild and working with a local copy of purchases-hybrid-common
+        // https://developer.android.com/studio/build/build-variants#resolve_matching_errors
         missingDimensionStrategy 'dependencyVersions', 'latestDependencies', 'unityIAP'
     }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,6 +39,10 @@ android {
     defaultConfig {
         minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        // purchases-hybrid-common has two variants, but this library doesn't have any
+        // Gradle doesn't know which variant of purchases-hybrid-common to use when using
+        // includeBuild and working with a local copy of purchases-hybrid-common
+        missingDimensionStrategy 'dependencyVersions', 'latestDependencies', 'unityIAP'
     }
 
     lintOptions {

--- a/revenuecat_examples/purchase_tester/android/app/build.gradle
+++ b/revenuecat_examples/purchase_tester/android/app/build.gradle
@@ -38,6 +38,11 @@ android {
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        // purchases-hybrid-common has two variants, but this library doesn't have any
+        // Gradle doesn't know which variant of purchases-hybrid-common to use when using
+        // includeBuild and working with a local copy of purchases-hybrid-common
+        // This line also needs to be added to purchases_flutter's build.gradle
+        missingDimensionStrategy 'dependencyVersions', 'latestDependencies', 'unityIAP'
     }
 
     buildTypes {

--- a/revenuecat_examples/purchase_tester/android/app/build.gradle
+++ b/revenuecat_examples/purchase_tester/android/app/build.gradle
@@ -43,6 +43,7 @@ android {
         // includeBuild and working with a local copy of purchases-hybrid-common
         // This line also needs to be added to purchases_flutter's build.gradle
         missingDimensionStrategy 'dependencyVersions', 'latestDependencies', 'unityIAP'
+        multiDexEnabled true
     }
 
     buildTypes {
@@ -58,6 +59,7 @@ flutter {
 }
 
 dependencies {
+    implementation 'com.android.support:multidex:1.0.3'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/revenuecat_examples/purchase_tester/android/app/build.gradle
+++ b/revenuecat_examples/purchase_tester/android/app/build.gradle
@@ -42,6 +42,7 @@ android {
         // Gradle doesn't know which variant of purchases-hybrid-common to use when using
         // includeBuild and working with a local copy of purchases-hybrid-common
         // This line also needs to be added to purchases_flutter's build.gradle
+        // https://developer.android.com/studio/build/build-variants#resolve_matching_errors
         missingDimensionStrategy 'dependencyVersions', 'latestDependencies', 'unityIAP'
         multiDexEnabled true
     }

--- a/revenuecat_examples/purchase_tester/android/app/src/main/AndroidManifest.xml
+++ b/revenuecat_examples/purchase_tester/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"
+            android:exported="true"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
@@ -40,6 +41,7 @@
         </activity>
         <activity
             android:name=".EmbeddingV1Activity"
+            android:exported="true"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale"
             android:hardwareAccelerated="true"

--- a/revenuecat_examples/purchase_tester/android/gradle/wrapper/gradle-wrapper.properties
+++ b/revenuecat_examples/purchase_tester/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip


### PR DESCRIPTION
- purchases-hybrid-common has two variants, but this library doesn't have any, trying to work with a local copy of purchases-hybrid-common fails to compile because Gradle doesn't know which variant to use. More info on this in https://developer.android.com/studio/build/build-variants#resolve_matching_errors
- purchases-hybrid-common uses Gradle 7.2 so that also required to be updated 
- purchase tester stopped working when upgrading the AGP version and also required some fixes
