### PR TITLE
Update update-hybrid-common-versions parameters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ orbs:
   android: circleci/android@0.2.1
   gcp-cli: circleci/gcp-cli@2.1.0
   swissknife: roopakv/swissknife@0.65.0
-  revenuecat: revenuecat/sdks-common-config@2.0.0
+  revenuecat: revenuecat/sdks-common-config@2.1.0
 
 parameters:
   action:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,7 +268,7 @@ jobs:
       - run:
           name: Updating to next version of phc
           command: |
-            bundle exec fastlane update_hybrid_common 
+            bundle exec fastlane update_hybrid_common \
             version:<< pipeline.parameters.version >> \
             open_pr:true \
             automatic_release:<< pipeline.parameters.automatic >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,9 +266,12 @@ jobs:
       - revenuecat/setup-git-credentials
       - setup-flutter
       - run:
-          name: Prepare next version
-          command: bundle exec fastlane update_hybrid_common version:<< pipeline.parameters.version >> open_pr:true automatic_release:<< pipeline.parameters.automatic >>
-
+          name: Updating to next version of phc
+          command: |
+            bundle exec fastlane update_hybrid_common 
+            version:<< pipeline.parameters.version >> \
+            open_pr:true \
+            automatic_release:<< pipeline.parameters.automatic >>
   make-release:
     description: "Publishes the new version to pub.dev and creates a github release"
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,9 +37,12 @@ parameters:
     type: enum
     enum: [build, upgrade-hybrid-common, bump]
     default: build
-  hybrid-common-version:
+  version:
     type: string
     default: ''
+  automatic:
+    type: boolean
+    default: false
 
 commands:
 
@@ -264,7 +267,7 @@ jobs:
       - setup-flutter
       - run:
           name: Prepare next version
-          command: bundle exec fastlane update_hybrid_common version:<< pipeline.parameters.hybrid-common-version >> open_pr:true automatic_release:true
+          command: bundle exec fastlane update_hybrid_common version:<< pipeline.parameters.version >> open_pr:true automatic_release:<< pipeline.parameters.automatic >>
 
   make-release:
     description: "Publishes the new version to pub.dev and creates a github release"


### PR DESCRIPTION
- Changed `hybrid-common-version` to `version`
- Created `automatic` to make it clear which ones are triggered automatically

Depends on https://github.com/RevenueCat/purchases-hybrid-common/pull/248/files