### PR TITLE
Calls correct lane when automatically upgrading phc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,7 +263,7 @@ jobs:
       - revenuecat/setup-git-credentials
       - run:
           name: Prepare next version
-          command: bundle exec fastlane update_hybrid_common_versions version:<< pipeline.parameters.hybrid-common-version >> open_pr:true automatic_release:true
+          command: bundle exec fastlane update_hybrid_common version:<< pipeline.parameters.hybrid-common-version >> open_pr:true automatic_release:true
 
   make-release:
     description: "Publishes the new version to pub.dev and creates a github release"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -129,12 +129,6 @@ lane :tag_current_branch do |options|
 end
 
 desc "Update hybrid common pod and gradle"
-lane :update_hybrid_common_versions_and_open_pr do |options|
-  options[:open_pr] = true
-  update_hybrid_common_versions(options)
-end
-
-desc "Update hybrid common pod and gradle"
 lane :update_hybrid_common_versions do |options|
   if options[:dry_run]
     dry_run = true

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -69,14 +69,6 @@ Builds and analyzes the api_tester project to make sure APIs are expected
 
 Tag current branch with current version number
 
-### update_hybrid_common_versions_and_open_pr
-
-```sh
-[bundle exec] fastlane update_hybrid_common_versions_and_open_pr
-```
-
-Update hybrid common pod and gradle
-
 ### update_hybrid_common_versions
 
 ```sh


### PR DESCRIPTION
update-hybrid-common-versions was calling the wrong lane and the Podfile.locks were not being updated