### PR TITLE
add `immediateAndChargeFullPrice` proration mode

### DIFF
--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -333,6 +333,7 @@ class _PurchasesFlutterApiTest {
       case ProrationMode.immediateAndChargeProratedPrice:
       case ProrationMode.immediateWithoutProration:
       case ProrationMode.deferred:
+      case ProrationMode.immediateAndChargeFullPrice:
         break;
     }
   }

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -918,7 +918,12 @@ enum ProrationMode {
 
   /// Replacement takes effect when the old plan expires, and the new price will
   /// be charged at the same time.
-  deferred
+  deferred,
+
+  /// Replacement takes effect immediately, and the user is charged full price
+  /// of new plan and is given a full billing cycle of subscription,
+  /// plus remaining prorated time from the old plan.
+  immediateAndChargeFullPrice
 }
 
 /// Supported SKU types.


### PR DESCRIPTION
Adds `immediateAndChargeFullPrice` proration mode to purchases-flutter. 