### PR TITLE
Add `next_version` and `automatic_release` to automatic_bump

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -46,7 +46,8 @@ lane :bump do |options|
     files_to_update_without_prerelease_modifiers: [],
     repo_name: repo_name,
     github_rate_limit: options[:github_rate_limit],
-    editor: options[:editor]
+    editor: options[:editor],
+    next_version: options[:next_version]
   )
   update_hybrids_versions_file(
     versions_file_path: './VERSIONS.md',

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -47,7 +47,8 @@ lane :bump do |options|
     repo_name: repo_name,
     github_rate_limit: options[:github_rate_limit],
     editor: options[:editor],
-    next_version: options[:next_version]
+    next_version: options[:next_version],
+    automatic_release: options[:automatic_release]
   )
   update_hybrids_versions_file(
     versions_file_path: './VERSIONS.md',
@@ -65,6 +66,7 @@ lane :automatic_bump do |options|
     github_rate_limit: options[:github_rate_limit]
   )
   options[:next_version] = next_version
+  options[:automatic_release] = true
   UI.user_error!('Skipping automatic bump since the next version is a major release') if type_of_bump == :major
   bump(options)
 end


### PR DESCRIPTION
I forgot to pass `next_version` and `automatic_release` as parameter to the bump lane