### PR TITLE
Update samples to 4.0.0

### DIFF
--- a/revenuecat_examples/MagicWeather/.run/Amazon Appstore.run.xml
+++ b/revenuecat_examples/MagicWeather/.run/Amazon Appstore.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Amazon Appstore" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/lib/main_amazon_appstore.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/revenuecat_examples/MagicWeather/.run/Apple Store.run.xml
+++ b/revenuecat_examples/MagicWeather/.run/Apple Store.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Apple Store" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/lib/main_apple_store.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/revenuecat_examples/MagicWeather/.run/Google Play.run.xml
+++ b/revenuecat_examples/MagicWeather/.run/Google Play.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Google Play" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/lib/main_google_play.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/revenuecat_examples/MagicWeather/lib/flavor_config.dart
+++ b/revenuecat_examples/MagicWeather/lib/flavor_config.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/foundation.dart';
+
+enum Flavor { appleStore, googlePlay, amazonAppstore }
+
+class FlavorValues {
+  FlavorValues({@required this.apiKey});
+
+  final String apiKey;
+}
+
+class FlavorConfig {
+  final Flavor flavor;
+  final String apiKey;
+  static FlavorConfig _instance;
+
+  factory FlavorConfig({@required Flavor flavor, @required String apiKey}) {
+    _instance ??= FlavorConfig._internal(flavor, apiKey);
+    return _instance;
+  }
+
+  FlavorConfig._internal(this.flavor, this.apiKey);
+
+  static FlavorConfig get instance {
+    return _instance;
+  }
+
+  static bool isForAppleStore() => _instance.flavor == Flavor.appleStore;
+
+  static bool isForGooglePlay() => _instance.flavor == Flavor.googlePlay;
+
+  static bool isForAmazonAppstore() =>
+      _instance.flavor == Flavor.amazonAppstore;
+}

--- a/revenuecat_examples/MagicWeather/lib/main.dart
+++ b/revenuecat_examples/MagicWeather/lib/main.dart
@@ -1,6 +1,0 @@
-import 'package:flutter/material.dart';
-import 'package:magic_weather_flutter/src/app.dart';
-
-void main() {
-  runApp(const MagicWeatherFlutter());
-}

--- a/revenuecat_examples/MagicWeather/lib/main_amazon_appstore.dart
+++ b/revenuecat_examples/MagicWeather/lib/main_amazon_appstore.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:magic_weather_flutter/src/app.dart';
+
+import 'flavor_config.dart';
+
+void main() {
+  FlavorConfig(
+    flavor: Flavor.amazonAppstore,
+    //TO DO: add the API key for your app from the RevenueCat dashboard: https://app.revenuecat.com
+    apiKey: "",
+  );
+
+  runApp(const MagicWeatherFlutter());
+}

--- a/revenuecat_examples/MagicWeather/lib/main_apple_store.dart
+++ b/revenuecat_examples/MagicWeather/lib/main_apple_store.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:magic_weather_flutter/src/app.dart';
+
+import 'flavor_config.dart';
+
+void main() {
+  FlavorConfig(
+    flavor: Flavor.appleStore,
+    //TO DO: add the API key for your app from the RevenueCat dashboard: https://app.revenuecat.com
+    apiKey: "",
+  );
+
+  runApp(const MagicWeatherFlutter());
+}

--- a/revenuecat_examples/MagicWeather/lib/main_google_play.dart
+++ b/revenuecat_examples/MagicWeather/lib/main_google_play.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:magic_weather_flutter/src/app.dart';
+
+import 'flavor_config.dart';
+
+void main() {
+  FlavorConfig(
+    flavor: Flavor.googlePlay,
+    //TO DO: add the API key for your app from the RevenueCat dashboard: https://app.revenuecat.com
+    apiKey: "",
+  );
+
+  runApp(const MagicWeatherFlutter());
+}

--- a/revenuecat_examples/MagicWeather/lib/src/constant.dart
+++ b/revenuecat_examples/MagicWeather/lib/src/constant.dart
@@ -1,6 +1,3 @@
-//TO DO: add the API key for your app from the RevenueCat dashboard: https://app.revenuecat.com
-const apiKey = 'api_key';
-
 //TO DO: add the entitlement ID from the RevenueCat dashboard that is activated upon successful in-app purchase for the duration of the purchase.
 const entitlementID = 'premium';
 

--- a/revenuecat_examples/MagicWeather/lib/src/views/home.dart
+++ b/revenuecat_examples/MagicWeather/lib/src/views/home.dart
@@ -7,6 +7,8 @@ import 'package:purchases_flutter/purchases_flutter.dart';
 import 'package:magic_weather_flutter/src/model/singletons_data.dart';
 import 'package:magic_weather_flutter/src/model/styles.dart';
 
+import '../../flavor_config.dart';
+
 final GlobalKey<NavigatorState> firstTabNavKey = GlobalKey<NavigatorState>();
 final GlobalKey<NavigatorState> secondTabNavKey = GlobalKey<NavigatorState>();
 
@@ -35,7 +37,17 @@ class AppContainerState extends State<AppContainer> {
 
     - observerMode is false, so Purchases will automatically handle finishing transactions. Read more about Observer Mode here: https://docs.revenuecat.com/docs/observer-mode
     */
-    await Purchases.setup(apiKey, appUserId: null, observerMode: false);
+    PurchasesConfiguration configuration;
+    if (FlavorConfig.isForAmazonAppstore()) {
+      configuration = AmazonConfiguration(FlavorConfig.instance.apiKey)
+        ..appUserID = null
+        ..observerMode = false;
+    } else {
+      configuration = PurchasesConfiguration(FlavorConfig.instance.apiKey)
+        ..appUserID = null
+        ..observerMode = false;
+    }
+    await Purchases.configure(configuration);
 
     appData.appUserID = await Purchases.appUserID;
 

--- a/revenuecat_examples/purchase_tester/.run/Amazon Appstore.run.xml
+++ b/revenuecat_examples/purchase_tester/.run/Amazon Appstore.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Amazon Appstore" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/lib/main_amazon_appstore.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/revenuecat_examples/purchase_tester/.run/Apple Store.run.xml
+++ b/revenuecat_examples/purchase_tester/.run/Apple Store.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Apple Store" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/lib/main_apple_store.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/revenuecat_examples/purchase_tester/.run/Google Play.run.xml
+++ b/revenuecat_examples/purchase_tester/.run/Google Play.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Google Play" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/lib/main_google_play.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/revenuecat_examples/purchase_tester/lib/flavor_config.dart
+++ b/revenuecat_examples/purchase_tester/lib/flavor_config.dart
@@ -1,33 +1,27 @@
 import 'package:flutter/foundation.dart';
 
-enum Flavor { appleStore, googlePlay, amazonAppstore }
+enum Store { appleStore, googlePlay, amazonAppstore }
 
-class FlavorValues {
-  FlavorValues({@required this.apiKey});
-
+class StoreConfig {
+  final Store store;
   final String apiKey;
-}
+  static StoreConfig _instance;
 
-class FlavorConfig {
-  final Flavor flavor;
-  final String apiKey;
-  static FlavorConfig _instance;
-
-  factory FlavorConfig({@required Flavor flavor, @required String apiKey}) {
-    _instance ??= FlavorConfig._internal(flavor, apiKey);
+  factory StoreConfig({@required Store store, @required String apiKey}) {
+    _instance ??= StoreConfig._internal(store, apiKey);
     return _instance;
   }
 
-  FlavorConfig._internal(this.flavor, this.apiKey);
+  StoreConfig._internal(this.store, this.apiKey);
 
-  static FlavorConfig get instance {
+  static StoreConfig get instance {
     return _instance;
   }
 
-  static bool isForAppleStore() => _instance.flavor == Flavor.appleStore;
+  static bool isForAppleStore() => _instance.store == Store.appleStore;
 
-  static bool isForGooglePlay() => _instance.flavor == Flavor.googlePlay;
+  static bool isForGooglePlay() => _instance.store == Store.googlePlay;
 
   static bool isForAmazonAppstore() =>
-      _instance.flavor == Flavor.amazonAppstore;
+      _instance.store == Store.amazonAppstore;
 }

--- a/revenuecat_examples/purchase_tester/lib/flavor_config.dart
+++ b/revenuecat_examples/purchase_tester/lib/flavor_config.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/foundation.dart';
+
+enum Flavor { appleStore, googlePlay, amazonAppstore }
+
+class FlavorValues {
+  FlavorValues({@required this.apiKey});
+
+  final String apiKey;
+}
+
+class FlavorConfig {
+  final Flavor flavor;
+  final String apiKey;
+  static FlavorConfig _instance;
+
+  factory FlavorConfig({@required Flavor flavor, @required String apiKey}) {
+    _instance ??= FlavorConfig._internal(flavor, apiKey);
+    return _instance;
+  }
+
+  FlavorConfig._internal(this.flavor, this.apiKey);
+
+  static FlavorConfig get instance {
+    return _instance;
+  }
+
+  static bool isForAppleStore() => _instance.flavor == Flavor.appleStore;
+
+  static bool isForGooglePlay() => _instance.flavor == Flavor.googlePlay;
+
+  static bool isForAmazonAppstore() =>
+      _instance.flavor == Flavor.amazonAppstore;
+}

--- a/revenuecat_examples/purchase_tester/lib/main_amazon_appstore.dart
+++ b/revenuecat_examples/purchase_tester/lib/main_amazon_appstore.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+import 'flavor_config.dart';
+import 'src/app.dart';
+
+void main() {
+  FlavorConfig(
+    flavor: Flavor.amazonAppstore,
+    //TO DO: add the API key for your app from the RevenueCat dashboard: https://app.revenuecat.com
+    apiKey: "",
+  );
+
+  runApp(const PurchaseTester());
+}

--- a/revenuecat_examples/purchase_tester/lib/main_amazon_appstore.dart
+++ b/revenuecat_examples/purchase_tester/lib/main_amazon_appstore.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:purchases_flutter_example/src/constant.dart';
 
 import 'flavor_config.dart';
 import 'src/app.dart';
 
 void main() {
-  FlavorConfig(
-    flavor: Flavor.amazonAppstore,
-    //TO DO: add the API key for your app from the RevenueCat dashboard: https://app.revenuecat.com
-    apiKey: "",
+  StoreConfig(
+    store: Store.amazonAppstore,
+    apiKey: amazonApiKey,
   );
 
   runApp(const PurchaseTester());

--- a/revenuecat_examples/purchase_tester/lib/main_apple_store.dart
+++ b/revenuecat_examples/purchase_tester/lib/main_apple_store.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+import 'flavor_config.dart';
+import 'src/app.dart';
+
+void main() {
+  FlavorConfig(
+    flavor: Flavor.appleStore,
+    //TO DO: add the API key for your app from the RevenueCat dashboard: https://app.revenuecat.com
+    apiKey: "",
+  );
+
+  runApp(const PurchaseTester());
+}

--- a/revenuecat_examples/purchase_tester/lib/main_apple_store.dart
+++ b/revenuecat_examples/purchase_tester/lib/main_apple_store.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:purchases_flutter_example/src/constant.dart';
 
 import 'flavor_config.dart';
 import 'src/app.dart';
 
 void main() {
-  FlavorConfig(
-    flavor: Flavor.appleStore,
-    //TO DO: add the API key for your app from the RevenueCat dashboard: https://app.revenuecat.com
-    apiKey: "",
+  StoreConfig(
+    store: Store.appleStore,
+    apiKey: appleApiKey,
   );
 
   runApp(const PurchaseTester());

--- a/revenuecat_examples/purchase_tester/lib/main_google_play.dart
+++ b/revenuecat_examples/purchase_tester/lib/main_google_play.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+import 'flavor_config.dart';
+import 'src/app.dart';
+
+void main() {
+  FlavorConfig(
+    flavor: Flavor.googlePlay,
+    //TO DO: add the API key for your app from the RevenueCat dashboard: https://app.revenuecat.com
+    apiKey: "",
+  );
+
+  runApp(const PurchaseTester());
+}

--- a/revenuecat_examples/purchase_tester/lib/main_google_play.dart
+++ b/revenuecat_examples/purchase_tester/lib/main_google_play.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:purchases_flutter_example/src/constant.dart';
 
 import 'flavor_config.dart';
 import 'src/app.dart';
 
 void main() {
-  FlavorConfig(
-    flavor: Flavor.googlePlay,
-    //TO DO: add the API key for your app from the RevenueCat dashboard: https://app.revenuecat.com
-    apiKey: "",
+  StoreConfig(
+    store: Store.googlePlay,
+    apiKey: googleApiKey,
   );
 
   runApp(const PurchaseTester());

--- a/revenuecat_examples/purchase_tester/lib/src/app.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/app.dart
@@ -1,18 +1,22 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:purchases_flutter/purchases_flutter.dart';
 
-import 'src/constant.dart';
+import '../flavor_config.dart';
 
-void main() => runApp(
-      const MaterialApp(
-        title: 'RevenueCat Sample',
-        home: InitialScreen(),
-      ),
+class PurchaseTester extends StatelessWidget {
+  const PurchaseTester({Key key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      title: 'RevenueCat Sample',
+      home: InitialScreen(),
     );
+  }
+}
 
 // ignore: public_member_api_docs
 class InitialScreen extends StatefulWidget {
@@ -35,11 +39,13 @@ class _MyAppState extends State<InitialScreen> {
   Future<void> initPlatformState() async {
     await Purchases.setDebugLogsEnabled(true);
 
-    if (Platform.isAndroid) {
-      await Purchases.setup(googleApiKey);
+    PurchasesConfiguration configuration;
+    if (FlavorConfig.isForAmazonAppstore()) {
+      configuration = AmazonConfiguration(FlavorConfig.instance.apiKey);
     } else {
-      await Purchases.setup(appleApiKey);
+      configuration = PurchasesConfiguration(FlavorConfig.instance.apiKey);
     }
+    await Purchases.configure(configuration);
 
     final customerInfo = await Purchases.getCustomerInfo();
 

--- a/revenuecat_examples/purchase_tester/lib/src/app.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/app.dart
@@ -40,10 +40,10 @@ class _MyAppState extends State<InitialScreen> {
     await Purchases.setDebugLogsEnabled(true);
 
     PurchasesConfiguration configuration;
-    if (FlavorConfig.isForAmazonAppstore()) {
-      configuration = AmazonConfiguration(FlavorConfig.instance.apiKey);
+    if (StoreConfig.isForAmazonAppstore()) {
+      configuration = AmazonConfiguration(StoreConfig.instance.apiKey);
     } else {
-      configuration = PurchasesConfiguration(FlavorConfig.instance.apiKey);
+      configuration = PurchasesConfiguration(StoreConfig.instance.apiKey);
     }
     await Purchases.configure(configuration);
 

--- a/revenuecat_examples/purchase_tester/lib/src/constant.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/constant.dart
@@ -3,3 +3,6 @@ const appleApiKey = 'appl_api_key';
 
 //TO DO: add the Google API key for your app from the RevenueCat dashboard: https://app.revenuecat.com
 const googleApiKey = 'googl_api_key';
+
+//TO DO: add the Amazon API key for your app from the RevenueCat dashboard: https://app.revenuecat.com
+const amazonApiKey = 'amazon_api_key';


### PR DESCRIPTION
I created a FlavorConfig in both examples that can be used for determining if the app is being built for Google Play, Amazon Appstore or Apple Store. Each flavor contains an api key for each platform. 

This required creating three different entry points (`main_amazon_appstore.dart`, `main_google_play.dart` and `main_apple_store.dart`). I also created three run configurations for Android Studio.

<img width="212" alt="Screen Shot 2022-05-19 at 6 56 43 PM" src="https://user-images.githubusercontent.com/664544/169433144-8d5ba627-0ec6-4940-865a-5fe17207977b.png">

The app can also be ran via terminal:

```
flutter run -t lib/main_google_play.dart
flutter run -t lib/main_amazon_appstore.dart
flutter run -t lib/main_apple_store.dart
```

https://medium.com/flutter-community/flutter-ready-to-go-e59873f9d7de#90e6