### PR TITLE
Adds missing `introEligibilityStatusNoIntroOfferExists` case

### DIFF
--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -317,6 +317,7 @@ class _PurchasesFlutterApiTest {
       case IntroEligibilityStatus.introEligibilityStatusUnknown:
       case IntroEligibilityStatus.introEligibilityStatusIneligible:
       case IntroEligibilityStatus.introEligibilityStatusEligible:
+      case IntroEligibilityStatus.introEligibilityStatusNoIntroOfferExists:
         break;
     }
   }

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -772,7 +772,10 @@ enum IntroEligibilityStatus {
   introEligibilityStatusIneligible,
 
   /// The user is eligible for a free trial or intro pricing for this product.
-  introEligibilityStatusEligible
+  introEligibilityStatusEligible,
+
+  /// There is no free trial or intro pricing for this product.
+  introEligibilityStatusNoIntroOfferExists
 }
 
 /// Holds the introductory price status

--- a/test/intro_eligibility_test.dart
+++ b/test/intro_eligibility_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:purchases_flutter/purchases_flutter.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const productName = 'monthly_intro_pricing_one_week';
+  const channel = MethodChannel('purchases_flutter');
+  final log = <MethodCall>[];
+  dynamic response;
+
+  setUp(() {
+    channel.setMockMethodCallHandler((call) async {
+      log.add(call);
+      return response;
+    });
+  });
+
+  tearDown(() {
+    channel.setMockMethodCallHandler(null);
+    log.clear();
+    response = null;
+  });
+
+  test('checkTrialOrIntroductoryPriceEligibility returns eligibility map',
+      () async {
+    response = {
+      productName: {'status': 0, 'description': 'Unknown status'}
+    };
+    final list = await Purchases.checkTrialOrIntroductoryPriceEligibility(
+      [productName],
+    );
+    expect(list.length, 1);
+  });
+
+  test('introEligibilityStatusUnknown is returned', () async {
+    response = {
+      productName: {'status': 0, 'description': 'Unknown status'}
+    };
+    final list = await Purchases.checkTrialOrIntroductoryPriceEligibility(
+      [productName],
+    );
+    expect(
+      list[productName]?.status,
+      IntroEligibilityStatus.introEligibilityStatusUnknown,
+    );
+  });
+
+  test('introEligibilityStatusIneligible is returned', () async {
+    response = {
+      productName: {
+        'status': 1,
+        'description': 'Not eligible for trial or introductory price.'
+      }
+    };
+    final list = await Purchases.checkTrialOrIntroductoryPriceEligibility(
+      [productName],
+    );
+    expect(
+      list[productName]?.status,
+      IntroEligibilityStatus.introEligibilityStatusIneligible,
+    );
+  });
+
+  test('introEligibilityStatusEligible is returned', () async {
+    response = {
+      productName: {
+        'status': 2,
+        'description': 'Eligible for trial or introductory price.'
+      }
+    };
+    final list = await Purchases.checkTrialOrIntroductoryPriceEligibility(
+      [productName],
+    );
+    expect(
+      list[productName]?.status,
+      IntroEligibilityStatus.introEligibilityStatusEligible,
+    );
+  });
+
+  test('introEligibilityStatusNoIntroOfferExists is returned', () async {
+    response = {
+      productName: {
+        'status': 3,
+        'description': 'Product does not have trial or introductory price.'
+      }
+    };
+    final list = await Purchases.checkTrialOrIntroductoryPriceEligibility(
+      [productName],
+    );
+    expect(
+      list[productName]?.status,
+      IntroEligibilityStatus.introEligibilityStatusNoIntroOfferExists,
+    );
+  });
+}

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -82,20 +82,6 @@ void main() {
     expect(list.length, 1);
   });
 
-  test('checkTrialOrIntroductoryPriceEligibility returns eligibility map',
-      () async {
-    response = {
-      'monthly_intro_pricing_one_week': {
-        'status': 0,
-        'description': 'Status indeterminate.'
-      }
-    };
-    final list = await Purchases.checkTrialOrIntroductoryPriceEligibility(
-      ['monthly_intro_pricing_one_week'],
-    );
-    expect(list.length, 1);
-  });
-
   test('canMakePayments with no params calls successfully', () async {
     response = Random().nextBool();
     final receivedCanMakePayments = await Purchases.canMakePayments();


### PR DESCRIPTION
[CSDK-333]

IntroEligibilityStatus was missing a new case that was added in purchases-ios 4

[CSDK-333]: https://revenuecats.atlassian.net/browse/CSDK-333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ