### PR TITLE
Remove `apiTestIntroductoryPrice` to fix integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,8 +236,7 @@ workflows:
       - freezed
   android-integration-test:
     jobs:
-      - android-integration-test-build
-      # - android-integration-test-build: *release-tags-and-branches
+      - android-integration-test-build: *release-tags-and-branches
       - run-firebase-tests:
           requires:
             - android-integration-test-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,7 +236,8 @@ workflows:
       - freezed
   android-integration-test:
     jobs:
-      - android-integration-test-build: *release-tags-and-branches
+      - android-integration-test-build
+      # - android-integration-test-build: *release-tags-and-branches
       - run-firebase-tests:
           requires:
             - android-integration-test-build

--- a/revenuecat_examples/purchase_tester/lib/src/app.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/app.dart
@@ -136,10 +136,6 @@ class _UpsellScreenState extends State<UpsellScreen> {
         final monthly = offering.monthly;
         final lifetime = offering.lifetime;
 
-        if (monthly.storeProduct.introductoryPrice != null) {
-          apiTestIntroductoryPrice(monthly.storeProduct.introductoryPrice);
-        }
-
         if (monthly != null && lifetime != null) {
           return Scaffold(
             appBar: AppBar(title: const Text('Upsell Screen')),
@@ -164,37 +160,6 @@ class _UpsellScreenState extends State<UpsellScreen> {
     );
   }
 
-  void apiTestIntroductoryPrice(IntroductoryPrice introPrice) {
-    final PeriodUnit periodUnit = introPrice.periodUnit;
-    final double price = introPrice.price;
-    final String priceString = introPrice.priceString;
-    final int cycles = introPrice.cycles;
-    final int periodNumberOfUnits = introPrice.periodNumberOfUnits;
-
-    /// deprecated properties
-    // ignore: deprecated_member_use
-    final String introPricePeriodUnit = introPrice.introPricePeriodUnit;
-    // ignore: deprecated_member_use
-    final double introPricePrice = introPrice.introPrice;
-    // ignore: deprecated_member_use
-    final String introPriceString = introPrice.introPriceString;
-    // ignore: deprecated_member_use
-    final String introPricePeriod = introPrice.introPricePeriod;
-    final int introPricePeriodNumberOfUnits =
-        // ignore: deprecated_member_use
-        introPrice.introPricePeriodNumberOfUnits;
-    // ignore: deprecated_member_use
-    final int introPriceCycles = introPrice.introPriceCycles;
-
-    print('introPricePeriodUnit: $introPricePeriodUnit, periodUnit: '
-        '$periodUnit, price: $price.toString(), priceString: '
-        '$priceString, cycles: $cycles.toString(), periodNumberOfUnits: '
-        '$periodNumberOfUnits, introPrice: $introPrice.toString(), '
-        'introPriceString: $introPriceString, introPricePeriod: '
-        '$introPricePeriod, introPricePeriodNumberOfUnits: '
-        '$introPricePeriodNumberOfUnits, introPriceCycles: '
-        '$introPriceCycles, introPricePrice: $introPricePrice.toString()');
-  }
 }
 
 class _PurchaseButton extends StatelessWidget {


### PR DESCRIPTION
Removes `apiTestIntroductoryPrice` since we now have https://github.com/RevenueCat/purchases-flutter/pull/388