### PR TITLE
Skip release if needed and change type of message

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -67,7 +67,14 @@ lane :automatic_bump do |options|
   )
   options[:next_version] = next_version
   options[:automatic_release] = true
-  UI.user_error!('Skipping automatic bump since the next version is a major release') if type_of_bump == :major
+  if type_of_bump == :skip
+    UI.message('Skipping automatic bump since the next version doesn\'t include public facing changes')
+    next
+  end
+  if type_of_bump == :major
+    UI.message('Skipping automatic bump since the next version is a major release')
+    next
+  end
   bump(options)
 end
 


### PR DESCRIPTION
- Checks `type_of_bump` and skips if needed
- Changes errors to be `message` instead of `user_error`