### PR TITLE
Add setCleverTapId, setMixpanelDistinctID, setFirebaseAppInstanceId

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -252,6 +252,18 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 String mparticleID = call.argument("mparticleID");
                 setMparticleID(mparticleID, result);
                 break;
+            case "setCleverTapID":
+                String cleverTapID = call.argument("cleverTapID");
+                setCleverTapID(cleverTapID, result);
+                break;
+            case "setMixpanelDistinctID":
+                String mixpanelDistinctID = call.argument("mixpanelDistinctID");
+                setMixpanelDistinctID(mixpanelDistinctID, result);
+                break;
+            case "setFirebaseAppInstanceID":
+                String firebaseAppInstanceID = call.argument("firebaseAppInstanceID");
+                setFirebaseAppInstanceID(firebaseAppInstanceID, result);
+                break;
             case "setOnesignalID":
                 String onesignalID = call.argument("onesignalID");
                 setOnesignalID(onesignalID, result);
@@ -498,6 +510,21 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
 
     private void setMparticleID(String mparticleID, final Result result) { 
         SubscriberAttributesKt.setMparticleID(mparticleID);
+        result.success(null);
+    }
+
+    private void setCleverTapID(String cleverTapID, final Result result) {
+        SubscriberAttributesKt.setCleverTapID(cleverTapID);
+        result.success(null);
+    }
+
+    private void setMixpanelDistinctID(String mixpanelDistinctID, final Result result) {
+        SubscriberAttributesKt.setMixpanelDistinctID(mixpanelDistinctID);
+        result.success(null);
+    }
+
+    private void setFirebaseAppInstanceID(String firebaseAppInstanceId, final Result result) {
+        SubscriberAttributesKt.setFirebaseAppInstanceID(firebaseAppInstanceId);
         result.success(null);
     }
 

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -220,6 +220,21 @@ class _PurchasesFlutterApiTest {
     Future<void> future = Purchases.setMparticleID(id);
   }
 
+  void _checkSetCleverTapID() {
+    String id = "fakeId";
+    Future<void> future = Purchases.setCleverTapID(id);
+  }
+
+  void _checkSetMixpanelDistinctID() {
+    String id = "fakeId";
+    Future<void> future = Purchases.setMixpanelDistinctID(id);
+  }
+
+  void _checkSetFirebaseAppInstanceId() {
+    String id = "fakeId";
+    Future<void> future = Purchases.setFirebaseAppInstanceId(id);
+  }
+
   void _checkSetOnesignalId() {
     String id = "fakeId";
     Future<void> future = Purchases.setOnesignalID(id);

--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -130,6 +130,15 @@ NSString *PurchasesReadyForPromotedProductPurchaseEvent = @"Purchases-ReadyForPr
     } else if ([@"setMparticleID" isEqualToString:call.method]) {
         NSString *mparticleID = arguments[@"mparticleID"];
         [self setMparticleID:mparticleID result:result];
+    } else if([@"setCleverTapID" isEqualToString:call.method]) {
+        NSString *cleverTapID = arguments[@"cleverTapID"];
+        [self setCleverTapID:cleverTapID result:result];
+    } else if([@"setMixpanelDistinctID" isEqualToString:call.method]) {
+        NSString *mixpanelDistinctID = arguments[@"mixpanelDistinctID"];
+        [self setMixpanelDistinctID:mixpanelDistinctID result:result];
+    } else if([@"setFirebaseAppInstanceID" isEqualToString:call.method]) {
+        NSString *firebaseAppInstanceID = arguments[@"firebaseAppInstanceID"];
+        [self setFirebaseAppInstanceID:firebaseAppInstanceID result:result];
     } else if ([@"setOnesignalID" isEqualToString:call.method]) {
         NSString *onesignalID = arguments[@"onesignalID"];
         [self setOnesignalID:onesignalID result:result];
@@ -382,6 +391,21 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
 
 - (void)setMparticleID:(nullable NSString *)mparticleID result:(FlutterResult)result {
     [RCCommonFunctionality setMparticleID:mparticleID];
+    result(nil);
+}
+
+- (void)setCleverTapID:(nullable NSString *)cleverTapID result:(FlutterResult)result {
+    [RCCommonFunctionality setCleverTapID:cleverTapID];
+    result(nil);
+}
+
+- (void)setMixpanelDistinctID:(nullable NSString *)mixpanelDistinctID result:(FlutterResult)result {
+    [RCCommonFunctionality setMixpanelDistinctID:mixpanelDistinctID];
+    result(nil);
+}
+
+- (void)setFirebaseAppInstanceID:(nullable NSString *)firebaseAppInstanceId result:(FlutterResult)result {
+    [RCCommonFunctionality setFirebaseAppInstanceID:firebaseAppInstanceId];
     result(nil);
 }
 

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -552,6 +552,27 @@ class Purchases {
   static Future<void> setMparticleID(String mparticleID) =>
       _channel.invokeMethod('setMparticleID', {'mparticleID': mparticleID});
 
+  /// Subscriber attribute associated with the Clever Tap Id for the user
+  /// Required for the RevenueCat CleverTap integration
+  ///
+  /// [cleverTapID] Empty String or null will delete the subscriber attribute.
+  static Future<void> setCleverTapID(String cleverTapID) =>
+      _channel.invokeMethod('setCleverTapID', {'cleverTapID': cleverTapID});
+
+  /// Subscriber attribute associated with the Mixpanel Distinct Id for the user
+  /// Required for the RevenueCat MixPanel integration
+  ///
+  /// [mixpanelDistinctID] Empty String or null will delete the subscriber attribute.
+  static Future<void> setMixpanelDistinctID(String mixpanelDistinctID) =>
+      _channel.invokeMethod('setMixpanelDistinctID', {'mixpanelDistinctID': mixpanelDistinctID});
+
+  /// Subscriber attribute associated with the Firebase Instance Id for the user
+  /// Required for the RevenueCat Firebase integration
+  ///
+  /// [firebaseAppInstanceId] Empty String or null will delete the subscriber attribute.
+  static Future<void> setFirebaseAppInstanceId(String firebaseAppInstanceId) =>
+      _channel.invokeMethod('setFirebaseAppInstanceID', {'firebaseAppInstanceID': firebaseAppInstanceId});
+
   /// Subscriber attribute associated with the OneSignal Player Id for the user
   /// Required for the RevenueCat OneSignal integration
   ///


### PR DESCRIPTION
Hi! In my team we wanted to send the FirebaseAppInstanceID to Revenuecat from the Flutter SDK, but there is no method to set it!

I know we can do it from the setAttributes method (`Purchases.setAttributes({r'$firebaseAppInstanceId': firebaseId});`) but it seems a bit ugly to do it this way having the others with their own setters.

So I started preparing a PR to add the FirebaseAppInstanceID but in the end I added other methods that I saw that are also missing in the Flutter SDK.

I just tested with iOS and Android with our app, and it seems to work properly. I didn't find any tests on setters, if there are any please let me know.

(Kinda bad english sorry ;). )

Changes:

* added `setCleverTapId` method
* added `setMixpanelDistinctID` method
* added `setFirebaseAppInstanceId` method
