### PR TITLE
Deprecate revenueCatId in favor of transactionIdentifier

### DIFF
--- a/api_tester/lib/api_tests/models/store_transaction_api_test.dart
+++ b/api_tester/lib/api_tests/models/store_transaction_api_test.dart
@@ -12,11 +12,13 @@ class _StoreTransactionApiTest {
     Map<String, dynamic> json = transaction.toJson();
   }
 
-  void _checkConstructor(String transactionIdentifier, String revenueCatIdentifier, 
-      String productIdentifier, String purchaseDate) {
+  void _checkConstructor(
+      String transactionIdentifier,
+      String revenueCatIdentifier,
+      String productIdentifier,
+      String purchaseDate) {
     StoreTransaction transaction =
-        StoreTransaction(transactionIdentifier, revenueCatIdentifier, 
-            productIdentifier, purchaseDate);
+        StoreTransaction(revenueCatIdentifier, productIdentifier, purchaseDate);
   }
 
   void _checkProperties(StoreTransaction transaction) {

--- a/api_tester/lib/api_tests/models/store_transaction_api_test.dart
+++ b/api_tester/lib/api_tests/models/store_transaction_api_test.dart
@@ -11,10 +11,11 @@ class _StoreTransactionApiTest {
     Map<String, dynamic> json = transaction.toJson();
   }
 
-  void _checkConstructor(String revenueCatIdentifier, String productIdentifier,
-      String purchaseDate) {
+  void _checkConstructor(String transactionIdentifier, String revenueCatIdentifier, 
+      String productIdentifier, String purchaseDate) {
     StoreTransaction transaction =
-        StoreTransaction(revenueCatIdentifier, productIdentifier, purchaseDate);
+        StoreTransaction(transactionIdentifier, revenueCatIdentifier, 
+            productIdentifier, purchaseDate);
   }
 
   void _checkProperties(StoreTransaction transaction) {

--- a/api_tester/lib/api_tests/models/store_transaction_api_test.dart
+++ b/api_tester/lib/api_tests/models/store_transaction_api_test.dart
@@ -2,6 +2,7 @@ import 'package:purchases_flutter/object_wrappers.dart';
 
 // ignore_for_file: unused_element
 // ignore_for_file: unused_local_variable
+// ignore_for_file: deprecated_member_use
 class _StoreTransactionApiTest {
   void _checkFromJsonFactory(Map<String, dynamic> json) {
     StoreTransaction transaction = StoreTransaction.fromJson(json);

--- a/api_tester/lib/api_tests/models/store_transaction_api_test.dart
+++ b/api_tester/lib/api_tests/models/store_transaction_api_test.dart
@@ -18,6 +18,7 @@ class _StoreTransactionApiTest {
   }
 
   void _checkProperties(StoreTransaction transaction) {
+    String transactionIdentifier = transaction.transactionIdentifier;
     String revenueCatIdentifier = transaction.revenueCatIdentifier;
     String productIdentifier = transaction.productIdentifier;
     String purchaseDate = transaction.purchaseDate;

--- a/api_tester/lib/api_tests/models/store_transaction_api_test.dart
+++ b/api_tester/lib/api_tests/models/store_transaction_api_test.dart
@@ -19,6 +19,13 @@ class _StoreTransactionApiTest {
       String purchaseDate) {
     StoreTransaction transaction =
         StoreTransaction(revenueCatIdentifier, productIdentifier, purchaseDate);
+    StoreTransaction transaction2 =
+        StoreTransaction.create(
+            transactionIdentifier,
+            revenueCatIdentifier,
+            productIdentifier,
+            purchaseDate
+        );
   }
 
   void _checkProperties(StoreTransaction transaction) {

--- a/lib/models/store_transaction.dart
+++ b/lib/models/store_transaction.dart
@@ -7,13 +7,15 @@ part 'store_transaction.g.dart';
 
 /// Represents a purchase transaction
 class StoreTransaction with _$StoreTransaction {
-  const factory StoreTransaction._create(
+  /// Experimental. This factory method is subject to changes without
+  /// a major release.
+  const factory StoreTransaction.create(
     /// RevenueCat Id associated to the transaction.
     @JsonKey(name: 'transactionIdentifier') String transactionIdentifier,
 
     /// Deprecated: Use transactionIdentifier instead.
     @Deprecated('Use transactionIdentifier instead.')
-    @JsonKey(name: 'revenueCatId')
+    @JsonKey(readValue: _readRevenueCatIdentifier)
         String revenueCatIdentifier,
 
     /// Product Id associated with the transaction.
@@ -23,7 +25,8 @@ class StoreTransaction with _$StoreTransaction {
     @JsonKey(name: 'purchaseDate') String purchaseDate,
   ) = _StoreTransaction;
 
-  @Deprecated('Constructor has become private. Avoid using constructor')
+  @Deprecated('Constructor has become experimental. Keeping old constructor '
+      'for backwards compatibility.')
   factory StoreTransaction(
     /// Deprecated: Use transactionIdentifier instead.
     @Deprecated('Use transactionIdentifier instead.')
@@ -35,7 +38,7 @@ class StoreTransaction with _$StoreTransaction {
     /// Purchase date of the transaction in ISO 8601 format.
     String purchaseDate,
   ) =>
-      StoreTransaction._create(
+      StoreTransaction.create(
         revenueCatIdentifier,
         revenueCatIdentifier,
         productIdentifier,
@@ -45,3 +48,6 @@ class StoreTransaction with _$StoreTransaction {
   factory StoreTransaction.fromJson(Map<String, dynamic> json) =>
       _$StoreTransactionFromJson(json);
 }
+
+Object? _readRevenueCatIdentifier(Map json, String key) =>
+    json['transactionIdentifier'];

--- a/lib/models/store_transaction.dart
+++ b/lib/models/store_transaction.dart
@@ -23,18 +23,17 @@ class StoreTransaction with _$StoreTransaction {
     @JsonKey(name: 'purchaseDate') String purchaseDate,
   ) = _StoreTransaction;
 
-  /// Deprecated: Constructor has become private.
+  @Deprecated('Constructor has become private. Avoid using constructor')
   factory StoreTransaction(
     /// Deprecated: Use transactionIdentifier instead.
     @Deprecated('Use transactionIdentifier instead.')
-    @JsonKey(name: 'revenueCatId')
         String revenueCatIdentifier,
 
     /// Product Id associated with the transaction.
-    @JsonKey(name: 'productIdentifier') String productIdentifier,
+    String productIdentifier,
 
     /// Purchase date of the transaction in ISO 8601 format.
-    @JsonKey(name: 'purchaseDate') String purchaseDate,
+    String purchaseDate,
   ) =>
       StoreTransaction._create(
         revenueCatIdentifier,

--- a/lib/models/store_transaction.dart
+++ b/lib/models/store_transaction.dart
@@ -7,13 +7,14 @@ part 'store_transaction.g.dart';
 
 /// Represents a purchase transaction
 class StoreTransaction with _$StoreTransaction {
-  const factory StoreTransaction(
+  const factory StoreTransaction._create(
     /// RevenueCat Id associated to the transaction.
     @JsonKey(name: 'transactionIdentifier') String transactionIdentifier,
 
     /// Deprecated: Use transactionIdentifier instead.
     @Deprecated('Use transactionIdentifier instead.')
-    @JsonKey(name: 'revenueCatId') String revenueCatIdentifier,
+    @JsonKey(name: 'revenueCatId')
+        String revenueCatIdentifier,
 
     /// Product Id associated with the transaction.
     @JsonKey(name: 'productIdentifier') String productIdentifier,
@@ -21,6 +22,26 @@ class StoreTransaction with _$StoreTransaction {
     /// Purchase date of the transaction in ISO 8601 format.
     @JsonKey(name: 'purchaseDate') String purchaseDate,
   ) = _StoreTransaction;
+
+  /// Deprecated: Constructor has become private.
+  factory StoreTransaction(
+    /// Deprecated: Use transactionIdentifier instead.
+    @Deprecated('Use transactionIdentifier instead.')
+    @JsonKey(name: 'revenueCatId')
+        String revenueCatIdentifier,
+
+    /// Product Id associated with the transaction.
+    @JsonKey(name: 'productIdentifier') String productIdentifier,
+
+    /// Purchase date of the transaction in ISO 8601 format.
+    @JsonKey(name: 'purchaseDate') String purchaseDate,
+  ) =>
+      StoreTransaction._create(
+        revenueCatIdentifier,
+        revenueCatIdentifier,
+        productIdentifier,
+        purchaseDate,
+      );
 
   factory StoreTransaction.fromJson(Map<String, dynamic> json) =>
       _$StoreTransactionFromJson(json);

--- a/lib/models/store_transaction.dart
+++ b/lib/models/store_transaction.dart
@@ -9,10 +9,14 @@ part 'store_transaction.g.dart';
 class StoreTransaction with _$StoreTransaction {
   const factory StoreTransaction(
     /// RevenueCat Id associated to the transaction.
+    @JsonKey(name: 'transactionIdentifier') String transactionIdentifier,
+
+    /// Deprecated: Use transactionIdentifier instead.
+    @Deprecated('Use transactionIdentifier instead.')
     @JsonKey(name: 'revenueCatId') String revenueCatIdentifier,
 
     /// Product Id associated with the transaction.
-    @JsonKey(name: 'productId') String productIdentifier,
+    @JsonKey(name: 'productIdentifier') String productIdentifier,
 
     /// Purchase date of the transaction in ISO 8601 format.
     @JsonKey(name: 'purchaseDate') String purchaseDate,

--- a/lib/models/store_transaction.freezed.dart
+++ b/lib/models/store_transaction.freezed.dart
@@ -26,7 +26,7 @@ mixin _$StoreTransaction {
 
   /// Deprecated: Use transactionIdentifier instead.
   @Deprecated('Use transactionIdentifier instead.')
-  @JsonKey(name: 'revenueCatId')
+  @JsonKey(readValue: _readRevenueCatIdentifier)
   String get revenueCatIdentifier => throw _privateConstructorUsedError;
 
   /// Product Id associated with the transaction.
@@ -36,7 +36,68 @@ mixin _$StoreTransaction {
   /// Purchase date of the transaction in ISO 8601 format.
   @JsonKey(name: 'purchaseDate')
   String get purchaseDate => throw _privateConstructorUsedError;
-
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(
+            @JsonKey(name: 'transactionIdentifier')
+                String transactionIdentifier,
+            @Deprecated('Use transactionIdentifier instead.')
+            @JsonKey(readValue: _readRevenueCatIdentifier)
+                String revenueCatIdentifier,
+            @JsonKey(name: 'productIdentifier')
+                String productIdentifier,
+            @JsonKey(name: 'purchaseDate')
+                String purchaseDate)
+        create,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(
+            @JsonKey(name: 'transactionIdentifier')
+                String transactionIdentifier,
+            @Deprecated('Use transactionIdentifier instead.')
+            @JsonKey(readValue: _readRevenueCatIdentifier)
+                String revenueCatIdentifier,
+            @JsonKey(name: 'productIdentifier')
+                String productIdentifier,
+            @JsonKey(name: 'purchaseDate')
+                String purchaseDate)?
+        create,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(
+            @JsonKey(name: 'transactionIdentifier')
+                String transactionIdentifier,
+            @Deprecated('Use transactionIdentifier instead.')
+            @JsonKey(readValue: _readRevenueCatIdentifier)
+                String revenueCatIdentifier,
+            @JsonKey(name: 'productIdentifier')
+                String productIdentifier,
+            @JsonKey(name: 'purchaseDate')
+                String purchaseDate)?
+        create,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_StoreTransaction value) create,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_StoreTransaction value)? create,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_StoreTransaction value)? create,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
   $StoreTransactionCopyWith<StoreTransaction> get copyWith =>
@@ -53,7 +114,7 @@ abstract class $StoreTransactionCopyWith<$Res> {
       {@JsonKey(name: 'transactionIdentifier')
           String transactionIdentifier,
       @Deprecated('Use transactionIdentifier instead.')
-      @JsonKey(name: 'revenueCatId')
+      @JsonKey(readValue: _readRevenueCatIdentifier)
           String revenueCatIdentifier,
       @JsonKey(name: 'productIdentifier')
           String productIdentifier,
@@ -112,7 +173,7 @@ abstract class _$$_StoreTransactionCopyWith<$Res>
       {@JsonKey(name: 'transactionIdentifier')
           String transactionIdentifier,
       @Deprecated('Use transactionIdentifier instead.')
-      @JsonKey(name: 'revenueCatId')
+      @JsonKey(readValue: _readRevenueCatIdentifier)
           String revenueCatIdentifier,
       @JsonKey(name: 'productIdentifier')
           String productIdentifier,
@@ -164,7 +225,7 @@ class _$_StoreTransaction implements _StoreTransaction {
       @JsonKey(name: 'transactionIdentifier')
           this.transactionIdentifier,
       @Deprecated('Use transactionIdentifier instead.')
-      @JsonKey(name: 'revenueCatId')
+      @JsonKey(readValue: _readRevenueCatIdentifier)
           this.revenueCatIdentifier,
       @JsonKey(name: 'productIdentifier')
           this.productIdentifier,
@@ -182,7 +243,7 @@ class _$_StoreTransaction implements _StoreTransaction {
   /// Deprecated: Use transactionIdentifier instead.
   @override
   @Deprecated('Use transactionIdentifier instead.')
-  @JsonKey(name: 'revenueCatId')
+  @JsonKey(readValue: _readRevenueCatIdentifier)
   final String revenueCatIdentifier;
 
   /// Product Id associated with the transaction.
@@ -197,7 +258,7 @@ class _$_StoreTransaction implements _StoreTransaction {
 
   @override
   String toString() {
-    return 'StoreTransaction._create(transactionIdentifier: $transactionIdentifier, revenueCatIdentifier: $revenueCatIdentifier, productIdentifier: $productIdentifier, purchaseDate: $purchaseDate)';
+    return 'StoreTransaction.create(transactionIdentifier: $transactionIdentifier, revenueCatIdentifier: $revenueCatIdentifier, productIdentifier: $productIdentifier, purchaseDate: $purchaseDate)';
   }
 
   @override
@@ -227,6 +288,95 @@ class _$_StoreTransaction implements _StoreTransaction {
       __$$_StoreTransactionCopyWithImpl<_$_StoreTransaction>(this, _$identity);
 
   @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(
+            @JsonKey(name: 'transactionIdentifier')
+                String transactionIdentifier,
+            @Deprecated('Use transactionIdentifier instead.')
+            @JsonKey(readValue: _readRevenueCatIdentifier)
+                String revenueCatIdentifier,
+            @JsonKey(name: 'productIdentifier')
+                String productIdentifier,
+            @JsonKey(name: 'purchaseDate')
+                String purchaseDate)
+        create,
+  }) {
+    return create(transactionIdentifier, revenueCatIdentifier,
+        productIdentifier, purchaseDate);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(
+            @JsonKey(name: 'transactionIdentifier')
+                String transactionIdentifier,
+            @Deprecated('Use transactionIdentifier instead.')
+            @JsonKey(readValue: _readRevenueCatIdentifier)
+                String revenueCatIdentifier,
+            @JsonKey(name: 'productIdentifier')
+                String productIdentifier,
+            @JsonKey(name: 'purchaseDate')
+                String purchaseDate)?
+        create,
+  }) {
+    return create?.call(transactionIdentifier, revenueCatIdentifier,
+        productIdentifier, purchaseDate);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(
+            @JsonKey(name: 'transactionIdentifier')
+                String transactionIdentifier,
+            @Deprecated('Use transactionIdentifier instead.')
+            @JsonKey(readValue: _readRevenueCatIdentifier)
+                String revenueCatIdentifier,
+            @JsonKey(name: 'productIdentifier')
+                String productIdentifier,
+            @JsonKey(name: 'purchaseDate')
+                String purchaseDate)?
+        create,
+    required TResult orElse(),
+  }) {
+    if (create != null) {
+      return create(transactionIdentifier, revenueCatIdentifier,
+          productIdentifier, purchaseDate);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_StoreTransaction value) create,
+  }) {
+    return create(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_StoreTransaction value)? create,
+  }) {
+    return create?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_StoreTransaction value)? create,
+    required TResult orElse(),
+  }) {
+    if (create != null) {
+      return create(this);
+    }
+    return orElse();
+  }
+
+  @override
   Map<String, dynamic> toJson() {
     return _$$_StoreTransactionToJson(
       this,
@@ -239,7 +389,7 @@ abstract class _StoreTransaction implements StoreTransaction {
       @JsonKey(name: 'transactionIdentifier')
           final String transactionIdentifier,
       @Deprecated('Use transactionIdentifier instead.')
-      @JsonKey(name: 'revenueCatId')
+      @JsonKey(readValue: _readRevenueCatIdentifier)
           final String revenueCatIdentifier,
       @JsonKey(name: 'productIdentifier')
           final String productIdentifier,
@@ -258,7 +408,7 @@ abstract class _StoreTransaction implements StoreTransaction {
 
   /// Deprecated: Use transactionIdentifier instead.
   @Deprecated('Use transactionIdentifier instead.')
-  @JsonKey(name: 'revenueCatId')
+  @JsonKey(readValue: _readRevenueCatIdentifier)
   String get revenueCatIdentifier;
   @override
 

--- a/lib/models/store_transaction.freezed.dart
+++ b/lib/models/store_transaction.freezed.dart
@@ -21,11 +21,16 @@ StoreTransaction _$StoreTransactionFromJson(Map<String, dynamic> json) {
 /// @nodoc
 mixin _$StoreTransaction {
   /// RevenueCat Id associated to the transaction.
+  @JsonKey(name: 'transactionIdentifier')
+  String get transactionIdentifier => throw _privateConstructorUsedError;
+
+  /// Deprecated: Use transactionIdentifier instead.
+  @Deprecated('Use transactionIdentifier instead.')
   @JsonKey(name: 'revenueCatId')
   String get revenueCatIdentifier => throw _privateConstructorUsedError;
 
   /// Product Id associated with the transaction.
-  @JsonKey(name: 'productId')
+  @JsonKey(name: 'productIdentifier')
   String get productIdentifier => throw _privateConstructorUsedError;
 
   /// Purchase date of the transaction in ISO 8601 format.
@@ -45,9 +50,15 @@ abstract class $StoreTransactionCopyWith<$Res> {
       _$StoreTransactionCopyWithImpl<$Res, StoreTransaction>;
   @useResult
   $Res call(
-      {@JsonKey(name: 'revenueCatId') String revenueCatIdentifier,
-      @JsonKey(name: 'productId') String productIdentifier,
-      @JsonKey(name: 'purchaseDate') String purchaseDate});
+      {@JsonKey(name: 'transactionIdentifier')
+          String transactionIdentifier,
+      @Deprecated('Use transactionIdentifier instead.')
+      @JsonKey(name: 'revenueCatId')
+          String revenueCatIdentifier,
+      @JsonKey(name: 'productIdentifier')
+          String productIdentifier,
+      @JsonKey(name: 'purchaseDate')
+          String purchaseDate});
 }
 
 /// @nodoc
@@ -63,11 +74,16 @@ class _$StoreTransactionCopyWithImpl<$Res, $Val extends StoreTransaction>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+    Object? transactionIdentifier = null,
     Object? revenueCatIdentifier = null,
     Object? productIdentifier = null,
     Object? purchaseDate = null,
   }) {
     return _then(_value.copyWith(
+      transactionIdentifier: null == transactionIdentifier
+          ? _value.transactionIdentifier
+          : transactionIdentifier // ignore: cast_nullable_to_non_nullable
+              as String,
       revenueCatIdentifier: null == revenueCatIdentifier
           ? _value.revenueCatIdentifier
           : revenueCatIdentifier // ignore: cast_nullable_to_non_nullable
@@ -93,9 +109,15 @@ abstract class _$$_StoreTransactionCopyWith<$Res>
   @override
   @useResult
   $Res call(
-      {@JsonKey(name: 'revenueCatId') String revenueCatIdentifier,
-      @JsonKey(name: 'productId') String productIdentifier,
-      @JsonKey(name: 'purchaseDate') String purchaseDate});
+      {@JsonKey(name: 'transactionIdentifier')
+          String transactionIdentifier,
+      @Deprecated('Use transactionIdentifier instead.')
+      @JsonKey(name: 'revenueCatId')
+          String revenueCatIdentifier,
+      @JsonKey(name: 'productIdentifier')
+          String productIdentifier,
+      @JsonKey(name: 'purchaseDate')
+          String purchaseDate});
 }
 
 /// @nodoc
@@ -109,11 +131,16 @@ class __$$_StoreTransactionCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+    Object? transactionIdentifier = null,
     Object? revenueCatIdentifier = null,
     Object? productIdentifier = null,
     Object? purchaseDate = null,
   }) {
     return _then(_$_StoreTransaction(
+      null == transactionIdentifier
+          ? _value.transactionIdentifier
+          : transactionIdentifier // ignore: cast_nullable_to_non_nullable
+              as String,
       null == revenueCatIdentifier
           ? _value.revenueCatIdentifier
           : revenueCatIdentifier // ignore: cast_nullable_to_non_nullable
@@ -134,21 +161,33 @@ class __$$_StoreTransactionCopyWithImpl<$Res>
 @JsonSerializable()
 class _$_StoreTransaction implements _StoreTransaction {
   const _$_StoreTransaction(
-      @JsonKey(name: 'revenueCatId') this.revenueCatIdentifier,
-      @JsonKey(name: 'productId') this.productIdentifier,
-      @JsonKey(name: 'purchaseDate') this.purchaseDate);
+      @JsonKey(name: 'transactionIdentifier')
+          this.transactionIdentifier,
+      @Deprecated('Use transactionIdentifier instead.')
+      @JsonKey(name: 'revenueCatId')
+          this.revenueCatIdentifier,
+      @JsonKey(name: 'productIdentifier')
+          this.productIdentifier,
+      @JsonKey(name: 'purchaseDate')
+          this.purchaseDate);
 
   factory _$_StoreTransaction.fromJson(Map<String, dynamic> json) =>
       _$$_StoreTransactionFromJson(json);
 
   /// RevenueCat Id associated to the transaction.
   @override
+  @JsonKey(name: 'transactionIdentifier')
+  final String transactionIdentifier;
+
+  /// Deprecated: Use transactionIdentifier instead.
+  @override
+  @Deprecated('Use transactionIdentifier instead.')
   @JsonKey(name: 'revenueCatId')
   final String revenueCatIdentifier;
 
   /// Product Id associated with the transaction.
   @override
-  @JsonKey(name: 'productId')
+  @JsonKey(name: 'productIdentifier')
   final String productIdentifier;
 
   /// Purchase date of the transaction in ISO 8601 format.
@@ -158,7 +197,7 @@ class _$_StoreTransaction implements _StoreTransaction {
 
   @override
   String toString() {
-    return 'StoreTransaction(revenueCatIdentifier: $revenueCatIdentifier, productIdentifier: $productIdentifier, purchaseDate: $purchaseDate)';
+    return 'StoreTransaction(transactionIdentifier: $transactionIdentifier, revenueCatIdentifier: $revenueCatIdentifier, productIdentifier: $productIdentifier, purchaseDate: $purchaseDate)';
   }
 
   @override
@@ -166,6 +205,8 @@ class _$_StoreTransaction implements _StoreTransaction {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_StoreTransaction &&
+            (identical(other.transactionIdentifier, transactionIdentifier) ||
+                other.transactionIdentifier == transactionIdentifier) &&
             (identical(other.revenueCatIdentifier, revenueCatIdentifier) ||
                 other.revenueCatIdentifier == revenueCatIdentifier) &&
             (identical(other.productIdentifier, productIdentifier) ||
@@ -176,8 +217,8 @@ class _$_StoreTransaction implements _StoreTransaction {
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(
-      runtimeType, revenueCatIdentifier, productIdentifier, purchaseDate);
+  int get hashCode => Object.hash(runtimeType, transactionIdentifier,
+      revenueCatIdentifier, productIdentifier, purchaseDate);
 
   @JsonKey(ignore: true)
   @override
@@ -195,10 +236,15 @@ class _$_StoreTransaction implements _StoreTransaction {
 
 abstract class _StoreTransaction implements StoreTransaction {
   const factory _StoreTransaction(
-          @JsonKey(name: 'revenueCatId') final String revenueCatIdentifier,
-          @JsonKey(name: 'productId') final String productIdentifier,
-          @JsonKey(name: 'purchaseDate') final String purchaseDate) =
-      _$_StoreTransaction;
+      @JsonKey(name: 'transactionIdentifier')
+          final String transactionIdentifier,
+      @Deprecated('Use transactionIdentifier instead.')
+      @JsonKey(name: 'revenueCatId')
+          final String revenueCatIdentifier,
+      @JsonKey(name: 'productIdentifier')
+          final String productIdentifier,
+      @JsonKey(name: 'purchaseDate')
+          final String purchaseDate) = _$_StoreTransaction;
 
   factory _StoreTransaction.fromJson(Map<String, dynamic> json) =
       _$_StoreTransaction.fromJson;
@@ -206,12 +252,18 @@ abstract class _StoreTransaction implements StoreTransaction {
   @override
 
   /// RevenueCat Id associated to the transaction.
+  @JsonKey(name: 'transactionIdentifier')
+  String get transactionIdentifier;
+  @override
+
+  /// Deprecated: Use transactionIdentifier instead.
+  @Deprecated('Use transactionIdentifier instead.')
   @JsonKey(name: 'revenueCatId')
   String get revenueCatIdentifier;
   @override
 
   /// Product Id associated with the transaction.
-  @JsonKey(name: 'productId')
+  @JsonKey(name: 'productIdentifier')
   String get productIdentifier;
   @override
 

--- a/lib/models/store_transaction.freezed.dart
+++ b/lib/models/store_transaction.freezed.dart
@@ -197,7 +197,7 @@ class _$_StoreTransaction implements _StoreTransaction {
 
   @override
   String toString() {
-    return 'StoreTransaction(transactionIdentifier: $transactionIdentifier, revenueCatIdentifier: $revenueCatIdentifier, productIdentifier: $productIdentifier, purchaseDate: $purchaseDate)';
+    return 'StoreTransaction._create(transactionIdentifier: $transactionIdentifier, revenueCatIdentifier: $revenueCatIdentifier, productIdentifier: $productIdentifier, purchaseDate: $purchaseDate)';
   }
 
   @override

--- a/lib/models/store_transaction.g.dart
+++ b/lib/models/store_transaction.g.dart
@@ -8,14 +8,16 @@ part of 'store_transaction.dart';
 
 _$_StoreTransaction _$$_StoreTransactionFromJson(Map json) =>
     _$_StoreTransaction(
+      json['transactionIdentifier'] as String,
       json['revenueCatId'] as String,
-      json['productId'] as String,
+      json['productIdentifier'] as String,
       json['purchaseDate'] as String,
     );
 
 Map<String, dynamic> _$$_StoreTransactionToJson(_$_StoreTransaction instance) =>
     <String, dynamic>{
+      'transactionIdentifier': instance.transactionIdentifier,
       'revenueCatId': instance.revenueCatIdentifier,
-      'productId': instance.productIdentifier,
+      'productIdentifier': instance.productIdentifier,
       'purchaseDate': instance.purchaseDate,
     };

--- a/lib/models/store_transaction.g.dart
+++ b/lib/models/store_transaction.g.dart
@@ -9,7 +9,7 @@ part of 'store_transaction.dart';
 _$_StoreTransaction _$$_StoreTransactionFromJson(Map json) =>
     _$_StoreTransaction(
       json['transactionIdentifier'] as String,
-      json['revenueCatId'] as String,
+      _readRevenueCatIdentifier(json, 'revenueCatIdentifier') as String,
       json['productIdentifier'] as String,
       json['purchaseDate'] as String,
     );
@@ -17,7 +17,7 @@ _$_StoreTransaction _$$_StoreTransactionFromJson(Map json) =>
 Map<String, dynamic> _$$_StoreTransactionToJson(_$_StoreTransaction instance) =>
     <String, dynamic>{
       'transactionIdentifier': instance.transactionIdentifier,
-      'revenueCatId': instance.revenueCatIdentifier,
+      'revenueCatIdentifier': instance.revenueCatIdentifier,
       'productIdentifier': instance.productIdentifier,
       'purchaseDate': instance.purchaseDate,
     };

--- a/test/store_transaction_test.dart
+++ b/test/store_transaction_test.dart
@@ -3,11 +3,19 @@ import 'package:purchases_flutter/models/store_transaction.dart';
 
 void main() {
   Map<String, Object?> generateStoreTransactionJSON() => {
+        'transactionIdentifier': 'abd123cd',
         'revenueCatId': 'abd123cd',
-        'productId': 'consumable',
+        'productIdentifier': 'consumable',
         'purchaseDateMillis': 1.58759855E9,
         'purchaseDate': '2020-04-22T23:35:50.000Z'
       };
+
+  test('transactionIdentifier is correctly parsed', () {
+    final storeTransaction =
+        StoreTransaction.fromJson(generateStoreTransactionJSON());
+
+    expect(storeTransaction.transactionIdentifier, 'abd123cd');
+  });
 
   test('revenueCatIdentifier is correctly parsed', () {
     final storeTransaction =

--- a/test/store_transaction_test.dart
+++ b/test/store_transaction_test.dart
@@ -4,20 +4,20 @@ import 'package:purchases_flutter/models/store_transaction.dart';
 void main() {
   Map<String, Object?> generateStoreTransactionJSON() => {
         'transactionIdentifier': 'abd123cd',
-        'revenueCatId': 'abd123cd',
         'productIdentifier': 'consumable',
         'purchaseDateMillis': 1.58759855E9,
         'purchaseDate': '2020-04-22T23:35:50.000Z'
       };
 
   test('constructor assigns correct values', () {
-    final storeTransaction = StoreTransaction(
+    const storeTransaction = StoreTransaction.create(
+      'transactionIdentifier',
       'revenueCatIdentifier',
       'productIdentifier',
       'purchaseDate',
     );
 
-    expect(storeTransaction.transactionIdentifier, 'revenueCatIdentifier');
+    expect(storeTransaction.transactionIdentifier, 'transactionIdentifier');
     expect(storeTransaction.revenueCatIdentifier, 'revenueCatIdentifier');
     expect(storeTransaction.productIdentifier, 'productIdentifier');
     expect(storeTransaction.purchaseDate, 'purchaseDate');

--- a/test/store_transaction_test.dart
+++ b/test/store_transaction_test.dart
@@ -10,6 +10,19 @@ void main() {
         'purchaseDate': '2020-04-22T23:35:50.000Z'
       };
 
+  test('constructor assigns correct values', () {
+    final storeTransaction = StoreTransaction(
+      'revenueCatIdentifier',
+      'productIdentifier',
+      'purchaseDate',
+    );
+
+    expect(storeTransaction.transactionIdentifier, 'revenueCatIdentifier');
+    expect(storeTransaction.revenueCatIdentifier, 'revenueCatIdentifier');
+    expect(storeTransaction.productIdentifier, 'productIdentifier');
+    expect(storeTransaction.purchaseDate, 'purchaseDate');
+  });
+
   test('transactionIdentifier is correctly parsed', () {
     final storeTransaction =
         StoreTransaction.fromJson(generateStoreTransactionJSON());


### PR DESCRIPTION
In this PR we deprecate `revenueCatId` in favor of `transactionIdentifier`. The PHC change was done a long time ago: https://github.com/RevenueCat/purchases-hybrid-common/pull/211
