### PR TITLE
Fix for java.lang.IllegalAccessError: Interface androidx.lifecycle.c 

### DIFF
--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,3 +1,4 @@
 -dontwarn com.amazon.**
 -keep class com.amazon.** {*;}
 -keepattributes *Annotation*
+-keep class androidx.lifecycle.DefaultLifecycleObserver


### PR DESCRIPTION
Makes sure `androidx.lifecycle.DefaultLifecycleObserver` doesn't get stripped out by R8.

We got reports of this in https://play.google.com/sdk-console/u/1/accounts/3894912036640479868/sdks/8672516042485634097/crashes/347b470a/details?timeRange=LAST_28_DAYS&installSources=PLAY_STORE&crashStatus=SDK_CRASH_STATUS_UNSPECIFIED and also via support. The stacktrace looks like:

```
Exception java.lang.IllegalAccessError: Interface androidx.lifecycle.c implemented by class com.revenuecat.purchases.AppLifecycleHandler is inaccessible (declaration of 'com.revenuecat.purchases.AppLifecycleHandler' appears in base.apk)
  at com.revenuecat.purchases.Purchases$lifecycleHandler$2.invoke (Purchases.java)
  at com.revenuecat.purchases.Purchases$lifecycleHandler$2.invoke (Purchases.java)
  at kotlin.SynchronizedLazyImpl.getValue (SynchronizedLazyImpl.java)
  at com.revenuecat.purchases.Purchases.getLifecycleHandler (Purchases.java)
  at com.revenuecat.purchases.Purchases.access$getLifecycleHandler (Purchases.java)
  at com.revenuecat.purchases.Purchases$1.invoke (Purchases.java)
  at com.revenuecat.purchases.Purchases$1.invoke (Purchases.java)
  at com.revenuecat.purchases.Purchases.dispatch (Purchases.java)
  at com.revenuecat.purchases.Purchases.<init> (Purchases.java)
  at com.revenuecat.purchases.Purchases.<init> (Purchases.java)
  at com.revenuecat.purchases.PurchasesFactory.createPurchases (PurchasesFactory.java)
  at com.revenuecat.purchases.Purchases$Companion.configure (Purchases.java)
  at com.revenuecat.purchases.hybridcommon.CommonKt.configure (CommonKt.java)
  at com.revenuecat.purchases.hybridcommon.CommonKt.configure$default (CommonKt.java)
  at com.revenuecat.purchases.hybridcommon.CommonKt.configure (CommonKt.java)
  at <private>
  at android.os.Handler.handleCallback (Handler.java:938)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loop (Looper.java:236)
  at android.app.ActivityThread.main (ActivityThread.java:8087)
  at java.lang.reflect.Method.invoke (Method.java)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:620)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1011)
  ```
  
 I found reports of this in:
 - https://github.com/flutter/flutter/issues/58479
 - This is how the lifecycle Flutter plugin fixed it https://github.com/flutter/plugins/pull/3746
 
I will port this change all the way down to purchases-android, but I would like to ship it first for Flutter since I think most affected apps will be Flutter.

I built a Flutter app on release mode and it looks like the class is there after this change:

<img width="1082" alt="Screenshot 2022-12-13 at 7 38 07 PM" src="https://user-images.githubusercontent.com/664544/207418665-c7233ea5-53a8-4f0b-b314-36bc1f1f5a73.png">

I can't see the class when analyzing the apk before this change, but I am not sure if it's due to it being renamed or something.

I wasn't able to reproduce the stacktrace, but I am pretty optimistic this will fix it.
