### PR TITLE
Makes hold job depend on integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,6 @@
 version: 2.1
 
 aliases:
-  release-tags-and-branches: &release-tags-and-branches
-    filters:
-      tags:
-        ignore: /^.*-SNAPSHOT/
-      branches:
-        only: /^release\/.*/
   release-tags: &release-tags
     filters:
       tags:
@@ -289,28 +283,21 @@ workflows:
       - test
       - api_test
       - freezed
-  android-integration-test:
-    when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-    jobs:
-      - android-integration-test-build: *release-tags-and-branches
-      - run-firebase-tests:
-          requires:
-            - android-integration-test-build
-  ios-integration-test:
-    when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-    jobs:
-      - ios-integration-test: *release-tags-and-branches
   deploy:
     when:
       not:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
+      - ios-integration-test: *release-branches
+      - android-integration-test-build: *release-branches
+      - run-firebase-tests:
+          requires:
+            - android-integration-test-build
       - hold:
           type: approval
+          requires:
+            - ios-integration-test
+            - run-firebase-tests
           <<: *release-branches
       - revenuecat/tag-current-branch:
           requires:


### PR DESCRIPTION
Equivalent of https://github.com/RevenueCat/purchases-android/pull/644/files

Fixes two things:
- Makes sure integration tests pass before deploying anything
- Prevents integration tests from running also when the branch is tagged (after the hold job is approved), which was unnecessary