### PR TITLE
Sends PurchasesCustomerInfoUpdatedEvent and PurchasesReadyForPromotedProductPurchaseEvent on UiThread

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -350,7 +350,8 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
     private void setUpdatedCustomerInfoListener() {
         Purchases.getSharedInstance().setUpdatedCustomerInfoListener(customerInfo -> {
             if (channel != null) {
-                channel.invokeMethod(CUSTOMER_INFO_UPDATED, CustomerInfoMapperKt.map(customerInfo));
+                Map<String, Object> customerInfoMap = CustomerInfoMapperKt.map(customerInfo);
+                runOnUiThread(() -> channel.invokeMethod(CUSTOMER_INFO_UPDATED, customerInfoMap));
             }
         });
     }

--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -557,8 +557,10 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
 #pragma mark Delegate Methods
 
 - (void)purchases:(RCPurchases *)purchases receivedUpdatedCustomerInfo:(RCCustomerInfo *)customerInfo {
-    [self.channel invokeMethod:PurchasesCustomerInfoUpdatedEvent
-                     arguments:customerInfo.dictionary];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.channel invokeMethod:PurchasesCustomerInfoUpdatedEvent
+                         arguments:customerInfo.dictionary];
+    });
 }
 
 - (void)      purchases:(RCPurchases *)purchases
@@ -570,10 +572,12 @@ readyForPromotedProduct:(RCStoreProduct *)product
 
     [self.startPurchaseBlocks addObject:startPurchase];
     NSInteger position = [self.startPurchaseBlocks count] - 1;
-    [self.channel invokeMethod:PurchasesReadyForPromotedProductPurchaseEvent
-                     arguments:@{@"callbackID": @(position),
-                                 @"productID": product.productIdentifier
-                               }];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.channel invokeMethod:PurchasesReadyForPromotedProductPurchaseEvent
+                         arguments:@{@"callbackID": @(position),
+                                     @"productID": product.productIdentifier
+                                   }];
+    });
 }
 
 #pragma mark -


### PR DESCRIPTION
Follow up on #591 changing PurchasesCustomerInfoUpdatedEvent and PurchasesReadyForPromotedProductPurchaseEvent to be sent on the UiThread.

Calling invokeMethod not on the UiThread will throw an exception. I've only seen it when sending logs, but we should make sure the other methods are invoked in the UiThread too