### PR TITLE
Fix customer info delegate in 4.0.0

### DIFF
--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -447,7 +447,7 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
 #pragma mark -
 #pragma mark Delegate Methods
 
-- (void)purchases:(RCPurchases *)purchases didReceiveUpdatedCustomerInfo:(RCCustomerInfo *)customerInfo {
+- (void)purchases:(RCPurchases *)purchases receivedUpdatedCustomerInfo:(RCCustomerInfo *)customerInfo {
     [self.channel invokeMethod:PurchasesCustomerInfoUpdatedEvent
                      arguments:customerInfo.dictionary];
 }


### PR DESCRIPTION
I was implementing un inexistent delegate. Since the delegate is optional, xcode wasn't complaining


[CF-752]

[CF-752]: https://revenuecats.atlassian.net/browse/CF-752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ