### PR TITLE
Bump fastlane plugin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 805c34fc9b7e13047a83d6d6411e87fc787143ba
+  revision: b470362026b92f43785d1de4c0e11508302ab3e0
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
 


### PR DESCRIPTION
This bumps fastlane plugins version to include some fixes for the release process from: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal/pull/18