### PR TITLE
Setup credentials in prepare_next_version job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,14 @@ commands:
             ssh-keyscan $ip; \
             done 2>/dev/null >> ~/.ssh/known_hosts
 
+  setup-git-credentials:
+    steps:
+      - run:
+          name: Setup Git config
+          command: |
+            git config user.email $GIT_EMAIL
+            git config user.name $GIT_USERNAME
+
 jobs:
   lint:
     description: "Run static analysis for Flutter"
@@ -252,6 +260,7 @@ jobs:
       - checkout
       - install-gem-dependencies
       - trust-github-key
+      - setup-git-credentials
       - run:
           name: Prepare next version
           command: bundle exec fastlane prepare_next_version


### PR DESCRIPTION
Fixes https://app.circleci.com/pipelines/github/RevenueCat/purchases-flutter/894/workflows/fa5a8257-5fed-4d14-acf1-b69003b00796/jobs/3047

We need to setup git credentials to commit the changes when preparing the next version
