### PR TITLE
Add beginRefundRequest APIs for iOS 15+

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -213,6 +213,9 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
             case "getPromotionalOffer":
             case "presentCodeRedemptionSheet":
             case "setSimulatesAskToBuyInSandbox":
+            case "beginRefundRequestForActiveEntitlement":
+            case "beginRefundRequestForProduct":
+            case "beginRefundRequestForEntitlement":
                 // NOOP
                 result.success(null);
                 break;
@@ -493,22 +496,22 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
         result.success(null);
     }
 
-    private void setAdjustID(String adjustID, final Result result) { 
+    private void setAdjustID(String adjustID, final Result result) {
         SubscriberAttributesKt.setAdjustID(adjustID);
         result.success(null);
     }
 
-    private void setAppsflyerID(String appsflyerID, final Result result) { 
+    private void setAppsflyerID(String appsflyerID, final Result result) {
         SubscriberAttributesKt.setAppsflyerID(appsflyerID);
         result.success(null);
     }
 
-    private void setFBAnonymousID(String fbAnonymousID, final Result result) { 
+    private void setFBAnonymousID(String fbAnonymousID, final Result result) {
         SubscriberAttributesKt.setFBAnonymousID(fbAnonymousID);
         result.success(null);
     }
 
-    private void setMparticleID(String mparticleID, final Result result) { 
+    private void setMparticleID(String mparticleID, final Result result) {
         SubscriberAttributesKt.setMparticleID(mparticleID);
         result.success(null);
     }
@@ -528,7 +531,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
         result.success(null);
     }
 
-    private void setOnesignalID(String onesignalID, final Result result) { 
+    private void setOnesignalID(String onesignalID, final Result result) {
         SubscriberAttributesKt.setOnesignalID(onesignalID);
         result.success(null);
     }
@@ -543,32 +546,32 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
         result.success(null);
     }
 
-    private void setCampaign(String campaign, final Result result) { 
+    private void setCampaign(String campaign, final Result result) {
         SubscriberAttributesKt.setCampaign(campaign);
         result.success(null);
     }
 
-    private void setAdGroup(String adGroup, final Result result) { 
+    private void setAdGroup(String adGroup, final Result result) {
         SubscriberAttributesKt.setAdGroup(adGroup);
         result.success(null);
     }
 
-    private void setAd(String ad, final Result result) { 
+    private void setAd(String ad, final Result result) {
         SubscriberAttributesKt.setAd(ad);
         result.success(null);
     }
 
-    private void setKeyword(String keyword, final Result result) { 
+    private void setKeyword(String keyword, final Result result) {
         SubscriberAttributesKt.setKeyword(keyword);
         result.success(null);
     }
 
-    private void setCreative(String creative, final Result result) { 
+    private void setCreative(String creative, final Result result) {
         SubscriberAttributesKt.setCreative(creative);
         result.success(null);
     }
 
-    private void collectDeviceIdentifiers(final Result result) { 
+    private void collectDeviceIdentifiers(final Result result) {
         SubscriberAttributesKt.collectDeviceIdentifiers();
         result.success(null);
     }

--- a/api_tester/lib/api_tests/errors_api_test.dart
+++ b/api_tester/lib/api_tests/errors_api_test.dart
@@ -31,6 +31,16 @@ class _ErrorsApiTest {
       case PurchasesErrorCode.logOutWithAnonymousUserError:
       case PurchasesErrorCode.configurationError:
       case PurchasesErrorCode.unsupportedError:
+      case PurchasesErrorCode.emptySubscriberAttributesError:
+      case PurchasesErrorCode.productDiscountMissingIdentifierError:
+      case PurchasesErrorCode.productDiscountMissingSubscriptionGroupIdentifierError:
+      case PurchasesErrorCode.customerInfoError:
+      case PurchasesErrorCode.systemInfoError:
+      case PurchasesErrorCode.beginRefundRequestError:
+      case PurchasesErrorCode.productRequestTimeout:
+      case PurchasesErrorCode.apiEndpointBlocked:
+      case PurchasesErrorCode.invalidPromotionalOfferError:
+      case PurchasesErrorCode.offlineConnectionError:
         break;
     }
   }

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -367,4 +367,29 @@ class _PurchasesFlutterApiTest {
     String storedProductIdentifier = purchaseResult.productIdentifier;
     CustomerInfo storedCustomerInfo = purchaseResult.customerInfo;
   }
+
+  void _checkRefundRequestStatus(RefundRequestStatus status) {
+    switch(status) {
+      case RefundRequestStatus.success:
+      case RefundRequestStatus.userCancelled:
+      case RefundRequestStatus.error:
+        break;
+    }
+    int statusCode = 0;
+    RefundRequestStatus processedStatus = RefundRequestStatusExtension.from(statusCode);
+  }
+
+  void _checkBeginRefundRequestForActiveEntitlement() async {
+    RefundRequestStatus status = await Purchases.beginRefundRequestForActiveEntitlement();
+  }
+
+  void _checkBeginRefundRequestForProduct(StoreProduct product) async {
+    RefundRequestStatus status = await Purchases.beginRefundRequestForProduct(product);
+  }
+
+  void _checkBeginRefundRequestForEntitlement(EntitlementInfo entitlement) async {
+    RefundRequestStatus status = await Purchases.beginRefundRequestForEntitlement(
+      entitlement
+    );
+  }
 }

--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -168,6 +168,14 @@ NSString *PurchasesReadyForPromotedProductPurchaseEvent = @"Purchases-ReadyForPr
     } else if ([@"canMakePayments" isEqualToString:call.method]) {
           NSArray<NSNumber*> *features = arguments[@"features"];
           [self canMakePaymentsWithFeatures:features result:result];
+    } else if ([@"beginRefundRequestForActiveEntitlement" isEqualToString:call.method]) {
+        [self beginRefundRequestForActiveEntitlementWithResult:result];
+    } else if ([@"beginRefundRequestForProduct" isEqualToString:call.method]) {
+        NSString *productID = arguments[@"productIdentifier"];
+        [self beginRefundRequestForProduct:productID result:result];
+    } else if ([@"beginRefundRequestForEntitlement" isEqualToString:call.method]) {
+        NSString *entitlementID = arguments[@"entitlementIdentifier"];
+        [self beginRefundRequestForEntitlement:entitlementID result:result];
     } else if ([@"getPromotionalOffer" isEqualToString:call.method]) {
         NSString *productIdentifier = arguments[@"productIdentifier"];
         NSString *discountIdentifier = arguments[@"discountIdentifier"];
@@ -473,6 +481,32 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
                                                 }];
 }
 
+- (void)beginRefundRequestForActiveEntitlementWithResult:(FlutterResult)result {
+    if (@available(iOS 15, *)) {
+        [RCCommonFunctionality beginRefundRequestForActiveEntitlementCompletion:[self getBeginRefundResponseCompletionBlock:result]];
+    } else {
+        result(nil);
+    }
+}
+
+- (void)beginRefundRequestForProduct:(NSString *)productIdentifier result:(FlutterResult)result {
+    if (@available(iOS 15, *)) {
+        [RCCommonFunctionality beginRefundRequestProductId:productIdentifier
+                                           completionBlock:[self getBeginRefundResponseCompletionBlock:result]];
+    } else {
+        result(nil);
+    }
+}
+
+- (void)beginRefundRequestForEntitlement:(NSString *)entitlementIdentifier result:(FlutterResult)result {
+    if (@available(iOS 15, *)) {
+        [RCCommonFunctionality beginRefundRequestEntitlementId:entitlementIdentifier
+                                               completionBlock:[self getBeginRefundResponseCompletionBlock:result]];
+    } else {
+        result(nil);
+    }
+}
+
 - (void)startPromotedProductPurchase:(NSNumber *)callbackID
                               result:(FlutterResult)result {
     RCStartPurchaseBlock makePurchaseBlock = [self.startPurchaseBlocks objectAtIndex:[callbackID integerValue]];
@@ -526,11 +560,23 @@ readyForPromotedProduct:(RCStoreProduct *)product
     };
 }
 
+- (void (^)(RCErrorContainer *))getBeginRefundResponseCompletionBlock:(FlutterResult)result {
+    return ^(RCErrorContainer * _Nullable error) {
+        if (error == nil) {
+            result(@0);
+        } else if ([error.info[@"userCancelled"] isEqual: @YES]) {
+            result(@1);
+        } else {
+            [self rejectWithResult:result error:error];
+        }
+    };
+}
+
 - (NSString *)platformFlavor {
     return @"flutter";
 }
 
-- (NSString *)platformFlavorVersion { 
+- (NSString *)platformFlavorVersion {
     return @"4.7.0-SNAPSHOT";
 }
 

--- a/lib/errors.dart
+++ b/lib/errors.dart
@@ -80,6 +80,39 @@ enum PurchasesErrorCode {
   /// There was a problem with the operation. Looks like we doesn't support that yet.
   /// Check the underlying error for more details.
   unsupportedError,
+
+  /// A request for subscriber attributes returned none.
+  emptySubscriberAttributesError,
+
+  /// The SKProductDiscount or Product.SubscriptionOffer wrapped
+  /// by StoreProductDiscount is missing an identifier.
+  /// This is a required property and likely an AppStore quirk that it is missing.
+  productDiscountMissingIdentifierError,
+
+  /// Unable to create a discount offer, the product is missing a subscriptionGroupIdentifier.
+  productDiscountMissingSubscriptionGroupIdentifierError,
+
+  /// There was a problem related to the customer info.
+  customerInfoError,
+
+  /// There was a problem related to the system info.
+  systemInfoError,
+
+  /// Error when trying to begin refund request.
+  beginRefundRequestError,
+
+  /// SKProductsRequest took too long to complete.
+  productRequestTimeout,
+
+  /// Requests to RevenueCat are being blocked. See: https://rev.cat/dnsBlocking for more info.
+  apiEndpointBlocked,
+
+  /// The information associated with this PromotionalOffer is not valid.
+  /// See https://rev.cat/ios-subscription-offers for more info.
+  invalidPromotionalOfferError,
+
+  /// Error performing request because the internet connection appears to be offline.
+  offlineConnectionError
 }
 
 /// Helper to convert from PlatformExceptions to PurchasesErrorCodes

--- a/revenuecat_examples/purchase_tester/lib/src/app.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/app.dart
@@ -202,8 +202,29 @@ class CatsScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) => Scaffold(
         appBar: AppBar(title: const Text('Cats Screen')),
-        body: const Center(
-          child: Text('User is pro'),
+        body: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text('User is pro'),
+              ElevatedButton(
+                onPressed: () async {
+                  try {
+                    final customerInfo = await Purchases.getCustomerInfo();
+                    final refundStatus = await Purchases
+                        .beginRefundRequestForEntitlement(
+                          customerInfo.entitlements.active['pro_cat']
+                        );
+                    print('Refund request successful with status: $refundStatus');
+                  } catch (e) {
+                    print('Refund request exception: $e');
+                  }
+                  return const InitialScreen();
+                },
+                child: const Text('Begin refund for pro_cat entitlement'),
+              ),
+            ],
+          )
         ),
       );
 }

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -197,6 +197,17 @@ void main() {
     expect(PurchasesErrorCode.logOutWithAnonymousUserError.index, 22);
     expect(PurchasesErrorCode.configurationError.index, 23);
     expect(PurchasesErrorCode.unsupportedError.index, 24);
+    expect(PurchasesErrorCode.emptySubscriberAttributesError.index, 25);
+    expect(PurchasesErrorCode.productDiscountMissingIdentifierError.index, 26);
+    expect(PurchasesErrorCode.productDiscountMissingSubscriptionGroupIdentifierError.index, 27);
+    expect(PurchasesErrorCode.customerInfoError.index, 28);
+    expect(PurchasesErrorCode.systemInfoError.index, 29);
+    expect(PurchasesErrorCode.beginRefundRequestError.index, 30);
+    expect(PurchasesErrorCode.productRequestTimeout.index, 31);
+    expect(PurchasesErrorCode.apiEndpointBlocked.index, 32);
+    expect(PurchasesErrorCode.invalidPromotionalOfferError.index, 33);
+    expect(PurchasesErrorCode.offlineConnectionError.index, 34);
+
   });
 
   test('PurchasesErrorHelper maps errors correctly', () {
@@ -302,6 +313,46 @@ void main() {
     );
     expect(
       PurchasesErrorHelper.getErrorCode(PlatformException(code: '25')),
+      PurchasesErrorCode.emptySubscriberAttributesError,
+    );
+    expect(
+      PurchasesErrorHelper.getErrorCode(PlatformException(code: '26')),
+      PurchasesErrorCode.productDiscountMissingIdentifierError,
+    );
+    expect(
+      PurchasesErrorHelper.getErrorCode(PlatformException(code: '27')),
+      PurchasesErrorCode.productDiscountMissingSubscriptionGroupIdentifierError,
+    );
+    expect(
+      PurchasesErrorHelper.getErrorCode(PlatformException(code: '28')),
+      PurchasesErrorCode.customerInfoError,
+    );
+    expect(
+      PurchasesErrorHelper.getErrorCode(PlatformException(code: '29')),
+      PurchasesErrorCode.systemInfoError,
+    );
+    expect(
+      PurchasesErrorHelper.getErrorCode(PlatformException(code: '30')),
+      PurchasesErrorCode.beginRefundRequestError,
+    );
+    expect(
+      PurchasesErrorHelper.getErrorCode(PlatformException(code: '31')),
+      PurchasesErrorCode.productRequestTimeout,
+    );
+    expect(
+      PurchasesErrorHelper.getErrorCode(PlatformException(code: '32')),
+      PurchasesErrorCode.apiEndpointBlocked,
+    );
+    expect(
+      PurchasesErrorHelper.getErrorCode(PlatformException(code: '33')),
+      PurchasesErrorCode.invalidPromotionalOfferError,
+    );
+    expect(
+      PurchasesErrorHelper.getErrorCode(PlatformException(code: '34')),
+      PurchasesErrorCode.offlineConnectionError,
+    );
+    expect(
+      PurchasesErrorHelper.getErrorCode(PlatformException(code: '35')),
       PurchasesErrorCode.unknownError,
     );
   });
@@ -532,5 +583,112 @@ void main() {
         )
       ],
     );
+  });
+
+  test('beginRefundRequestForActiveEntitlement calls channel correctly for success', () async {
+    response = 0; // Success code
+    final refundRequestStatus = await Purchases.beginRefundRequestForActiveEntitlement();
+
+    expect(refundRequestStatus, RefundRequestStatus.success);
+    expect(log, <Matcher>[
+      isMethodCall(
+        'beginRefundRequestForActiveEntitlement',
+        arguments: null,
+      )
+    ]);
+  });
+
+  test('beginRefundRequestForActiveEntitlement calls channel correctly for user cancelled', () async {
+    response = 1; // User cancelled code
+    final refundRequestStatus = await Purchases.beginRefundRequestForActiveEntitlement();
+
+    expect(refundRequestStatus, RefundRequestStatus.userCancelled);
+    expect(log, <Matcher>[
+      isMethodCall(
+        'beginRefundRequestForActiveEntitlement',
+        arguments: null,
+      )
+    ]);
+  });
+
+  test('beginRefundRequestForActiveEntitlement calls channel correctly for error', () async {
+    response = 2; // Error code
+    final refundRequestStatus = await Purchases.beginRefundRequestForActiveEntitlement();
+
+    expect(refundRequestStatus, RefundRequestStatus.error);
+    expect(log, <Matcher>[
+      isMethodCall(
+        'beginRefundRequestForActiveEntitlement',
+        arguments: null,
+      )
+    ]);
+  });
+
+  test('beginRefundRequestForActiveEntitlement throws UnsupportedPlatformException', () async {
+    response = null;
+    try {
+      await Purchases.beginRefundRequestForActiveEntitlement();
+      fail('Should have thrown an exception');
+    } on UnsupportedPlatformException {
+      // Success
+    }
+  });
+
+  test('beginRefundRequestForProduct calls channel correctly', () async {
+    response = 0; // Success
+
+    const mockStoreProduct = StoreProduct(
+      'com.revenuecat.lifetime',
+      'description',
+      'lifetime (PurchasesSample)',
+      199.99,
+      '\$199.99',
+      'USD',
+    );
+
+    final refundRequestStatus = await Purchases.beginRefundRequestForProduct(mockStoreProduct);
+
+    expect(refundRequestStatus, RefundRequestStatus.success);
+    expect(log, <Matcher>[
+      isMethodCall(
+        'beginRefundRequestForProduct',
+        arguments: {'productIdentifier': 'com.revenuecat.lifetime'},
+      )
+    ]);
+  });
+
+    test('beginRefundRequestForEntitlement calls channel correctly', () async {
+    response = 0; // Success
+
+    final entitlementInfoJson = {
+        'identifier': 'almost_pro',
+        'isActive': true,
+        'willRenew': true,
+        'periodType': 'NORMAL',
+        'latestPurchaseDateMillis': 1.58759855E9,
+        'latestPurchaseDate': '2020-04-22T23:35:50.000Z',
+        'originalPurchaseDateMillis': 1.591725245E9,
+        'originalPurchaseDate': '2020-06-09T17:54:05.000Z',
+        'expirationDateMillis': null,
+        'expirationDate': null,
+        'productIdentifier': 'consumable',
+        'isSandbox': true,
+        'unsubscribeDetectedAt': null,
+        'unsubscribeDetectedAtMillis': null,
+        'billingIssueDetectedAt': null,
+        'billingIssueDetectedAtMillis': null,
+        'store': Store.appStore
+      };
+    final entitlementInfo = EntitlementInfo.fromJson(entitlementInfoJson);
+
+    final refundRequestStatus = await Purchases.beginRefundRequestForEntitlement(entitlementInfo);
+
+    expect(refundRequestStatus, RefundRequestStatus.success);
+    expect(log, <Matcher>[
+      isMethodCall(
+        'beginRefundRequestForEntitlement',
+        arguments: {'entitlementIdentifier': 'almost_pro'},
+      )
+    ]);
   });
 }


### PR DESCRIPTION
Adds [CSDK-94](https://revenuecats.atlassian.net/browse/CSDK-94)

This PR adds 3 new methods to the flutter API that will only be available in iOS 15+.
- `beginRefundRequestForActiveEntitlement`
- `beginRefundRequestForProduct`
- `beginRefundRequestForEntitlement`
In Android/iOS < 15, we will throw an `UnsupportedPlatformException`.

In this PR, I'm also updating the error codes to match the latest in PHC.

This PR is partially based on the work on https://github.com/RevenueCat/purchases-flutter/pull/360

[CSDK-94]: https://revenuecats.atlassian.net/browse/CSDK-94?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ