### PR TITLE
Update fastlane plugin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: b470362026b92f43785d1de4c0e11508302ab3e0
+  revision: 078609b63c55ad91a674765e68937d805264a827
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,9 +2,10 @@
 
 1. Create a `fastlane/.env` file with your GitHub API token (see `fastlane/.env.SAMPLE`). This will be used to create the PR, so you should use your own token so the PR gets assigned to you.
 1. Run `bundle exec fastlane bump`
-    1. Input new version number
-    2. Update CHANGELOG.latest.md to include the latest changes. Call out API changes (if any). You can use the existing CHANGELOG.md as a base for formatting. To compile the changelog, you can compare the changes between the base branch for the release (usually main) against the latest release, by checking https://github.com/revenuecat/purchases-flutter/compare/<latest_release>...<base_branch>. For example, https://github.com/revenuecat/purchases-flutter/compare/3.10.0...main. 
-    3. A new branch and PR will automatically be created
+    1. Confirm base branch is correct
+    2. Input new version number
+    3. Update CHANGELOG.latest.md to include the latest changes. Call out API changes (if any). You can use the existing CHANGELOG.md as a base for formatting. To compile the changelog, you can compare the changes between the base branch for the release (usually main) against the latest release, by checking https://github.com/revenuecat/purchases-flutter/compare/<latest_release>...<base_branch>. For example, https://github.com/revenuecat/purchases-flutter/compare/3.10.0...main.
+    4. A new branch and PR will automatically be created
 1. Update to the latest SDK versions in ios/purchases_flutter.podspec, macos/purchases_flutter.podspec and android/build.gradle.
 1. If purchases-hybrid-common was updated, run `pod update PurchasesHybridCommon` in both `MagicWeather` and `purchase_tester`
 1. Wait until PR approved and make sure local copy matches remote

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,6 +8,7 @@
     4. A new branch and PR will automatically be created
 1. Update to the latest SDK versions in ios/purchases_flutter.podspec, macos/purchases_flutter.podspec and android/build.gradle.
 1. If purchases-hybrid-common was updated, run `pod update PurchasesHybridCommon` in both `MagicWeather` and `purchase_tester`
-1. Wait until PR approved and make sure local copy matches remote
+1. Wait until PR is approved (don't merge yet) and pull branch from origin (to make sure you've got all the changes locally)
 1. Run `flutter pub publish --dry-run`. Fix any errors if any show
 1. Create a tag for the new release in the last commit of the branch and push the tag. The rest will be performed automatically by CircleCI. If the automation fails, you can revert to manually calling `bundle exec fastlane release`.
+1. After that, you can merge the release PR to main and merge the bump to the next snapshot version PR right after.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -32,7 +32,7 @@ changelog_path = './CHANGELOG.md'
 
 before_all do
   setup_circle_ci
-  update_fastlane  
+  update_fastlane
 end
 
 desc "Bump version, edit changelog, and create pull request"
@@ -46,7 +46,6 @@ lane :bump do |options|
     files_to_update_without_prerelease_modifiers: [],
     repo_name: repo_name,
     github_rate_limit: options[:github_rate_limit],
-    branch: options[:branch],
     editor: options[:editor]
   )
   update_hybrids_versions_file(


### PR DESCRIPTION
### Description
This PR bumps the fastlane internal plugin to use the latest version. One of the changes is that we won't be validating the base branch automatically in the `bump` lane anymore. Instead, we will ask for confirmation from the user in a prompt: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal/pull/20
