### PR TITLE
 Update to phc 3.0.0 (Part 4 Second part): Add useAmazon boolean to configure function 

### DIFF
--- a/CHANGELOG-LATEST.md
+++ b/CHANGELOG-LATEST.md
@@ -3,3 +3,4 @@
 - `purchaserInfo` renamed to `customerInfo`
 - Renamed `StoreProduct`, `StoreTransaction` and `StoreProductDiscount`. `package.product` to `package.storeProduct`
 - Store enum has been moved into store.dart
+- `setup` changed with `configure`

--- a/CHANGELOG-LATEST.md
+++ b/CHANGELOG-LATEST.md
@@ -2,3 +2,4 @@
 
 - `purchaserInfo` renamed to `customerInfo`
 - Renamed `StoreProduct`, `StoreTransaction` and `StoreProductDiscount`. `package.product` to `package.storeProduct`
+- Store enum has been moved into store.dart

--- a/lib/models/entitlement_info_wrapper.dart
+++ b/lib/models/entitlement_info_wrapper.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'store.dart';
 
 part 'entitlement_info_wrapper.freezed.dart';
 part 'entitlement_info_wrapper.g.dart';
@@ -19,32 +20,6 @@ enum PeriodType {
 
   /// If the period type couldn't be determined.
   unknown
-}
-
-/// Enum of supported stores
-enum Store {
-  /// For entitlements granted via Apple App Store.
-  @JsonValue('APP_STORE')
-  appStore,
-
-  /// For entitlements granted via Apple Mac App Store.
-  @JsonValue('MAC_APP_STORE')
-  macAppStore,
-
-  /// For entitlements granted via Google Play Store.
-  @JsonValue('PLAY_STORE')
-  playStore,
-
-  /// For entitlements granted via Stripe.
-  @JsonValue('STRIPE')
-  stripe,
-
-  /// For entitlements granted via a promo in RevenueCat.
-  @JsonValue('PROMOTIONAL')
-  promotional,
-
-  /// For entitlements granted via an unknown store.
-  unknownStore
 }
 
 /// Enum of ownership types

--- a/lib/models/entitlement_info_wrapper.g.dart
+++ b/lib/models/entitlement_info_wrapper.g.dart
@@ -59,6 +59,7 @@ const _$StoreEnumMap = {
   Store.stripe: 'STRIPE',
   Store.promotional: 'PROMOTIONAL',
   Store.unknownStore: 'unknownStore',
+  Store.amazon: 'AMAZON',
 };
 
 const _$PeriodTypeEnumMap = {

--- a/lib/models/purchases_configuration.dart
+++ b/lib/models/purchases_configuration.dart
@@ -1,0 +1,37 @@
+/// Used when calling [configure] to configure the RevenueCat plugin
+class PurchasesConfiguration {
+  /// RevenueCat API Key.
+  final String apiKey;
+
+  PurchasesConfiguration(this.apiKey);
+
+  /// An optional unique id for identifying the user.
+  String? appUserID;
+
+  /// An optional boolean. Set this to TRUE if you have your own
+  /// IAP implementation and want to use only RevenueCat's backend.
+  /// Default is FALSE.
+  bool observerMode = false;
+
+  /// iOS-only, will be ignored for Android.
+  /// Set this if you would like the RevenueCat SDK to store its preferences in
+  /// a different NSUserDefaults suite, otherwise it will use
+  /// standardUserDefaults. Default is null, which will make the SDK
+  /// use standardUserDefaults.
+  String? userDefaultsSuiteName;
+
+  /// Android only. Set this to true if you are building the app
+  /// to be distributed in the Amazon Appstore
+  bool useAmazon = false;
+
+}
+
+/// A [PurchasesConfiguration] convenience object that
+/// sets [PurchasesConfiguration.useAmazon] to true
+class AmazonConfiguration extends PurchasesConfiguration {
+
+  AmazonConfiguration(String apiKey) : super(apiKey) {
+    useAmazon = true;
+  }
+
+}

--- a/lib/models/purchases_configuration.dart
+++ b/lib/models/purchases_configuration.dart
@@ -1,3 +1,6 @@
+import '../purchases_flutter.dart';
+import 'store.dart';
+
 /// Used when calling [configure] to configure the RevenueCat plugin
 class PurchasesConfiguration {
   /// RevenueCat API Key.
@@ -20,18 +23,18 @@ class PurchasesConfiguration {
   /// use standardUserDefaults.
   String? userDefaultsSuiteName;
 
-  /// Android only. Set this to true if you are building the app
-  /// to be distributed in the Amazon Appstore
-  bool useAmazon = false;
+  /// Required to configure the plugin to be used in the Amazon Appstore.
+  /// Values different to [Store.amazon] don't have any effect.
+  Store? store;
 
 }
 
 /// A [PurchasesConfiguration] convenience object that
-/// sets [PurchasesConfiguration.useAmazon] to true
+/// sets [PurchasesConfiguration.store] to [Store.amazon]
 class AmazonConfiguration extends PurchasesConfiguration {
 
   AmazonConfiguration(String apiKey) : super(apiKey) {
-    useAmazon = true;
+    store = Store.amazon;
   }
 
 }

--- a/lib/models/store.dart
+++ b/lib/models/store.dart
@@ -1,0 +1,31 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+/// Enum of supported stores
+enum Store {
+  /// For entitlements granted via Apple App Store.
+  @JsonValue('APP_STORE')
+  appStore,
+
+  /// For entitlements granted via Apple Mac App Store.
+  @JsonValue('MAC_APP_STORE')
+  macAppStore,
+
+  /// For entitlements granted via Google Play Store.
+  @JsonValue('PLAY_STORE')
+  playStore,
+
+  /// For entitlements granted via Stripe.
+  @JsonValue('STRIPE')
+  stripe,
+
+  /// For entitlements granted via a promo in RevenueCat.
+  @JsonValue('PROMOTIONAL')
+  promotional,
+
+  /// For entitlements granted via an unknown store.
+  unknownStore,
+
+  /// For entitlements granted via Amazon Appstore.
+  @JsonValue('AMAZON')
+  amazon,
+}

--- a/lib/object_wrappers.dart
+++ b/lib/object_wrappers.dart
@@ -8,6 +8,7 @@ export 'models/offerings_wrapper.dart';
 export 'models/package_wrapper.dart';
 export 'models/payment_discount.dart';
 export 'models/purchases_configuration.dart';
+export 'models/store.dart';
 export 'models/store_product_discount.dart';
 export 'models/store_product_wrapper.dart';
 export 'models/store_transaction.dart';

--- a/lib/object_wrappers.dart
+++ b/lib/object_wrappers.dart
@@ -7,6 +7,7 @@ export 'models/offering_wrapper.dart';
 export 'models/offerings_wrapper.dart';
 export 'models/package_wrapper.dart';
 export 'models/payment_discount.dart';
+export 'models/purchases_configuration.dart';
 export 'models/store_product_discount.dart';
 export 'models/store_product_wrapper.dart';
 export 'models/store_transaction.dart';

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -96,7 +96,7 @@ class Purchases {
         ..appUserID = appUserId
         ..observerMode = observerMode
         ..userDefaultsSuiteName = userDefaultsSuiteName
-        ..useAmazon = useAmazon
+        ..store = useAmazon ? Store.amazon : null
     );
     return configure(configuration);
   }
@@ -114,7 +114,7 @@ class Purchases {
         'appUserId': purchasesConfiguration.appUserID,
         'observerMode': purchasesConfiguration.observerMode,
         'userDefaultsSuiteName': purchasesConfiguration.userDefaultsSuiteName,
-        'useAmazon': purchasesConfiguration.useAmazon
+        'useAmazon': purchasesConfiguration.store == Store.amazon
       },
     );
 

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -80,23 +80,43 @@ class Purchases {
   /// Set this if you would like the RevenueCat SDK to store its preferences in a different
   /// NSUserDefaults suite, otherwise it will use standardUserDefaults.
   /// Default is null, which will make the SDK use standardUserDefaults.
+  ///
+  /// [useAmazon] Android only. Set this to true if you are building the app
+  /// to be distributed in the Amazon Appstore
+  @Deprecated('Use PurchasesConfiguration')
   static Future<void> setup(
     String apiKey, {
     String? appUserId,
     bool observerMode = false,
     String? userDefaultsSuiteName,
     bool useAmazon = false,
-  }) =>
-      _channel.invokeMethod(
-        'setupPurchases',
-        {
-          'apiKey': apiKey,
-          'appUserId': appUserId,
-          'observerMode': observerMode,
-          'userDefaultsSuiteName': userDefaultsSuiteName,
-          'useAmazon': useAmazon
-        },
-      );
+  }) {
+    final configuration = (
+        PurchasesConfiguration(apiKey)
+        ..appUserID = appUserId
+        ..observerMode = observerMode
+        ..userDefaultsSuiteName = userDefaultsSuiteName
+        ..useAmazon = useAmazon
+    );
+    return configure(configuration);
+  }
+
+  /// Sets up Purchases with your API key and an app user id.
+  ///
+  /// [PurchasesConfiguration] Object containing configuration parameters
+  static Future<void> configure(
+    PurchasesConfiguration purchasesConfiguration,
+  ) =>
+    _channel.invokeMethod(
+      'setupPurchases',
+      {
+        'apiKey': purchasesConfiguration.apiKey,
+        'appUserId': purchasesConfiguration.appUserID,
+        'observerMode': purchasesConfiguration.observerMode,
+        'userDefaultsSuiteName': purchasesConfiguration.userDefaultsSuiteName,
+        'useAmazon': purchasesConfiguration.useAmazon
+      },
+    );
 
   // Default to TRUE, set this to FALSE if you are consuming and acknowledging transactions outside of the Purchases SDK.
   ///

--- a/test/entitlement_info_test.dart
+++ b/test/entitlement_info_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:purchases_flutter/models/entitlement_info_wrapper.dart';
+import 'package:purchases_flutter/models/store.dart';
 
 void main() {
   test('unknown period if missing from json', () {

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -589,7 +589,7 @@ void main() {
       (PurchasesConfiguration('api_key')
         ..appUserID = 'cesar'
         ..observerMode = true
-        ..useAmazon = true),
+        ..store = Store.amazon),
     );
     expect(
       log,

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -538,12 +538,58 @@ void main() {
     );
   });
 
-  test('setupPurchases with amazon', () async {
-    await Purchases.setup(
-      'api_key',
-      appUserId: 'cesar',
-      observerMode: true,
-      useAmazon: true,
+  test('configure with amazon', () async {
+    await Purchases.configure(
+      (AmazonConfiguration('api_key')
+        ..appUserID = 'cesar'
+        ..observerMode = true),
+    );
+    expect(
+      log,
+      <Matcher>[
+        isMethodCall(
+          'setupPurchases',
+          arguments: <String, dynamic>{
+            'apiKey': 'api_key',
+            'appUserId': 'cesar',
+            'observerMode': true,
+            'userDefaultsSuiteName': null,
+            'useAmazon': true
+          },
+        )
+      ],
+    );
+  });
+
+  test('configure with base configuration', () async {
+    await Purchases.configure(
+      (PurchasesConfiguration('api_key')
+        ..appUserID = 'cesar'
+        ..observerMode = true),
+    );
+    expect(
+      log,
+      <Matcher>[
+        isMethodCall(
+          'setupPurchases',
+          arguments: <String, dynamic>{
+            'apiKey': 'api_key',
+            'appUserId': 'cesar',
+            'observerMode': true,
+            'userDefaultsSuiteName': null,
+            'useAmazon': false
+          },
+        )
+      ],
+    );
+  });
+
+  test('configure with base configuration and using amazon', () async {
+    await Purchases.configure(
+      (PurchasesConfiguration('api_key')
+        ..appUserID = 'cesar'
+        ..observerMode = true
+        ..useAmazon = true),
     );
     expect(
       log,


### PR DESCRIPTION
- Creates a `PurchasesConfiguration` and an `AmazonConfiguration`
- Deprecates `setup` in favor of `configure`
-  Extracts `Store` to its own file

On top of #350 

[[CF-654]]

[CF-654]: https://revenuecats.atlassian.net/browse/CF-654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ