### PR TITLE
Deprecate `usesStoreKit2IfAvailable`

### DIFF
--- a/api_tester/lib/api_tests/models/purchase_configuration_api_test.dart
+++ b/api_tester/lib/api_tests/models/purchase_configuration_api_test.dart
@@ -12,7 +12,6 @@ class _PurchaseConfigurationApiTest {
     bool observerMode = configuration.observerMode;
     String? userDefaultsSuiteName = configuration.userDefaultsSuiteName;
     Store? store = configuration.store;
-    bool usesStoreKit2IfAvailable = configuration.usesStoreKit2IfAvailable;
     configuration.appUserID = null;
     configuration.appUserID = "fakeUserId";
     configuration.observerMode = false;
@@ -20,6 +19,10 @@ class _PurchaseConfigurationApiTest {
     configuration.userDefaultsSuiteName = "fakeSuiteName";
     configuration.store = null;
     configuration.store = Store.playStore;
+    // deprecated, but we still need to check that the API hasn't been removed.
+    // ignore: deprecated_member_use
+    bool usesStoreKit2IfAvailable = configuration.usesStoreKit2IfAvailable;
+    // ignore: deprecated_member_use
     configuration.usesStoreKit2IfAvailable = true;
   }
 

--- a/lib/models/purchases_configuration.dart
+++ b/lib/models/purchases_configuration.dart
@@ -26,6 +26,19 @@ class PurchasesConfiguration {
   /// iOS-only, will be ignored for Android.
   /// Set this to FALSE to disable StoreKit2.
   /// Default is FALSE.
+  ///
+  /// RevenueCat currently uses StoreKit 1 for purchases, as its stability in production scenarios has
+  /// proven to be more performant than StoreKit 2.
+  /// We're collecting more data on the best approach, but StoreKit 1 vs StoreKit 2 is an implementation detail
+  /// that you shouldn't need to care about.
+  /// Simply remove this method call to let RevenueCat decide for you which StoreKit implementation to use.
+  @Deprecated("""
+    RevenueCat currently uses StoreKit 1 for purchases, as its stability in production scenarios has
+    proven to be more performant than StoreKit 2.
+    We're collecting more data on the best approach, but StoreKit 1 vs StoreKit 2 is an implementation detail
+    that you shouldn't need to care about.
+    Simply remove this method call to let RevenueCat decide for you which StoreKit implementation to use.
+  """)
   bool usesStoreKit2IfAvailable = false;
 
   /// Required to configure the plugin to be used in the Amazon Appstore.

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -141,6 +141,7 @@ class Purchases {
           'userDefaultsSuiteName': purchasesConfiguration.userDefaultsSuiteName,
           'useAmazon': purchasesConfiguration.store == Store.amazon,
           'usesStoreKit2IfAvailable':
+              // ignore: deprecated_member_use_from_same_package
               purchasesConfiguration.usesStoreKit2IfAvailable
         },
       );

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -99,6 +99,13 @@ class Purchases {
   /// to be distributed in the Amazon Appstore
 
   /// [usesStoreKit2IfAvailable] iOS-only, will be ignored for Android.
+  /// RevenueCat currently uses StoreKit 1 for purchases, as its stability in production scenarios has
+  /// proven to be more performant than StoreKit 2.
+  ///
+  /// We're collecting more data on the best approach, but StoreKit 1 vs StoreKit 2 is an implementation detail
+  /// that you shouldn't need to care about.
+  ///
+  /// Simply leave this parameter as default to let RevenueCat decide for you which StoreKit implementation to use.
   /// Set this to FALSE to disable StoreKit2.
   @Deprecated('Use PurchasesConfiguration')
   static Future<void> setup(


### PR DESCRIPTION
Deprecates `usesStoreKit2IfAvailable` and adds a message explaining the reasoning. 

<img width="1478" alt="image" src="https://user-images.githubusercontent.com/3922667/222804895-73d1e243-5910-4617-b669-77f8ce599abb.png">
