### PR TITLE
Fix Store transaction JSON keys in 4.0.0

### DIFF
--- a/lib/models/store_transaction.dart
+++ b/lib/models/store_transaction.dart
@@ -9,10 +9,10 @@ part 'store_transaction.g.dart';
 class StoreTransaction with _$StoreTransaction {
   const factory StoreTransaction(
     /// RevenueCat Id associated to the transaction.
-    @JsonKey(name: 'revenueCatIdentifier') String revenueCatIdentifier,
+    @JsonKey(name: 'revenueCatId') String revenueCatIdentifier,
 
     /// Product Id associated with the transaction.
-    @JsonKey(name: 'productIdentifier') String productIdentifier,
+    @JsonKey(name: 'productId') String productIdentifier,
 
     /// Purchase date of the transaction in ISO 8601 format.
     @JsonKey(name: 'purchaseDate') String purchaseDate,

--- a/lib/models/store_transaction.freezed.dart
+++ b/lib/models/store_transaction.freezed.dart
@@ -21,11 +21,11 @@ StoreTransaction _$StoreTransactionFromJson(Map<String, dynamic> json) {
 /// @nodoc
 mixin _$StoreTransaction {
   /// RevenueCat Id associated to the transaction.
-  @JsonKey(name: 'revenueCatIdentifier')
+  @JsonKey(name: 'revenueCatId')
   String get revenueCatIdentifier => throw _privateConstructorUsedError;
 
   /// Product Id associated with the transaction.
-  @JsonKey(name: 'productIdentifier')
+  @JsonKey(name: 'productId')
   String get productIdentifier => throw _privateConstructorUsedError;
 
   /// Purchase date of the transaction in ISO 8601 format.
@@ -44,8 +44,8 @@ abstract class $StoreTransactionCopyWith<$Res> {
           StoreTransaction value, $Res Function(StoreTransaction) then) =
       _$StoreTransactionCopyWithImpl<$Res>;
   $Res call(
-      {@JsonKey(name: 'revenueCatIdentifier') String revenueCatIdentifier,
-      @JsonKey(name: 'productIdentifier') String productIdentifier,
+      {@JsonKey(name: 'revenueCatId') String revenueCatIdentifier,
+      @JsonKey(name: 'productId') String productIdentifier,
       @JsonKey(name: 'purchaseDate') String purchaseDate});
 }
 
@@ -89,8 +89,8 @@ abstract class _$$_StoreTransactionCopyWith<$Res>
       __$$_StoreTransactionCopyWithImpl<$Res>;
   @override
   $Res call(
-      {@JsonKey(name: 'revenueCatIdentifier') String revenueCatIdentifier,
-      @JsonKey(name: 'productIdentifier') String productIdentifier,
+      {@JsonKey(name: 'revenueCatId') String revenueCatIdentifier,
+      @JsonKey(name: 'productId') String productIdentifier,
       @JsonKey(name: 'purchaseDate') String purchaseDate});
 }
 
@@ -132,8 +132,8 @@ class __$$_StoreTransactionCopyWithImpl<$Res>
 @JsonSerializable()
 class _$_StoreTransaction implements _StoreTransaction {
   const _$_StoreTransaction(
-      @JsonKey(name: 'revenueCatIdentifier') this.revenueCatIdentifier,
-      @JsonKey(name: 'productIdentifier') this.productIdentifier,
+      @JsonKey(name: 'revenueCatId') this.revenueCatIdentifier,
+      @JsonKey(name: 'productId') this.productIdentifier,
       @JsonKey(name: 'purchaseDate') this.purchaseDate);
 
   factory _$_StoreTransaction.fromJson(Map<String, dynamic> json) =>
@@ -141,12 +141,12 @@ class _$_StoreTransaction implements _StoreTransaction {
 
   /// RevenueCat Id associated to the transaction.
   @override
-  @JsonKey(name: 'revenueCatIdentifier')
+  @JsonKey(name: 'revenueCatId')
   final String revenueCatIdentifier;
 
   /// Product Id associated with the transaction.
   @override
-  @JsonKey(name: 'productIdentifier')
+  @JsonKey(name: 'productId')
   final String productIdentifier;
 
   /// Purchase date of the transaction in ISO 8601 format.
@@ -193,12 +193,10 @@ class _$_StoreTransaction implements _StoreTransaction {
 
 abstract class _StoreTransaction implements StoreTransaction {
   const factory _StoreTransaction(
-      @JsonKey(name: 'revenueCatIdentifier')
-          final String revenueCatIdentifier,
-      @JsonKey(name: 'productIdentifier')
-          final String productIdentifier,
-      @JsonKey(name: 'purchaseDate')
-          final String purchaseDate) = _$_StoreTransaction;
+          @JsonKey(name: 'revenueCatId') final String revenueCatIdentifier,
+          @JsonKey(name: 'productId') final String productIdentifier,
+          @JsonKey(name: 'purchaseDate') final String purchaseDate) =
+      _$_StoreTransaction;
 
   factory _StoreTransaction.fromJson(Map<String, dynamic> json) =
       _$_StoreTransaction.fromJson;
@@ -206,12 +204,12 @@ abstract class _StoreTransaction implements StoreTransaction {
   @override
 
   /// RevenueCat Id associated to the transaction.
-  @JsonKey(name: 'revenueCatIdentifier')
+  @JsonKey(name: 'revenueCatId')
   String get revenueCatIdentifier => throw _privateConstructorUsedError;
   @override
 
   /// Product Id associated with the transaction.
-  @JsonKey(name: 'productIdentifier')
+  @JsonKey(name: 'productId')
   String get productIdentifier => throw _privateConstructorUsedError;
   @override
 

--- a/lib/models/store_transaction.g.dart
+++ b/lib/models/store_transaction.g.dart
@@ -8,14 +8,14 @@ part of 'store_transaction.dart';
 
 _$_StoreTransaction _$$_StoreTransactionFromJson(Map json) =>
     _$_StoreTransaction(
-      json['revenueCatIdentifier'] as String,
-      json['productIdentifier'] as String,
+      json['revenueCatId'] as String,
+      json['productId'] as String,
       json['purchaseDate'] as String,
     );
 
 Map<String, dynamic> _$$_StoreTransactionToJson(_$_StoreTransaction instance) =>
     <String, dynamic>{
-      'revenueCatIdentifier': instance.revenueCatIdentifier,
-      'productIdentifier': instance.productIdentifier,
+      'revenueCatId': instance.revenueCatIdentifier,
+      'productId': instance.productIdentifier,
       'purchaseDate': instance.purchaseDate,
     };

--- a/test/store_transaction_test.dart
+++ b/test/store_transaction_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:purchases_flutter/models/store_transaction.dart';
+
+void main() {
+  Map<String, Object?> generateStoreTransactionJSON() => {
+        'revenueCatId': 'abd123cd',
+        'productId': 'consumable',
+        'purchaseDateMillis': 1.58759855E9,
+        'purchaseDate': '2020-04-22T23:35:50.000Z'
+      };
+
+  test('revenueCatIdentifier is correctly parsed', () {
+    final storeTransaction = StoreTransaction.fromJson(generateStoreTransactionJSON());
+
+    expect(storeTransaction.revenueCatIdentifier, 'abd123cd');
+  });
+
+  test('productId is correctly parsed', () {
+    final storeTransaction = StoreTransaction.fromJson(generateStoreTransactionJSON());
+
+    expect(storeTransaction.productIdentifier, 'consumable');
+  });
+
+  test('purchaseDate is correctly parsed', () {
+    final storeTransaction = StoreTransaction.fromJson(generateStoreTransactionJSON());
+
+    expect(storeTransaction.purchaseDate, '2020-04-22T23:35:50.000Z');
+  });
+
+}


### PR DESCRIPTION
Store transaction had wrong JSON keys

[CF-753]

[CF-753]: https://revenuecats.atlassian.net/browse/CF-753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ