### PR TITLE
chore: Updated freezed dependencies to latest.

### DIFF
--- a/lib/models/offering_wrapper.dart
+++ b/lib/models/offering_wrapper.dart
@@ -51,3 +51,12 @@ class Offering with _$Offering {
   factory Offering.fromJson(Map<String, dynamic> json) =>
       _$OfferingFromJson(json);
 }
+
+extension PackageListX on List<Package> {
+  Package? firstWhereOrNull(bool Function(Package element) test) {
+    for (final element in this) {
+      if (test(element)) return element;
+    }
+    return null;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,17 +15,17 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  freezed_annotation: ^1.1.0
-  json_annotation: ^4.4.0
+  freezed_annotation: ^2.0.1
+  json_annotation: ^4.5.0
 
 dev_dependencies:
-  build_runner: ^2.1.4
+  build_runner: ^2.1.10
   flutter_driver:
     sdk: flutter
   flutter_lints: ^1.0.4
   flutter_test:
     sdk: flutter
-  freezed: ^1.1.1
+  freezed: ^2.0.2
   json_serializable: ^6.0.0
 
 flutter:

--- a/revenuecat_examples/MagicWeather/ios/Podfile.lock
+++ b/revenuecat_examples/MagicWeather/ios/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Flutter (1.0.0)
   - Purchases (3.13.2):
     - PurchasesCoreSwift (= 3.13.2)
-  - purchases_flutter (3.9.4):
+  - purchases_flutter (3.10.0):
     - Flutter
     - PurchasesHybridCommon (= 1.11.2)
   - PurchasesCoreSwift (3.13.2)
@@ -28,10 +28,10 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   Purchases: 03200de9288724e77de435000d1828601e6b8e00
-  purchases_flutter: 3b13af6f0fbb20ebc62d5e41943aa1a17ec723ab
+  purchases_flutter: bcc0010ed14e80a46cc9050bd1afbfb9c48eee17
   PurchasesCoreSwift: 2ea4b33e5cece5c8a0751594ef7c6cbfcbd747a9
   PurchasesHybridCommon: 56ef42d85c3e930d49aff4ac5fa027373d2e1bb8
 
 PODFILE CHECKSUM: a75497545d4391e2d394c3668e20cfb1c2bbd4aa
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3


### PR DESCRIPTION
purchases_flutter package was creating a dependency conflict due to the breaking changes within freezed v2.0.0. Updating dependencies is the only way forward without removing revenue cat entirely.

  -  Updated ```freezed``` and ```freezed_annotation``` to the latest versions
  - As freezed is no longer including package:collection, added an extension for firstWhereOrNull to resolve the breaking change

  - No functionality changed, no additional unit tests necessary
  - All existing unit tests passed
