### PR TITLE
Added `Purchases.setLogLevel`

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -179,6 +179,10 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 boolean enabled = call.argument("enabled") != null && (boolean) call.argument("enabled");
                 setDebugLogsEnabled(enabled, result);
                 break;
+            case "setLogLevel":
+                String level = (String) call.argument("level");
+                setLogLevel(level, result);
+                break;
             case "setProxyURLString":
                 String proxyURLString = call.argument("proxyURLString");
                 setProxyURLString(proxyURLString, result);
@@ -433,6 +437,11 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
 
     private void setDebugLogsEnabled(boolean enabled, final Result result) {
         CommonKt.setDebugLogsEnabled(enabled);
+        result.success(null);
+    }
+
+    private void setLogLevel(String level, final Result result) {
+        CommonKt.setLogLevel(level);
         result.success(null);
     }
 

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -121,6 +121,23 @@ class _PurchasesFlutterApiTest {
         Purchases.setDebugLogsEnabled(setDebugLogsEnabled);
   }
 
+  void _checkSetLogLevel() {
+    LogLevel logLevel = LogLevel.debug;
+    Future<void> setLogLevelFuture =
+        Purchases.setLogLevel(logLevel);
+  }
+
+  void _checkLogLevels(LogLevel level) {
+    switch (level) {
+      case LogLevel.verbose:
+      case LogLevel.debug:
+      case LogLevel.info:
+      case LogLevel.warn:
+      case LogLevel.error:
+        break;
+    }
+  }
+
   void _checkSetSimulatesAskToBuyInSandbox() {
     bool setSimulatesAskToBuyInSandbox = false;
     Future<void> future =

--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -81,6 +81,8 @@ NSString *PurchasesReadyForPromotedProductPurchaseEvent = @"Purchases-ReadyForPr
         [self logInAppUserID:arguments[@"appUserID"] result:result];
     } else if ([@"setDebugLogsEnabled" isEqualToString:call.method]) {
         [self setDebugLogsEnabled:[arguments[@"enabled"] boolValue] result:result];
+    } else if ([@"setLogLevel" isEqualToString:call.method]) {
+        [self setLogLevel:arguments[@"level"] result:result];
     } else if ([@"setSimulatesAskToBuyInSandbox" isEqualToString:call.method]) {
         [self setSimulatesAskToBuyInSandbox:[arguments[@"enabled"] boolValue] result:result];
     } else if ([@"setProxyURLString" isEqualToString:call.method]) {
@@ -299,6 +301,12 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
 - (void)setDebugLogsEnabled:(BOOL)enabled
                      result:(FlutterResult)result {
     [RCCommonFunctionality setDebugLogsEnabled:enabled];
+    result(nil);
+}
+
+- (void)setLogLevel:(NSString *)level
+             result:(FlutterResult)result {
+    [RCCommonFunctionality setLogLevel:level];
     result(nil);
 }
 

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -389,8 +389,15 @@ class Purchases {
   }
 
   /// Enables/Disables debugs logs
+  @Deprecated('Use setLogLevel')
   static Future<void> setDebugLogsEnabled(bool enabled) =>
       _channel.invokeMethod('setDebugLogsEnabled', {'enabled': enabled});
+
+  /// Configures log level
+  /// Used to set the log level. Useful for debugging issues with the lovely team @RevenueCat.
+  /// The default is {LOG_LEVEL.INFO} in release builds and {LOG_LEVEL.DEBUG} in debug builds.
+  static Future<void> setLogLevel(LogLevel level) =>
+      _channel.invokeMethod('setLogLevel', {'level': level.name.toUpperCase()});
 
   ///
   /// iOS only. Set this property to true *only* when testing the ask-to-buy / SCA purchases flow.
@@ -920,6 +927,15 @@ enum RefundRequestStatus {
   success,
 
   /// There was an error with the request. See message for more details.
+  error
+}
+
+/// Log levels.
+enum LogLevel {
+  verbose,
+  debug,
+  info,
+  warn,
   error
 }
 

--- a/revenuecat_examples/MagicWeather/lib/src/views/home.dart
+++ b/revenuecat_examples/MagicWeather/lib/src/views/home.dart
@@ -30,7 +30,7 @@ class AppContainerState extends State<AppContainer> {
 
   Future<void> initPlatformState() async {
     // Enable debug logs before calling `configure`.
-    await Purchases.setDebugLogsEnabled(true);
+    await Purchases.setLogLevel(LogLevel.DEBUG);
 
     /*
     - appUserID is nil, so an anonymous ID will be generated automatically by the Purchases SDK. Read more about Identifying Users here: https://docs.revenuecat.com/docs/user-ids

--- a/revenuecat_examples/purchase_tester/lib/src/app.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/app.dart
@@ -38,7 +38,7 @@ class _MyAppState extends State<InitialScreen> {
 
   // Platform messages are asynchronous, so we initialize in an async method.
   Future<void> initPlatformState() async {
-    await Purchases.setDebugLogsEnabled(true);
+    await Purchases.setLogLevel(LogLevel.debug);
 
     PurchasesConfiguration configuration;
     if (StoreConfig.isForAmazonAppstore()) {


### PR DESCRIPTION
Fixes [CSDK-607].
Depends on https://github.com/RevenueCat/purchases-android/pull/753 and https://github.com/RevenueCat/purchases-hybrid-common/pull/301


[CSDK-607]: https://revenuecats.atlassian.net/browse/CSDK-607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ