### PR TITLE
[BC5] Rename `UpgradeInfo` to `ProductChangeInfo` and hide unsupported `ProrationMode`s

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,6 +3,7 @@ include: package:flutter_lints/flutter.yaml
 analyzer:
   errors:
     invalid_annotation_target: ignore
+    deprecated_member_use_from_same_package: ignore
   exclude:
     - lib/models/*.freezed.dart
     - lib/models/*.g.dart
@@ -18,8 +19,8 @@ linter:
     avoid_unused_constructor_parameters: true
     avoid_void_async: true
     cascade_invocations: true
+    deprecated_consistency: true
     directives_ordering: true
-    invalid_annotation_target: false
     omit_local_variable_types: true
     prefer_const_constructors: true
     prefer_const_constructors_in_immutables: true
@@ -33,6 +34,7 @@ linter:
     prefer_relative_imports: true
     prefer_single_quotes: true
     prefer_spread_collections: true
+    provide_deprecation_message: true
     require_trailing_commas: true
     unnecessary_brace_in_string_interps: true
     unnecessary_lambdas: true

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ version '4.12.0-SNAPSHOT'
 
 buildscript {
     ext.kotlin_version = '1.6.21'
-    ext.common_version = '5.0.0-beta.3'
+    ext.common_version = '5.0.0-beta.4'
     repositories {
         google()
         mavenCentral()

--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -156,27 +156,27 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 break;
             case "purchaseProduct":
                 String productIdentifier = call.argument("productIdentifier");
-                String oldProductIdentifer = call.argument("oldProductIdentifer");
-                Integer prorationMode = call.argument("prorationMode");
-                Boolean isPersonalizedPrice = call.argument("isPersonalizedPrice");
+                String googleOldProductIdentifer = call.argument("googleOldProductIdentifer");
+                Integer googleProrationMode = call.argument("googleProrationMode");
+                Boolean googleIsPersonalizedPrice = call.argument("googleIsPersonalizedPrice");
                 type = call.argument("type");
-                purchaseProduct(productIdentifier, type, oldProductIdentifer, prorationMode, isPersonalizedPrice, result);
+                purchaseProduct(productIdentifier, type, googleOldProductIdentifer, googleProrationMode, googleIsPersonalizedPrice, result);
                 break;
             case "purchasePackage":
                 String packageIdentifier = call.argument("packageIdentifier");
                 String offeringIdentifier = call.argument("offeringIdentifier");
-                oldProductIdentifer = call.argument("oldProductIdentifer");
-                prorationMode = call.argument("prorationMode");
-                isPersonalizedPrice = call.argument("isPersonalizedPrice");
-                purchasePackage(packageIdentifier, offeringIdentifier, oldProductIdentifer, prorationMode, isPersonalizedPrice, result);
+                googleOldProductIdentifer = call.argument("googleOldProductIdentifer");
+                googleProrationMode = call.argument("googleProrationMode");
+                googleIsPersonalizedPrice = call.argument("googleIsPersonalizedPrice");
+                purchasePackage(packageIdentifier, offeringIdentifier, googleOldProductIdentifer, googleProrationMode, googleIsPersonalizedPrice, result);
                 break;
             case "purchaseSubscriptionOption":
                 productIdentifier = call.argument("productIdentifier");
                 String optionIdentifier = call.argument("optionIdentifier");
-                oldProductIdentifer = call.argument("oldProductIdentifer");
-                prorationMode = call.argument("prorationMode");
-                isPersonalizedPrice = call.argument("isPersonalizedPrice");
-                purchaseSubscriptionOption(productIdentifier, optionIdentifier, oldProductIdentifer, prorationMode, isPersonalizedPrice, result);
+                googleOldProductIdentifer = call.argument("googleOldProductIdentifer");
+                googleProrationMode = call.argument("googleProrationMode");
+                googleIsPersonalizedPrice = call.argument("googleIsPersonalizedPrice");
+                purchaseSubscriptionOption(productIdentifier, optionIdentifier, googleOldProductIdentifer, googleProrationMode, googleIsPersonalizedPrice, result);
                 break;
             case "getAppUserID":
                 getAppUserID(result);

--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -156,7 +156,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 break;
             case "purchaseProduct":
                 String productIdentifier = call.argument("productIdentifier");
-                String googleOldProductIdentifer = call.argument("googleOldProductIdentifer");
+                String googleOldProductIdentifer = call.argument("googleOldProductIdentifier");
                 Integer googleProrationMode = call.argument("googleProrationMode");
                 Boolean googleIsPersonalizedPrice = call.argument("googleIsPersonalizedPrice");
                 type = call.argument("type");
@@ -165,7 +165,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
             case "purchasePackage":
                 String packageIdentifier = call.argument("packageIdentifier");
                 String offeringIdentifier = call.argument("offeringIdentifier");
-                googleOldProductIdentifer = call.argument("googleOldProductIdentifer");
+                googleOldProductIdentifer = call.argument("googleOldProductIdentifier");
                 googleProrationMode = call.argument("googleProrationMode");
                 googleIsPersonalizedPrice = call.argument("googleIsPersonalizedPrice");
                 purchasePackage(packageIdentifier, offeringIdentifier, googleOldProductIdentifer, googleProrationMode, googleIsPersonalizedPrice, result);
@@ -173,7 +173,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
             case "purchaseSubscriptionOption":
                 productIdentifier = call.argument("productIdentifier");
                 String optionIdentifier = call.argument("optionIdentifier");
-                googleOldProductIdentifer = call.argument("googleOldProductIdentifer");
+                googleOldProductIdentifer = call.argument("googleOldProductIdentifier");
                 googleProrationMode = call.argument("googleProrationMode");
                 googleIsPersonalizedPrice = call.argument("googleIsPersonalizedPrice");
                 purchaseSubscriptionOption(productIdentifier, optionIdentifier, googleOldProductIdentifer, googleProrationMode, googleIsPersonalizedPrice, result);

--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -160,7 +160,8 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 Integer googleProrationMode = call.argument("googleProrationMode");
                 Boolean googleIsPersonalizedPrice = call.argument("googleIsPersonalizedPrice");
                 type = call.argument("type");
-                purchaseProduct(productIdentifier, type, googleOldProductIdentifer, googleProrationMode, googleIsPersonalizedPrice, result);
+                String presentedOfferingIdentifier = call.argument("presentedOfferingIdentifier");
+                purchaseProduct(productIdentifier, type, googleOldProductIdentifer, googleProrationMode, googleIsPersonalizedPrice, presentedOfferingIdentifier, result);
                 break;
             case "purchasePackage":
                 String packageIdentifier = call.argument("packageIdentifier");
@@ -176,7 +177,8 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 googleOldProductIdentifer = call.argument("googleOldProductIdentifier");
                 googleProrationMode = call.argument("googleProrationMode");
                 googleIsPersonalizedPrice = call.argument("googleIsPersonalizedPrice");
-                purchaseSubscriptionOption(productIdentifier, optionIdentifier, googleOldProductIdentifer, googleProrationMode, googleIsPersonalizedPrice, result);
+                presentedOfferingIdentifier = call.argument("presentedOfferingIdentifier");
+                purchaseSubscriptionOption(productIdentifier, optionIdentifier, googleOldProductIdentifer, googleProrationMode, googleIsPersonalizedPrice, presentedOfferingIdentifier, result);
                 break;
             case "getAppUserID":
                 getAppUserID(result);
@@ -418,10 +420,11 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
     }
 
     private void purchaseProduct(final String productIdentifier,
-                                 final String googleOldProductId,
                                  final String type,
+                                 final String googleOldProductId,
                                  @Nullable final Integer googleProrationMode,
                                  @Nullable final Boolean googleIsPersonalizedPrice,
+                                 @Nullable final String presentedOfferingIdentifier,
                                  final Result result) {
         CommonKt.purchaseProduct(
                 getActivity(),
@@ -431,6 +434,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 googleOldProductId,
                 googleProrationMode,
                 googleIsPersonalizedPrice,
+                presentedOfferingIdentifier,
                 getOnResult(result)
         );
     }
@@ -457,6 +461,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                                             final String googleOldProductId,
                                             @Nullable final Integer googleProrationMode,
                                             @Nullable final Boolean googleIsPersonalizedPrice,
+                                            @Nullable final String presentedOfferingIdentifier,
                                             final Result result) {
         CommonKt.purchaseSubscriptionOption(
                 getActivity(),
@@ -465,6 +470,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 googleOldProductId,
                 googleProrationMode,
                 googleIsPersonalizedPrice,
+                presentedOfferingIdentifier,
                 getOnResult(result)
         );
     }

--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -156,27 +156,27 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 break;
             case "purchaseProduct":
                 String productIdentifier = call.argument("productIdentifier");
-                String oldSKU = call.argument("oldSKU"); // TODO: Rename
-                Integer prorationMode = call.argument("prorationMode"); // TODO: Rename
-                Boolean isPersonalizedPrice = call.argument("isPersonalizedPrice"); // TODO: Rename
+                String oldProductIdentifer = call.argument("oldProductIdentifer");
+                Integer prorationMode = call.argument("prorationMode");
+                Boolean isPersonalizedPrice = call.argument("isPersonalizedPrice");
                 type = call.argument("type");
-                purchaseProduct(productIdentifier, type, oldSKU, prorationMode, isPersonalizedPrice, result);
+                purchaseProduct(productIdentifier, type, oldProductIdentifer, prorationMode, isPersonalizedPrice, result);
                 break;
             case "purchasePackage":
                 String packageIdentifier = call.argument("packageIdentifier");
                 String offeringIdentifier = call.argument("offeringIdentifier");
-                oldSKU = call.argument("oldSKU"); // TODO: Rename
-                prorationMode = call.argument("prorationMode"); // TODO: Rename
-                isPersonalizedPrice = call.argument("isPersonalizedPrice"); // TODO: Rename
-                purchasePackage(packageIdentifier, offeringIdentifier, oldSKU, prorationMode, isPersonalizedPrice, result);
+                oldProductIdentifer = call.argument("oldProductIdentifer");
+                prorationMode = call.argument("prorationMode");
+                isPersonalizedPrice = call.argument("isPersonalizedPrice");
+                purchasePackage(packageIdentifier, offeringIdentifier, oldProductIdentifer, prorationMode, isPersonalizedPrice, result);
                 break;
             case "purchaseSubscriptionOption":
                 productIdentifier = call.argument("productIdentifier");
                 String optionIdentifier = call.argument("optionIdentifier");
-                oldSKU = call.argument("oldSKU"); // TODO: Rename
-                prorationMode = call.argument("prorationMode"); // TODO: Rename
-                isPersonalizedPrice = call.argument("isPersonalizedPrice"); // TODO: Rename
-                purchaseSubscriptionOption(productIdentifier, optionIdentifier, oldSKU, prorationMode, isPersonalizedPrice, result);
+                oldProductIdentifer = call.argument("oldProductIdentifer");
+                prorationMode = call.argument("prorationMode");
+                isPersonalizedPrice = call.argument("isPersonalizedPrice");
+                purchaseSubscriptionOption(productIdentifier, optionIdentifier, oldProductIdentifer, prorationMode, isPersonalizedPrice, result);
                 break;
             case "getAppUserID":
                 getAppUserID(result);

--- a/api_tester/lib/api_tests/models/pricing_phase_wrapper_api_test.dart
+++ b/api_tester/lib/api_tests/models/pricing_phase_wrapper_api_test.dart
@@ -16,9 +16,10 @@ class _PricingPhaseApiTest {
     RecurrenceMode? recurrenceMode,
     int? billingCycleCount,
     Price price,
+    OfferPaymentMode? offerPaymentMode,
   ) {
-    PricingPhase pricingPhase =
-        PricingPhase(billingPeriod, recurrenceMode, billingCycleCount, price);
+    PricingPhase pricingPhase = PricingPhase(billingPeriod, recurrenceMode,
+        billingCycleCount, price, offerPaymentMode);
   }
 
   void _checkProperties(PricingPhase pricingPhase) {
@@ -26,5 +27,6 @@ class _PricingPhaseApiTest {
     RecurrenceMode? recurrenceMode = pricingPhase.recurrenceMode;
     int? billingCycleCount = pricingPhase.billingCycleCount;
     Price price = pricingPhase.price;
+    OfferPaymentMode? offerPaymentMode = pricingPhase.offerPaymentMode;
   }
 }

--- a/api_tester/lib/api_tests/models/store_product_wrapper_api_test.dart
+++ b/api_tester/lib/api_tests/models/store_product_wrapper_api_test.dart
@@ -20,14 +20,18 @@ class _StoreProductApiTest {
       String currencyCode,
       IntroductoryPrice? introductoryPrice,
       List<StoreProductDiscount>? discounts,
-      String? subscriptionPeriod) {
+      ProductType? productType,
+      String? subscriptionPeriod,
+      String? presentedOfferingIdentifier) {
     StoreProduct product = StoreProduct(
         identifier, description, title, price, priceString, currencyCode);
     product = StoreProduct(
         identifier, description, title, price, priceString, currencyCode,
         introductoryPrice: introductoryPrice,
         discounts: discounts,
-        subscriptionPeriod: subscriptionPeriod);
+        productType: productType,
+        subscriptionPeriod: subscriptionPeriod,
+        presentedOfferingIdentifier: presentedOfferingIdentifier);
   }
 
   void _checkProperties(StoreProduct product) {
@@ -39,8 +43,10 @@ class _StoreProductApiTest {
     String currencyCode = product.currencyCode;
     IntroductoryPrice? introductoryPrice = product.introductoryPrice;
     List<StoreProductDiscount>? discounts = product.discounts;
+    ProductType? productType = product.productType;
     SubscriptionOption? defaultOption = product.defaultOption;
     List<SubscriptionOption>? subscriptionOptions = product.subscriptionOptions;
     String? subscriptionPeriod = product.subscriptionPeriod;
+    String? presentedOfferingIdentifier = product.presentedOfferingIdentifier;
   }
 }

--- a/api_tester/lib/api_tests/models/subscription_option_wrapper_api_test.dart
+++ b/api_tester/lib/api_tests/models/subscription_option_wrapper_api_test.dart
@@ -21,7 +21,8 @@ class _SubscriptionOptionApiTest {
       Period? billingPeriod,
       PricingPhase? fullPricePhase,
       PricingPhase? freePhase,
-      PricingPhase? introPhase) {
+      PricingPhase? introPhase,
+      String? presentedOfferingIdentifier) {
     SubscriptionOption subscriptionOption = SubscriptionOption(
         id,
         storeProductId,
@@ -32,7 +33,8 @@ class _SubscriptionOptionApiTest {
         billingPeriod,
         fullPricePhase,
         freePhase,
-        introPhase);
+        introPhase,
+        presentedOfferingIdentifier);
   }
 
   void _checkProperties(SubscriptionOption subscriptionOption) {
@@ -46,5 +48,7 @@ class _SubscriptionOptionApiTest {
     PricingPhase? fullPricePhase = subscriptionOption.fullPricePhase;
     PricingPhase? freePhase = subscriptionOption.freePhase;
     PricingPhase? introPhase = subscriptionOption.introPhase;
+    String? presentedOfferingIdentifier =
+        subscriptionOption.presentedOfferingIdentifier;
   }
 }

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -73,17 +73,18 @@ class _PurchasesFlutterApiTest {
     String productIdentifier = "fakeProductId";
     UpgradeInfo? upgradeInfo;
     PurchaseType purchaseType = PurchaseType.subs;
-    CustomerInfo customerInfo = await Purchases.purchaseProduct(
-        productIdentifier,
-        upgradeInfo: upgradeInfo,
-        isPersonalizedPrice: true);
-    customerInfo = await Purchases.purchaseProduct(productIdentifier,
-        upgradeInfo: upgradeInfo, type: purchaseType);
-    customerInfo = await Purchases.purchaseProduct(productIdentifier,
-        upgradeInfo: upgradeInfo);
-    customerInfo = await Purchases.purchaseProduct(productIdentifier,
-        isPersonalizedPrice: true);
-    customerInfo = await Purchases.purchaseProduct(productIdentifier);
+
+    // CustomerInfo customerInfo = await Purchases.purchaseProduct(
+    //     productIdentifier,
+    //     upgradeInfo: upgradeInfo,
+    //     isPersonalizedPrice: true);
+    // customerInfo = await Purchases.purchaseProduct(productIdentifier,
+    //     upgradeInfo: upgradeInfo, type: purchaseType);
+    // customerInfo = await Purchases.purchaseProduct(productIdentifier,
+    //     upgradeInfo: upgradeInfo);
+    // customerInfo = await Purchases.purchaseProduct(productIdentifier,
+    //     isPersonalizedPrice: true);
+    // customerInfo = await Purchases.purchaseProduct(productIdentifier);
   }
 
   void _checkPurchasePackage(Package package) async {

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -72,48 +72,49 @@ class _PurchasesFlutterApiTest {
   void _checkPurchaseProduct() async {
     String productIdentifier = "fakeProductId";
     UpgradeInfo? upgradeInfo;
-    ProductChangeInfo? productChangeInfo;
+    GoogleProductChangeInfo? googleProductChangeInfo;
     PurchaseType purchaseType = PurchaseType.subs;
     CustomerInfo customerInfo = await Purchases.purchaseProduct(
         productIdentifier,
         upgradeInfo: upgradeInfo,
-        isPersonalizedPrice: true);
+        googleIsPersonalizedPrice: true);
     customerInfo = await Purchases.purchaseProduct(productIdentifier,
         upgradeInfo: upgradeInfo, type: purchaseType);
     customerInfo = await Purchases.purchaseProduct(productIdentifier,
-        productChangeInfo: productChangeInfo);
+        googleProductChangeInfo: googleProductChangeInfo);
     customerInfo = await Purchases.purchaseProduct(productIdentifier,
         upgradeInfo: upgradeInfo);
     customerInfo = await Purchases.purchaseProduct(productIdentifier,
-        isPersonalizedPrice: true);
+        googleIsPersonalizedPrice: true);
     customerInfo = await Purchases.purchaseProduct(productIdentifier);
   }
 
   void _checkPurchasePackage(Package package) async {
     UpgradeInfo? upgradeInfo;
-    ProductChangeInfo? productChangeInfo;
+    GoogleProductChangeInfo? googleProductChangeInfo;
     CustomerInfo customerInfo =
         await Purchases.purchasePackage(package, upgradeInfo: upgradeInfo);
     customerInfo = await Purchases.purchasePackage(package,
-        productChangeInfo: productChangeInfo, isPersonalizedPrice: true);
+        googleProductChangeInfo: googleProductChangeInfo,
+        googleIsPersonalizedPrice: true);
     customerInfo = await Purchases.purchasePackage(package,
-        upgradeInfo: upgradeInfo, isPersonalizedPrice: true);
-    customerInfo =
-        await Purchases.purchasePackage(package, isPersonalizedPrice: true);
+        upgradeInfo: upgradeInfo, googleIsPersonalizedPrice: true);
+    customerInfo = await Purchases.purchasePackage(package,
+        googleIsPersonalizedPrice: true);
   }
 
   void _checkPurchaseSubscriptionOption(SubscriptionOption subscriptionOption,
-      ProductChangeInfo? productChangeInfo) async {
+      GoogleProductChangeInfo? googleProductChangeInfo) async {
     CustomerInfo customerInfo = await Purchases.purchaseSubscriptionOption(
         subscriptionOption,
-        productChangeInfo: productChangeInfo);
+        googleProductChangeInfo: googleProductChangeInfo);
     customerInfo = await Purchases.purchaseSubscriptionOption(
         subscriptionOption,
-        productChangeInfo: productChangeInfo,
-        isPersonalizedPrice: true);
+        googleProductChangeInfo: googleProductChangeInfo,
+        googleIsPersonalizedPrice: true);
     customerInfo = await Purchases.purchaseSubscriptionOption(
         subscriptionOption,
-        isPersonalizedPrice: true);
+        googleIsPersonalizedPrice: true);
     customerInfo =
         await Purchases.purchaseSubscriptionOption(subscriptionOption);
   }

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -358,14 +358,34 @@ class _PurchasesFlutterApiTest {
     ProrationMode? storedProrationMode = purchaseInfo.prorationMode;
   }
 
+  void _checkGoogleProductChangeInfoInfo() {
+    String oldProductIdentifier = "fakeOldProductIdentifier";
+    GoogleProrationMode? prorationMode;
+
+    GoogleProductChangeInfo purchaseInfo =
+        GoogleProductChangeInfo(oldProductIdentifier);
+    purchaseInfo = GoogleProductChangeInfo(oldProductIdentifier,
+        prorationMode: prorationMode);
+    String storedOldProductIdentifier = purchaseInfo.oldProductIdentifier;
+    GoogleProrationMode? storedProrationMode = purchaseInfo.prorationMode;
+  }
+
   void _checkProrationMode(ProrationMode prorationMode) {
     switch (prorationMode) {
       case ProrationMode.unknownSubscriptionUpgradeDowngradePolicy:
       case ProrationMode.immediateWithTimeProration:
-      // case ProrationMode.immediateAndChargeProratedPrice:
+      case ProrationMode.immediateAndChargeProratedPrice:
       case ProrationMode.immediateWithoutProration:
-        // case ProrationMode.deferred:
-        // case ProrationMode.immediateAndChargeFullPrice:
+      case ProrationMode.deferred:
+      case ProrationMode.immediateAndChargeFullPrice:
+        break;
+    }
+  }
+
+  void _checkGoogleProrationMode(GoogleProrationMode prorationMode) {
+    switch (prorationMode) {
+      case GoogleProrationMode.immediateWithTimeProration:
+      case GoogleProrationMode.immediateWithoutProration:
         break;
     }
   }

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -355,10 +355,10 @@ class _PurchasesFlutterApiTest {
     switch (prorationMode) {
       case ProrationMode.unknownSubscriptionUpgradeDowngradePolicy:
       case ProrationMode.immediateWithTimeProration:
-      case ProrationMode.immediateAndChargeProratedPrice:
+      // case ProrationMode.immediateAndChargeProratedPrice:
       case ProrationMode.immediateWithoutProration:
-      case ProrationMode.deferred:
-      case ProrationMode.immediateAndChargeFullPrice:
+        // case ProrationMode.deferred:
+        // case ProrationMode.immediateAndChargeFullPrice:
         break;
     }
   }

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -74,8 +74,14 @@ class _PurchasesFlutterApiTest {
     UpgradeInfo? upgradeInfo;
     GoogleProductChangeInfo? googleProductChangeInfo;
     PurchaseType purchaseType = PurchaseType.subs;
+    ProductType productType = ProductType.subs;
     CustomerInfo customerInfo = await Purchases.purchaseProduct(
         productIdentifier,
+        type: purchaseType,
+        upgradeInfo: upgradeInfo,
+        googleIsPersonalizedPrice: true);
+    customerInfo = await Purchases.purchaseProduct(productIdentifier,
+        productType: productType,
         upgradeInfo: upgradeInfo,
         googleIsPersonalizedPrice: true);
     customerInfo = await Purchases.purchaseProduct(productIdentifier,
@@ -87,6 +93,19 @@ class _PurchasesFlutterApiTest {
     customerInfo = await Purchases.purchaseProduct(productIdentifier,
         googleIsPersonalizedPrice: true);
     customerInfo = await Purchases.purchaseProduct(productIdentifier);
+  }
+
+  void _checkPurchaseStoreProduct(StoreProduct storeProduct) async {
+    GoogleProductChangeInfo? googleProductChangeInfo;
+    CustomerInfo customerInfo = await Purchases.purchaseStoreProduct(
+        storeProduct,
+        googleProductChangeInfo: googleProductChangeInfo,
+        googleIsPersonalizedPrice: true);
+    customerInfo = await Purchases.purchaseStoreProduct(storeProduct,
+        googleIsPersonalizedPrice: true);
+    customerInfo = await Purchases.purchaseStoreProduct(storeProduct,
+        googleProductChangeInfo: googleProductChangeInfo);
+    customerInfo = await Purchases.purchaseStoreProduct(storeProduct);
   }
 
   void _checkPurchasePackage(Package package) async {
@@ -386,6 +405,14 @@ class _PurchasesFlutterApiTest {
     switch (prorationMode) {
       case GoogleProrationMode.immediateWithTimeProration:
       case GoogleProrationMode.immediateWithoutProration:
+        break;
+    }
+  }
+
+  void _checkProductType(ProductType type) {
+    switch (type) {
+      case ProductType.subs:
+      case ProductType.inapp:
         break;
     }
   }

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -72,39 +72,44 @@ class _PurchasesFlutterApiTest {
   void _checkPurchaseProduct() async {
     String productIdentifier = "fakeProductId";
     UpgradeInfo? upgradeInfo;
+    ProductChangeInfo? productChangeInfo;
     PurchaseType purchaseType = PurchaseType.subs;
-
-    // CustomerInfo customerInfo = await Purchases.purchaseProduct(
-    //     productIdentifier,
-    //     upgradeInfo: upgradeInfo,
-    //     isPersonalizedPrice: true);
-    // customerInfo = await Purchases.purchaseProduct(productIdentifier,
-    //     upgradeInfo: upgradeInfo, type: purchaseType);
-    // customerInfo = await Purchases.purchaseProduct(productIdentifier,
-    //     upgradeInfo: upgradeInfo);
-    // customerInfo = await Purchases.purchaseProduct(productIdentifier,
-    //     isPersonalizedPrice: true);
-    // customerInfo = await Purchases.purchaseProduct(productIdentifier);
+    CustomerInfo customerInfo = await Purchases.purchaseProduct(
+        productIdentifier,
+        upgradeInfo: upgradeInfo,
+        isPersonalizedPrice: true);
+    customerInfo = await Purchases.purchaseProduct(productIdentifier,
+        upgradeInfo: upgradeInfo, type: purchaseType);
+    customerInfo = await Purchases.purchaseProduct(productIdentifier,
+        productChangeInfo: productChangeInfo);
+    customerInfo = await Purchases.purchaseProduct(productIdentifier,
+        upgradeInfo: upgradeInfo);
+    customerInfo = await Purchases.purchaseProduct(productIdentifier,
+        isPersonalizedPrice: true);
+    customerInfo = await Purchases.purchaseProduct(productIdentifier);
   }
 
   void _checkPurchasePackage(Package package) async {
     UpgradeInfo? upgradeInfo;
+    ProductChangeInfo? productChangeInfo;
     CustomerInfo customerInfo =
         await Purchases.purchasePackage(package, upgradeInfo: upgradeInfo);
+    customerInfo = await Purchases.purchasePackage(package,
+        productChangeInfo: productChangeInfo, isPersonalizedPrice: true);
     customerInfo = await Purchases.purchasePackage(package,
         upgradeInfo: upgradeInfo, isPersonalizedPrice: true);
     customerInfo =
         await Purchases.purchasePackage(package, isPersonalizedPrice: true);
   }
 
-  void _checkPurchaseSubscriptionOption(
-      SubscriptionOption subscriptionOption, UpgradeInfo? upgradeInfo) async {
+  void _checkPurchaseSubscriptionOption(SubscriptionOption subscriptionOption,
+      ProductChangeInfo? productChangeInfo) async {
     CustomerInfo customerInfo = await Purchases.purchaseSubscriptionOption(
         subscriptionOption,
-        upgradeInfo: upgradeInfo);
+        productChangeInfo: productChangeInfo);
     customerInfo = await Purchases.purchaseSubscriptionOption(
         subscriptionOption,
-        upgradeInfo: upgradeInfo,
+        productChangeInfo: productChangeInfo,
         isPersonalizedPrice: true);
     customerInfo = await Purchases.purchaseSubscriptionOption(
         subscriptionOption,

--- a/lib/google_product_change.dart
+++ b/lib/google_product_change.dart
@@ -1,12 +1,12 @@
 class GoogleProductChangeInfo {
-  /// The oldProductIdentifer to change from.
-  String oldProductIdentifer;
+  /// The oldProductIdentifier to change from.
+  String oldProductIdentifier;
 
   /// The [GoogleProrationMode] to use when changing from the given oldProductIdentifer.
   GoogleProrationMode? prorationMode;
 
   /// Constructs an GoogleProductChangeInfo
-  GoogleProductChangeInfo(this.oldProductIdentifer, {this.prorationMode});
+  GoogleProductChangeInfo(this.oldProductIdentifier, {this.prorationMode});
 }
 
 /// GoogleProductChangeInfo's ProrationMode.

--- a/lib/google_product_change.dart
+++ b/lib/google_product_change.dart
@@ -3,6 +3,7 @@ class GoogleProductChangeInfo {
   String oldProductIdentifier;
 
   /// The [GoogleProrationMode] to use when changing from the given oldProductIdentifer.
+  /// Defaults to [GoogleProrationMode.immediateWithoutProration]
   GoogleProrationMode? prorationMode;
 
   /// Constructs an GoogleProductChangeInfo
@@ -18,4 +19,17 @@ enum GoogleProrationMode {
   /// Replacement takes effect immediately, and the new price will be charged on
   /// next recurrence time. The billing cycle stays the same.
   immediateWithoutProration,
+}
+
+extension GoogleProrationModeExtension on GoogleProrationMode {
+  int? get value {
+    switch (this) {
+      case GoogleProrationMode.immediateWithTimeProration:
+        return 1;
+      case GoogleProrationMode.immediateWithoutProration:
+        return 3;
+      default:
+        return null;
+    }
+  }
 }

--- a/lib/google_product_change.dart
+++ b/lib/google_product_change.dart
@@ -1,0 +1,21 @@
+class GoogleProductChangeInfo {
+  /// The oldProductIdentifer to change from.
+  String oldProductIdentifer;
+
+  /// The [GoogleProrationMode] to use when changing from the given oldProductIdentifer.
+  GoogleProrationMode? prorationMode;
+
+  /// Constructs an GoogleProductChangeInfo
+  GoogleProductChangeInfo(this.oldProductIdentifer, {this.prorationMode});
+}
+
+/// GoogleProductChangeInfo's ProrationMode.
+enum GoogleProrationMode {
+  /// Replacement takes effect immediately, and the remaining time will be
+  /// prorated and credited to the user. This is the current default behavior.
+  immediateWithTimeProration,
+
+  /// Replacement takes effect immediately, and the new price will be charged on
+  /// next recurrence time. The billing cycle stays the same.
+  immediateWithoutProration,
+}

--- a/lib/models/pricing_phase_wrapper.dart
+++ b/lib/models/pricing_phase_wrapper.dart
@@ -24,6 +24,10 @@ class PricingPhase with _$PricingPhase {
 
     /// Price of the PricingPhase
     @JsonKey(name: 'price') Price price,
+
+    /// Indicates how the pricing phase is charged for finiteRecurring pricing phases
+    @JsonKey(name: 'offerPaymentMode', nullable: true)
+        OfferPaymentMode? offerPaymentMode,
   ) = _PricingPhase;
 
   factory PricingPhase.fromJson(Map<String, dynamic> json) =>
@@ -39,4 +43,18 @@ enum RecurrenceMode {
   nonRecurring,
   @JsonValue(null)
   unknown,
+}
+
+enum OfferPaymentMode {
+  // Subscribers don't pay until the specified period ends
+  @JsonValue('FREE_TRIAL')
+  freeTrial,
+
+  // Subscribers pay up front for a specified period
+  @JsonValue('SINGLE_PAYMENT')
+  singlePayment,
+
+  // Subscribers pay a discounted amount for a specified number of periods
+  @JsonValue('DISCOUNTED_RECURRING_PAYMENT')
+  discountedRecurringPayment,
 }

--- a/lib/models/pricing_phase_wrapper.freezed.dart
+++ b/lib/models/pricing_phase_wrapper.freezed.dart
@@ -37,6 +37,10 @@ mixin _$PricingPhase {
   @JsonKey(name: 'price')
   Price get price => throw _privateConstructorUsedError;
 
+  /// Indicates how the pricing phase is charged for finiteRecurring pricing phases
+  @JsonKey(name: 'offerPaymentMode', nullable: true)
+  OfferPaymentMode? get offerPaymentMode => throw _privateConstructorUsedError;
+
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
   $PricingPhaseCopyWith<PricingPhase> get copyWith =>
@@ -57,7 +61,9 @@ abstract class $PricingPhaseCopyWith<$Res> {
       @JsonKey(name: 'billingCycleCount', nullable: true)
           int? billingCycleCount,
       @JsonKey(name: 'price')
-          Price price});
+          Price price,
+      @JsonKey(name: 'offerPaymentMode', nullable: true)
+          OfferPaymentMode? offerPaymentMode});
 
   $PeriodCopyWith<$Res>? get billingPeriod;
   $PriceCopyWith<$Res> get price;
@@ -80,6 +86,7 @@ class _$PricingPhaseCopyWithImpl<$Res, $Val extends PricingPhase>
     Object? recurrenceMode = freezed,
     Object? billingCycleCount = freezed,
     Object? price = null,
+    Object? offerPaymentMode = freezed,
   }) {
     return _then(_value.copyWith(
       billingPeriod: freezed == billingPeriod
@@ -98,6 +105,10 @@ class _$PricingPhaseCopyWithImpl<$Res, $Val extends PricingPhase>
           ? _value.price
           : price // ignore: cast_nullable_to_non_nullable
               as Price,
+      offerPaymentMode: freezed == offerPaymentMode
+          ? _value.offerPaymentMode
+          : offerPaymentMode // ignore: cast_nullable_to_non_nullable
+              as OfferPaymentMode?,
     ) as $Val);
   }
 
@@ -138,7 +149,9 @@ abstract class _$$_PricingPhaseCopyWith<$Res>
       @JsonKey(name: 'billingCycleCount', nullable: true)
           int? billingCycleCount,
       @JsonKey(name: 'price')
-          Price price});
+          Price price,
+      @JsonKey(name: 'offerPaymentMode', nullable: true)
+          OfferPaymentMode? offerPaymentMode});
 
   @override
   $PeriodCopyWith<$Res>? get billingPeriod;
@@ -161,6 +174,7 @@ class __$$_PricingPhaseCopyWithImpl<$Res>
     Object? recurrenceMode = freezed,
     Object? billingCycleCount = freezed,
     Object? price = null,
+    Object? offerPaymentMode = freezed,
   }) {
     return _then(_$_PricingPhase(
       freezed == billingPeriod
@@ -179,6 +193,10 @@ class __$$_PricingPhaseCopyWithImpl<$Res>
           ? _value.price
           : price // ignore: cast_nullable_to_non_nullable
               as Price,
+      freezed == offerPaymentMode
+          ? _value.offerPaymentMode
+          : offerPaymentMode // ignore: cast_nullable_to_non_nullable
+              as OfferPaymentMode?,
     ));
   }
 }
@@ -194,7 +212,9 @@ class _$_PricingPhase implements _PricingPhase {
       @JsonKey(name: 'billingCycleCount', nullable: true)
           this.billingCycleCount,
       @JsonKey(name: 'price')
-          this.price);
+          this.price,
+      @JsonKey(name: 'offerPaymentMode', nullable: true)
+          this.offerPaymentMode);
 
   factory _$_PricingPhase.fromJson(Map<String, dynamic> json) =>
       _$$_PricingPhaseFromJson(json);
@@ -220,9 +240,14 @@ class _$_PricingPhase implements _PricingPhase {
   @JsonKey(name: 'price')
   final Price price;
 
+  /// Indicates how the pricing phase is charged for finiteRecurring pricing phases
+  @override
+  @JsonKey(name: 'offerPaymentMode', nullable: true)
+  final OfferPaymentMode? offerPaymentMode;
+
   @override
   String toString() {
-    return 'PricingPhase(billingPeriod: $billingPeriod, recurrenceMode: $recurrenceMode, billingCycleCount: $billingCycleCount, price: $price)';
+    return 'PricingPhase(billingPeriod: $billingPeriod, recurrenceMode: $recurrenceMode, billingCycleCount: $billingCycleCount, price: $price, offerPaymentMode: $offerPaymentMode)';
   }
 
   @override
@@ -236,13 +261,15 @@ class _$_PricingPhase implements _PricingPhase {
                 other.recurrenceMode == recurrenceMode) &&
             (identical(other.billingCycleCount, billingCycleCount) ||
                 other.billingCycleCount == billingCycleCount) &&
-            (identical(other.price, price) || other.price == price));
+            (identical(other.price, price) || other.price == price) &&
+            (identical(other.offerPaymentMode, offerPaymentMode) ||
+                other.offerPaymentMode == offerPaymentMode));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(
-      runtimeType, billingPeriod, recurrenceMode, billingCycleCount, price);
+  int get hashCode => Object.hash(runtimeType, billingPeriod, recurrenceMode,
+      billingCycleCount, price, offerPaymentMode);
 
   @JsonKey(ignore: true)
   @override
@@ -267,7 +294,9 @@ abstract class _PricingPhase implements PricingPhase {
       @JsonKey(name: 'billingCycleCount', nullable: true)
           final int? billingCycleCount,
       @JsonKey(name: 'price')
-          final Price price) = _$_PricingPhase;
+          final Price price,
+      @JsonKey(name: 'offerPaymentMode', nullable: true)
+          final OfferPaymentMode? offerPaymentMode) = _$_PricingPhase;
 
   factory _PricingPhase.fromJson(Map<String, dynamic> json) =
       _$_PricingPhase.fromJson;
@@ -293,6 +322,11 @@ abstract class _PricingPhase implements PricingPhase {
   /// Price of the PricingPhase
   @JsonKey(name: 'price')
   Price get price;
+  @override
+
+  /// Indicates how the pricing phase is charged for finiteRecurring pricing phases
+  @JsonKey(name: 'offerPaymentMode', nullable: true)
+  OfferPaymentMode? get offerPaymentMode;
   @override
   @JsonKey(ignore: true)
   _$$_PricingPhaseCopyWith<_$_PricingPhase> get copyWith =>

--- a/lib/models/pricing_phase_wrapper.g.dart
+++ b/lib/models/pricing_phase_wrapper.g.dart
@@ -14,6 +14,7 @@ _$_PricingPhase _$$_PricingPhaseFromJson(Map json) => _$_PricingPhase(
       $enumDecodeNullable(_$RecurrenceModeEnumMap, json['recurrenceMode']),
       json['billingCycleCount'] as int?,
       Price.fromJson(Map<String, dynamic>.from(json['price'] as Map)),
+      $enumDecodeNullable(_$OfferPaymentModeEnumMap, json['offerPaymentMode']),
     );
 
 Map<String, dynamic> _$$_PricingPhaseToJson(_$_PricingPhase instance) =>
@@ -22,6 +23,7 @@ Map<String, dynamic> _$$_PricingPhaseToJson(_$_PricingPhase instance) =>
       'recurrenceMode': _$RecurrenceModeEnumMap[instance.recurrenceMode],
       'billingCycleCount': instance.billingCycleCount,
       'price': instance.price.toJson(),
+      'offerPaymentMode': _$OfferPaymentModeEnumMap[instance.offerPaymentMode],
     };
 
 const _$RecurrenceModeEnumMap = {
@@ -29,4 +31,10 @@ const _$RecurrenceModeEnumMap = {
   RecurrenceMode.finiteRecurring: 2,
   RecurrenceMode.nonRecurring: 3,
   RecurrenceMode.unknown: null,
+};
+
+const _$OfferPaymentModeEnumMap = {
+  OfferPaymentMode.freeTrial: 'FREE_TRIAL',
+  OfferPaymentMode.singlePayment: 'SINGLE_PAYMENT',
+  OfferPaymentMode.discountedRecurringPayment: 'DISCOUNTED_RECURRING_PAYMENT',
 };

--- a/lib/models/store_product_wrapper.dart
+++ b/lib/models/store_product_wrapper.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import '../product_type.dart';
 import 'introductory_price.dart';
 import 'store_product_discount.dart';
 import 'subscription_option_wrapper.dart';
@@ -29,7 +30,6 @@ class StoreProduct with _$StoreProduct {
 
     /// Currency code for price and original price.
     @JsonKey(name: 'currencyCode') String currencyCode, {
-
     /// Introductory price for product. Can be null.
     @JsonKey(name: 'introPrice', nullable: true)
         IntroductoryPrice? introductoryPrice,
@@ -38,13 +38,21 @@ class StoreProduct with _$StoreProduct {
     @JsonKey(name: 'discounts', nullable: true)
         List<StoreProductDiscount>? discounts,
 
-    // Default subscription option for a product. Google Play only.
+    /// Product type. Null for iOS.
+    @JsonKey(name: 'productCategory', nullable: true) ProductType? productType,
+
+    /// Default subscription option for a product. Google Play only.
     @JsonKey(name: 'defaultOption', nullable: true)
         SubscriptionOption? defaultOption,
 
-    // Collection of subscription options for a product. Google Play only.
+    /// Collection of subscription options for a product. Google Play only.
     @JsonKey(name: 'subscriptionOptions', nullable: true)
         List<SubscriptionOption>? subscriptionOptions,
+
+    /// Offering identifier the store product was presented from
+    /// Null if not using offerings or if fetched directly from store via getProducts
+    @JsonKey(name: 'presentedOfferingIdentifier', nullable: true)
+        String? presentedOfferingIdentifier,
 
     /// Subscription period, specified in ISO 8601 format. For example,
     /// P1W equates to one week, P1M equates to one month,

--- a/lib/models/store_product_wrapper.freezed.dart
+++ b/lib/models/store_product_wrapper.freezed.dart
@@ -52,13 +52,25 @@ mixin _$StoreProduct {
   /// Collection of discount offers for a product. Null for Android.
   @JsonKey(name: 'discounts', nullable: true)
   List<StoreProductDiscount>? get discounts =>
-      throw _privateConstructorUsedError; // Default subscription option for a product. Google Play only.
+      throw _privateConstructorUsedError;
+
+  /// Product type. Null for iOS.
+  @JsonKey(name: 'productCategory', nullable: true)
+  ProductType? get productType => throw _privateConstructorUsedError;
+
+  /// Default subscription option for a product. Google Play only.
   @JsonKey(name: 'defaultOption', nullable: true)
-  SubscriptionOption? get defaultOption =>
-      throw _privateConstructorUsedError; // Collection of subscription options for a product. Google Play only.
+  SubscriptionOption? get defaultOption => throw _privateConstructorUsedError;
+
+  /// Collection of subscription options for a product. Google Play only.
   @JsonKey(name: 'subscriptionOptions', nullable: true)
   List<SubscriptionOption>? get subscriptionOptions =>
       throw _privateConstructorUsedError;
+
+  /// Offering identifier the store product was presented from
+  /// Null if not using offerings or if fetched directly from store via getProducts
+  @JsonKey(name: 'presentedOfferingIdentifier', nullable: true)
+  String? get presentedOfferingIdentifier => throw _privateConstructorUsedError;
 
   /// Subscription period, specified in ISO 8601 format. For example,
   /// P1W equates to one week, P1M equates to one month,
@@ -97,10 +109,14 @@ abstract class $StoreProductCopyWith<$Res> {
           IntroductoryPrice? introductoryPrice,
       @JsonKey(name: 'discounts', nullable: true)
           List<StoreProductDiscount>? discounts,
+      @JsonKey(name: 'productCategory', nullable: true)
+          ProductType? productType,
       @JsonKey(name: 'defaultOption', nullable: true)
           SubscriptionOption? defaultOption,
       @JsonKey(name: 'subscriptionOptions', nullable: true)
           List<SubscriptionOption>? subscriptionOptions,
+      @JsonKey(name: 'presentedOfferingIdentifier', nullable: true)
+          String? presentedOfferingIdentifier,
       @JsonKey(name: 'subscriptionPeriod', nullable: true)
           String? subscriptionPeriod});
 
@@ -129,8 +145,10 @@ class _$StoreProductCopyWithImpl<$Res, $Val extends StoreProduct>
     Object? currencyCode = null,
     Object? introductoryPrice = freezed,
     Object? discounts = freezed,
+    Object? productType = freezed,
     Object? defaultOption = freezed,
     Object? subscriptionOptions = freezed,
+    Object? presentedOfferingIdentifier = freezed,
     Object? subscriptionPeriod = freezed,
   }) {
     return _then(_value.copyWith(
@@ -166,6 +184,10 @@ class _$StoreProductCopyWithImpl<$Res, $Val extends StoreProduct>
           ? _value.discounts
           : discounts // ignore: cast_nullable_to_non_nullable
               as List<StoreProductDiscount>?,
+      productType: freezed == productType
+          ? _value.productType
+          : productType // ignore: cast_nullable_to_non_nullable
+              as ProductType?,
       defaultOption: freezed == defaultOption
           ? _value.defaultOption
           : defaultOption // ignore: cast_nullable_to_non_nullable
@@ -174,6 +196,10 @@ class _$StoreProductCopyWithImpl<$Res, $Val extends StoreProduct>
           ? _value.subscriptionOptions
           : subscriptionOptions // ignore: cast_nullable_to_non_nullable
               as List<SubscriptionOption>?,
+      presentedOfferingIdentifier: freezed == presentedOfferingIdentifier
+          ? _value.presentedOfferingIdentifier
+          : presentedOfferingIdentifier // ignore: cast_nullable_to_non_nullable
+              as String?,
       subscriptionPeriod: freezed == subscriptionPeriod
           ? _value.subscriptionPeriod
           : subscriptionPeriod // ignore: cast_nullable_to_non_nullable
@@ -231,10 +257,14 @@ abstract class _$$_StoreProductCopyWith<$Res>
           IntroductoryPrice? introductoryPrice,
       @JsonKey(name: 'discounts', nullable: true)
           List<StoreProductDiscount>? discounts,
+      @JsonKey(name: 'productCategory', nullable: true)
+          ProductType? productType,
       @JsonKey(name: 'defaultOption', nullable: true)
           SubscriptionOption? defaultOption,
       @JsonKey(name: 'subscriptionOptions', nullable: true)
           List<SubscriptionOption>? subscriptionOptions,
+      @JsonKey(name: 'presentedOfferingIdentifier', nullable: true)
+          String? presentedOfferingIdentifier,
       @JsonKey(name: 'subscriptionPeriod', nullable: true)
           String? subscriptionPeriod});
 
@@ -263,8 +293,10 @@ class __$$_StoreProductCopyWithImpl<$Res>
     Object? currencyCode = null,
     Object? introductoryPrice = freezed,
     Object? discounts = freezed,
+    Object? productType = freezed,
     Object? defaultOption = freezed,
     Object? subscriptionOptions = freezed,
+    Object? presentedOfferingIdentifier = freezed,
     Object? subscriptionPeriod = freezed,
   }) {
     return _then(_$_StoreProduct(
@@ -300,6 +332,10 @@ class __$$_StoreProductCopyWithImpl<$Res>
           ? _value._discounts
           : discounts // ignore: cast_nullable_to_non_nullable
               as List<StoreProductDiscount>?,
+      productType: freezed == productType
+          ? _value.productType
+          : productType // ignore: cast_nullable_to_non_nullable
+              as ProductType?,
       defaultOption: freezed == defaultOption
           ? _value.defaultOption
           : defaultOption // ignore: cast_nullable_to_non_nullable
@@ -308,6 +344,10 @@ class __$$_StoreProductCopyWithImpl<$Res>
           ? _value._subscriptionOptions
           : subscriptionOptions // ignore: cast_nullable_to_non_nullable
               as List<SubscriptionOption>?,
+      presentedOfferingIdentifier: freezed == presentedOfferingIdentifier
+          ? _value.presentedOfferingIdentifier
+          : presentedOfferingIdentifier // ignore: cast_nullable_to_non_nullable
+              as String?,
       subscriptionPeriod: freezed == subscriptionPeriod
           ? _value.subscriptionPeriod
           : subscriptionPeriod // ignore: cast_nullable_to_non_nullable
@@ -336,10 +376,14 @@ class _$_StoreProduct implements _StoreProduct {
           this.introductoryPrice,
       @JsonKey(name: 'discounts', nullable: true)
           final List<StoreProductDiscount>? discounts,
+      @JsonKey(name: 'productCategory', nullable: true)
+          this.productType,
       @JsonKey(name: 'defaultOption', nullable: true)
           this.defaultOption,
       @JsonKey(name: 'subscriptionOptions', nullable: true)
           final List<SubscriptionOption>? subscriptionOptions,
+      @JsonKey(name: 'presentedOfferingIdentifier', nullable: true)
+          this.presentedOfferingIdentifier,
       @JsonKey(name: 'subscriptionPeriod', nullable: true)
           this.subscriptionPeriod})
       : _discounts = discounts,
@@ -397,13 +441,20 @@ class _$_StoreProduct implements _StoreProduct {
     return EqualUnmodifiableListView(value);
   }
 
-// Default subscription option for a product. Google Play only.
+  /// Product type. Null for iOS.
+  @override
+  @JsonKey(name: 'productCategory', nullable: true)
+  final ProductType? productType;
+
+  /// Default subscription option for a product. Google Play only.
   @override
   @JsonKey(name: 'defaultOption', nullable: true)
   final SubscriptionOption? defaultOption;
-// Collection of subscription options for a product. Google Play only.
+
+  /// Collection of subscription options for a product. Google Play only.
   final List<SubscriptionOption>? _subscriptionOptions;
-// Collection of subscription options for a product. Google Play only.
+
+  /// Collection of subscription options for a product. Google Play only.
   @override
   @JsonKey(name: 'subscriptionOptions', nullable: true)
   List<SubscriptionOption>? get subscriptionOptions {
@@ -414,6 +465,12 @@ class _$_StoreProduct implements _StoreProduct {
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(value);
   }
+
+  /// Offering identifier the store product was presented from
+  /// Null if not using offerings or if fetched directly from store via getProducts
+  @override
+  @JsonKey(name: 'presentedOfferingIdentifier', nullable: true)
+  final String? presentedOfferingIdentifier;
 
   /// Subscription period, specified in ISO 8601 format. For example,
   /// P1W equates to one week, P1M equates to one month,
@@ -426,7 +483,7 @@ class _$_StoreProduct implements _StoreProduct {
 
   @override
   String toString() {
-    return 'StoreProduct(identifier: $identifier, description: $description, title: $title, price: $price, priceString: $priceString, currencyCode: $currencyCode, introductoryPrice: $introductoryPrice, discounts: $discounts, defaultOption: $defaultOption, subscriptionOptions: $subscriptionOptions, subscriptionPeriod: $subscriptionPeriod)';
+    return 'StoreProduct(identifier: $identifier, description: $description, title: $title, price: $price, priceString: $priceString, currencyCode: $currencyCode, introductoryPrice: $introductoryPrice, discounts: $discounts, productType: $productType, defaultOption: $defaultOption, subscriptionOptions: $subscriptionOptions, presentedOfferingIdentifier: $presentedOfferingIdentifier, subscriptionPeriod: $subscriptionPeriod)';
   }
 
   @override
@@ -448,10 +505,16 @@ class _$_StoreProduct implements _StoreProduct {
                 other.introductoryPrice == introductoryPrice) &&
             const DeepCollectionEquality()
                 .equals(other._discounts, _discounts) &&
+            (identical(other.productType, productType) ||
+                other.productType == productType) &&
             (identical(other.defaultOption, defaultOption) ||
                 other.defaultOption == defaultOption) &&
             const DeepCollectionEquality()
                 .equals(other._subscriptionOptions, _subscriptionOptions) &&
+            (identical(other.presentedOfferingIdentifier,
+                    presentedOfferingIdentifier) ||
+                other.presentedOfferingIdentifier ==
+                    presentedOfferingIdentifier) &&
             (identical(other.subscriptionPeriod, subscriptionPeriod) ||
                 other.subscriptionPeriod == subscriptionPeriod));
   }
@@ -468,8 +531,10 @@ class _$_StoreProduct implements _StoreProduct {
       currencyCode,
       introductoryPrice,
       const DeepCollectionEquality().hash(_discounts),
+      productType,
       defaultOption,
       const DeepCollectionEquality().hash(_subscriptionOptions),
+      presentedOfferingIdentifier,
       subscriptionPeriod);
 
   @JsonKey(ignore: true)
@@ -504,10 +569,14 @@ abstract class _StoreProduct implements StoreProduct {
           final IntroductoryPrice? introductoryPrice,
       @JsonKey(name: 'discounts', nullable: true)
           final List<StoreProductDiscount>? discounts,
+      @JsonKey(name: 'productCategory', nullable: true)
+          final ProductType? productType,
       @JsonKey(name: 'defaultOption', nullable: true)
           final SubscriptionOption? defaultOption,
       @JsonKey(name: 'subscriptionOptions', nullable: true)
           final List<SubscriptionOption>? subscriptionOptions,
+      @JsonKey(name: 'presentedOfferingIdentifier', nullable: true)
+          final String? presentedOfferingIdentifier,
       @JsonKey(name: 'subscriptionPeriod', nullable: true)
           final String? subscriptionPeriod}) = _$_StoreProduct;
 
@@ -554,12 +623,27 @@ abstract class _StoreProduct implements StoreProduct {
   /// Collection of discount offers for a product. Null for Android.
   @JsonKey(name: 'discounts', nullable: true)
   List<StoreProductDiscount>? get discounts;
-  @override // Default subscription option for a product. Google Play only.
+  @override
+
+  /// Product type. Null for iOS.
+  @JsonKey(name: 'productCategory', nullable: true)
+  ProductType? get productType;
+  @override
+
+  /// Default subscription option for a product. Google Play only.
   @JsonKey(name: 'defaultOption', nullable: true)
   SubscriptionOption? get defaultOption;
-  @override // Collection of subscription options for a product. Google Play only.
+  @override
+
+  /// Collection of subscription options for a product. Google Play only.
   @JsonKey(name: 'subscriptionOptions', nullable: true)
   List<SubscriptionOption>? get subscriptionOptions;
+  @override
+
+  /// Offering identifier the store product was presented from
+  /// Null if not using offerings or if fetched directly from store via getProducts
+  @JsonKey(name: 'presentedOfferingIdentifier', nullable: true)
+  String? get presentedOfferingIdentifier;
   @override
 
   /// Subscription period, specified in ISO 8601 format. For example,

--- a/lib/models/store_product_wrapper.g.dart
+++ b/lib/models/store_product_wrapper.g.dart
@@ -21,6 +21,8 @@ _$_StoreProduct _$$_StoreProductFromJson(Map json) => _$_StoreProduct(
           ?.map((e) => StoreProductDiscount.fromJson(
               Map<String, dynamic>.from(e as Map)))
           .toList(),
+      productType:
+          $enumDecodeNullable(_$ProductTypeEnumMap, json['productCategory']),
       defaultOption: json['defaultOption'] == null
           ? null
           : SubscriptionOption.fromJson(
@@ -29,6 +31,8 @@ _$_StoreProduct _$$_StoreProductFromJson(Map json) => _$_StoreProduct(
           ?.map((e) =>
               SubscriptionOption.fromJson(Map<String, dynamic>.from(e as Map)))
           .toList(),
+      presentedOfferingIdentifier:
+          json['presentedOfferingIdentifier'] as String?,
       subscriptionPeriod: json['subscriptionPeriod'] as String?,
     );
 
@@ -42,8 +46,15 @@ Map<String, dynamic> _$$_StoreProductToJson(_$_StoreProduct instance) =>
       'currencyCode': instance.currencyCode,
       'introPrice': instance.introductoryPrice?.toJson(),
       'discounts': instance.discounts?.map((e) => e.toJson()).toList(),
+      'productCategory': _$ProductTypeEnumMap[instance.productType],
       'defaultOption': instance.defaultOption?.toJson(),
       'subscriptionOptions':
           instance.subscriptionOptions?.map((e) => e.toJson()).toList(),
+      'presentedOfferingIdentifier': instance.presentedOfferingIdentifier,
       'subscriptionPeriod': instance.subscriptionPeriod,
     };
+
+const _$ProductTypeEnumMap = {
+  ProductType.inapp: 'NON_SUBSCRIPTION',
+  ProductType.subs: 'SUBSCRIPTION',
+};

--- a/lib/models/subscription_option_wrapper.dart
+++ b/lib/models/subscription_option_wrapper.dart
@@ -52,6 +52,10 @@ class SubscriptionOption with _$SubscriptionOption {
     /// Looks for the first pricing phase of the SubscriptionOption where amountMicros is greater than 0.
     /// There can be a freeTrialPhase and an introductoryPhase in the same SubscriptionOption.
     @JsonKey(name: 'introPhase', nullable: true) PricingPhase? introPhase,
+
+    // Offering identifier the subscriptioni option was presented from
+    @JsonKey(name: 'presentedOfferingIdentifier', nullable: true)
+        String? presentedOfferingIdentifier,
   ) = _SubscriptionOption;
 
   factory SubscriptionOption.fromJson(Map<String, dynamic> json) =>

--- a/lib/models/subscription_option_wrapper.freezed.dart
+++ b/lib/models/subscription_option_wrapper.freezed.dart
@@ -68,7 +68,10 @@ mixin _$SubscriptionOption {
   /// Looks for the first pricing phase of the SubscriptionOption where amountMicros is greater than 0.
   /// There can be a freeTrialPhase and an introductoryPhase in the same SubscriptionOption.
   @JsonKey(name: 'introPhase', nullable: true)
-  PricingPhase? get introPhase => throw _privateConstructorUsedError;
+  PricingPhase? get introPhase =>
+      throw _privateConstructorUsedError; // Offering identifier the subscriptioni option was presented from
+  @JsonKey(name: 'presentedOfferingIdentifier', nullable: true)
+  String? get presentedOfferingIdentifier => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -102,7 +105,9 @@ abstract class $SubscriptionOptionCopyWith<$Res> {
       @JsonKey(name: 'freePhase', nullable: true)
           PricingPhase? freePhase,
       @JsonKey(name: 'introPhase', nullable: true)
-          PricingPhase? introPhase});
+          PricingPhase? introPhase,
+      @JsonKey(name: 'presentedOfferingIdentifier', nullable: true)
+          String? presentedOfferingIdentifier});
 
   $PeriodCopyWith<$Res>? get billingPeriod;
   $PricingPhaseCopyWith<$Res>? get fullPricePhase;
@@ -133,6 +138,7 @@ class _$SubscriptionOptionCopyWithImpl<$Res, $Val extends SubscriptionOption>
     Object? fullPricePhase = freezed,
     Object? freePhase = freezed,
     Object? introPhase = freezed,
+    Object? presentedOfferingIdentifier = freezed,
   }) {
     return _then(_value.copyWith(
       id: null == id
@@ -175,6 +181,10 @@ class _$SubscriptionOptionCopyWithImpl<$Res, $Val extends SubscriptionOption>
           ? _value.introPhase
           : introPhase // ignore: cast_nullable_to_non_nullable
               as PricingPhase?,
+      presentedOfferingIdentifier: freezed == presentedOfferingIdentifier
+          ? _value.presentedOfferingIdentifier
+          : presentedOfferingIdentifier // ignore: cast_nullable_to_non_nullable
+              as String?,
     ) as $Val);
   }
 
@@ -255,7 +265,9 @@ abstract class _$$_SubscriptionOptionCopyWith<$Res>
       @JsonKey(name: 'freePhase', nullable: true)
           PricingPhase? freePhase,
       @JsonKey(name: 'introPhase', nullable: true)
-          PricingPhase? introPhase});
+          PricingPhase? introPhase,
+      @JsonKey(name: 'presentedOfferingIdentifier', nullable: true)
+          String? presentedOfferingIdentifier});
 
   @override
   $PeriodCopyWith<$Res>? get billingPeriod;
@@ -288,6 +300,7 @@ class __$$_SubscriptionOptionCopyWithImpl<$Res>
     Object? fullPricePhase = freezed,
     Object? freePhase = freezed,
     Object? introPhase = freezed,
+    Object? presentedOfferingIdentifier = freezed,
   }) {
     return _then(_$_SubscriptionOption(
       null == id
@@ -330,6 +343,10 @@ class __$$_SubscriptionOptionCopyWithImpl<$Res>
           ? _value.introPhase
           : introPhase // ignore: cast_nullable_to_non_nullable
               as PricingPhase?,
+      freezed == presentedOfferingIdentifier
+          ? _value.presentedOfferingIdentifier
+          : presentedOfferingIdentifier // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 }
@@ -338,16 +355,28 @@ class __$$_SubscriptionOptionCopyWithImpl<$Res>
 @JsonSerializable()
 class _$_SubscriptionOption implements _SubscriptionOption {
   const _$_SubscriptionOption(
-      @JsonKey(name: 'id') this.id,
-      @JsonKey(name: 'storeProductId') this.storeProductId,
-      @JsonKey(name: 'productId') this.productId,
-      @JsonKey(name: 'pricingPhases') final List<PricingPhase> pricingPhases,
-      @JsonKey(name: 'tags') final List<String> tags,
-      @JsonKey(name: 'isBasePlan') this.isBasePlan,
-      @JsonKey(name: 'billingPeriod', nullable: true) this.billingPeriod,
-      @JsonKey(name: 'fullPricePhase', nullable: true) this.fullPricePhase,
-      @JsonKey(name: 'freePhase', nullable: true) this.freePhase,
-      @JsonKey(name: 'introPhase', nullable: true) this.introPhase)
+      @JsonKey(name: 'id')
+          this.id,
+      @JsonKey(name: 'storeProductId')
+          this.storeProductId,
+      @JsonKey(name: 'productId')
+          this.productId,
+      @JsonKey(name: 'pricingPhases')
+          final List<PricingPhase> pricingPhases,
+      @JsonKey(name: 'tags')
+          final List<String> tags,
+      @JsonKey(name: 'isBasePlan')
+          this.isBasePlan,
+      @JsonKey(name: 'billingPeriod', nullable: true)
+          this.billingPeriod,
+      @JsonKey(name: 'fullPricePhase', nullable: true)
+          this.fullPricePhase,
+      @JsonKey(name: 'freePhase', nullable: true)
+          this.freePhase,
+      @JsonKey(name: 'introPhase', nullable: true)
+          this.introPhase,
+      @JsonKey(name: 'presentedOfferingIdentifier', nullable: true)
+          this.presentedOfferingIdentifier)
       : _pricingPhases = pricingPhases,
         _tags = tags;
 
@@ -427,10 +456,14 @@ class _$_SubscriptionOption implements _SubscriptionOption {
   @override
   @JsonKey(name: 'introPhase', nullable: true)
   final PricingPhase? introPhase;
+// Offering identifier the subscriptioni option was presented from
+  @override
+  @JsonKey(name: 'presentedOfferingIdentifier', nullable: true)
+  final String? presentedOfferingIdentifier;
 
   @override
   String toString() {
-    return 'SubscriptionOption(id: $id, storeProductId: $storeProductId, productId: $productId, pricingPhases: $pricingPhases, tags: $tags, isBasePlan: $isBasePlan, billingPeriod: $billingPeriod, fullPricePhase: $fullPricePhase, freePhase: $freePhase, introPhase: $introPhase)';
+    return 'SubscriptionOption(id: $id, storeProductId: $storeProductId, productId: $productId, pricingPhases: $pricingPhases, tags: $tags, isBasePlan: $isBasePlan, billingPeriod: $billingPeriod, fullPricePhase: $fullPricePhase, freePhase: $freePhase, introPhase: $introPhase, presentedOfferingIdentifier: $presentedOfferingIdentifier)';
   }
 
   @override
@@ -455,7 +488,11 @@ class _$_SubscriptionOption implements _SubscriptionOption {
             (identical(other.freePhase, freePhase) ||
                 other.freePhase == freePhase) &&
             (identical(other.introPhase, introPhase) ||
-                other.introPhase == introPhase));
+                other.introPhase == introPhase) &&
+            (identical(other.presentedOfferingIdentifier,
+                    presentedOfferingIdentifier) ||
+                other.presentedOfferingIdentifier ==
+                    presentedOfferingIdentifier));
   }
 
   @JsonKey(ignore: true)
@@ -471,7 +508,8 @@ class _$_SubscriptionOption implements _SubscriptionOption {
       billingPeriod,
       fullPricePhase,
       freePhase,
-      introPhase);
+      introPhase,
+      presentedOfferingIdentifier);
 
   @JsonKey(ignore: true)
   @override
@@ -509,7 +547,9 @@ abstract class _SubscriptionOption implements SubscriptionOption {
       @JsonKey(name: 'freePhase', nullable: true)
           final PricingPhase? freePhase,
       @JsonKey(name: 'introPhase', nullable: true)
-          final PricingPhase? introPhase) = _$_SubscriptionOption;
+          final PricingPhase? introPhase,
+      @JsonKey(name: 'presentedOfferingIdentifier', nullable: true)
+          final String? presentedOfferingIdentifier) = _$_SubscriptionOption;
 
   factory _SubscriptionOption.fromJson(Map<String, dynamic> json) =
       _$_SubscriptionOption.fromJson;
@@ -574,6 +614,9 @@ abstract class _SubscriptionOption implements SubscriptionOption {
   /// There can be a freeTrialPhase and an introductoryPhase in the same SubscriptionOption.
   @JsonKey(name: 'introPhase', nullable: true)
   PricingPhase? get introPhase;
+  @override // Offering identifier the subscriptioni option was presented from
+  @JsonKey(name: 'presentedOfferingIdentifier', nullable: true)
+  String? get presentedOfferingIdentifier;
   @override
   @JsonKey(ignore: true)
   _$$_SubscriptionOptionCopyWith<_$_SubscriptionOption> get copyWith =>

--- a/lib/models/subscription_option_wrapper.g.dart
+++ b/lib/models/subscription_option_wrapper.g.dart
@@ -33,6 +33,7 @@ _$_SubscriptionOption _$$_SubscriptionOptionFromJson(Map json) =>
           ? null
           : PricingPhase.fromJson(
               Map<String, dynamic>.from(json['introPhase'] as Map)),
+      json['presentedOfferingIdentifier'] as String?,
     );
 
 Map<String, dynamic> _$$_SubscriptionOptionToJson(
@@ -48,4 +49,5 @@ Map<String, dynamic> _$$_SubscriptionOptionToJson(
       'fullPricePhase': instance.fullPricePhase?.toJson(),
       'freePhase': instance.freePhase?.toJson(),
       'introPhase': instance.introPhase?.toJson(),
+      'presentedOfferingIdentifier': instance.presentedOfferingIdentifier,
     };

--- a/lib/object_wrappers.dart
+++ b/lib/object_wrappers.dart
@@ -1,4 +1,5 @@
 export 'errors.dart';
+export 'google_product_change.dart';
 export 'models/customer_info_wrapper.dart';
 export 'models/entitlement_info_wrapper.dart';
 export 'models/entitlement_infos_wrapper.dart';
@@ -16,3 +17,4 @@ export 'models/store_product_discount.dart';
 export 'models/store_product_wrapper.dart';
 export 'models/store_transaction.dart';
 export 'models/subscription_option_wrapper.dart';
+export 'upgrade_info.dart';

--- a/lib/object_wrappers.dart
+++ b/lib/object_wrappers.dart
@@ -17,4 +17,5 @@ export 'models/store_product_discount.dart';
 export 'models/store_product_wrapper.dart';
 export 'models/store_transaction.dart';
 export 'models/subscription_option_wrapper.dart';
+export 'product_type.dart';
 export 'upgrade_info.dart';

--- a/lib/product_type.dart
+++ b/lib/product_type.dart
@@ -1,0 +1,22 @@
+import 'package:json_annotation/json_annotation.dart';
+
+/// Supported [StoreProduct] types.
+enum ProductType {
+  /// A type of [StoreProduct] for in-app products.
+  @JsonValue('NON_SUBSCRIPTION')
+  inapp,
+
+  /// A type of [StoreProduct] for subscriptions.
+  @JsonValue('SUBSCRIPTION')
+  subs
+}
+
+/// Supported SKU types.
+@Deprecated('Use ProductType')
+enum PurchaseType {
+  /// A type of SKU for in-app products.
+  inapp,
+
+  /// A type of SKU for subscriptions.
+  subs
+}

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -302,8 +302,8 @@ class Purchases {
     final customerInfo = await _invokeReturningCustomerInfo('purchaseProduct', {
       'productIdentifier': productIdentifier,
       'type': describeEnum(type),
-      'googleOldProductIdentifer':
-          googleProductChangeInfo?.oldProductIdentifer ?? upgradeInfo?.oldSKU,
+      'googleOldProductIdentifier':
+          googleProductChangeInfo?.oldProductIdentifier ?? upgradeInfo?.oldSKU,
       'googleProrationMode': prorationMode?.index,
       'googleIsPersonalizedPrice': googleIsPersonalizedPrice,
     });
@@ -342,8 +342,8 @@ class Purchases {
     final customerInfo = await _invokeReturningCustomerInfo('purchasePackage', {
       'packageIdentifier': packageToPurchase.identifier,
       'offeringIdentifier': packageToPurchase.offeringIdentifier,
-      'googleOldProductIdentifer':
-          googleProductChangeInfo?.oldProductIdentifer ?? upgradeInfo?.oldSKU,
+      'googleOldProductIdentifier':
+          googleProductChangeInfo?.oldProductIdentifier ?? upgradeInfo?.oldSKU,
       'googleProrationMode': prorationMode?.index,
       'googleIsPersonalizedPrice': googleIsPersonalizedPrice,
     });
@@ -384,7 +384,8 @@ class Purchases {
         await _invokeReturningCustomerInfo('purchaseSubscriptionOption', {
       'productIdentifier': subscriptionOption.productId,
       'optionIdentifier': subscriptionOption.id,
-      'googleOldProductIdentifer': googleProductChangeInfo?.oldProductIdentifer,
+      'googleOldProductIdentifier':
+          googleProductChangeInfo?.oldProductIdentifier,
       'googleProrationMode': prorationMode?.index,
       'googleIsPersonalizedPrice': googleIsPersonalizedPrice,
     });

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -288,12 +288,13 @@ class Purchases {
   /// for more info.
   static Future<CustomerInfo> purchaseProduct(
     String productIdentifier, {
-    UpgradeInfo? upgradeInfo,
+    @Deprecated('Use ProductChangeInfo') UpgradeInfo? upgradeInfo,
     ProductChangeInfo? productChangeInfo,
     PurchaseType type = PurchaseType.subs,
     bool? isPersonalizedPrice,
   }) async {
-    final prorationMode = upgradeInfo?.prorationMode;
+    final prorationMode =
+        productChangeInfo?.prorationMode ?? upgradeInfo?.prorationMode;
     final customerInfo = await _invokeReturningCustomerInfo('purchaseProduct', {
       'productIdentifier': productIdentifier,
       'oldProductIdentifer':
@@ -328,11 +329,12 @@ class Purchases {
   /// for more info.
   static Future<CustomerInfo> purchasePackage(
     Package packageToPurchase, {
-    UpgradeInfo? upgradeInfo,
+    @Deprecated('Use ProductChangeInfo') UpgradeInfo? upgradeInfo,
     ProductChangeInfo? productChangeInfo,
     bool? isPersonalizedPrice,
   }) async {
-    final prorationMode = upgradeInfo?.prorationMode;
+    final prorationMode =
+        productChangeInfo?.prorationMode ?? upgradeInfo?.prorationMode;
     final customerInfo = await _invokeReturningCustomerInfo('purchasePackage', {
       'packageIdentifier': packageToPurchase.identifier,
       'offeringIdentifier': packageToPurchase.offeringIdentifier,
@@ -354,9 +356,6 @@ class Purchases {
   ///
   /// [packageToPurchase] The Package you wish to purchase
   ///
-  /// [upgradeInfo] Android only. Optional UpgradeInfo you wish to upgrade from
-  /// containing the oldSKU and the optional prorationMode.
-  ///
   /// [productChangeInfo] Android only. Optional ProductChangeInfo you wish to
   /// change from containing the oldProductIdentifer and the
   /// optional prorationMode.
@@ -369,7 +368,6 @@ class Purchases {
   /// for more info.
   static Future<CustomerInfo> purchaseSubscriptionOption(
     SubscriptionOption subscriptionOption, {
-    UpgradeInfo? upgradeInfo,
     ProductChangeInfo? productChangeInfo,
     bool? isPersonalizedPrice,
   }) async {
@@ -377,13 +375,12 @@ class Purchases {
       throw UnsupportedPlatformException();
     }
 
-    final prorationMode = upgradeInfo?.prorationMode;
+    final prorationMode = productChangeInfo?.prorationMode;
     final customerInfo =
         await _invokeReturningCustomerInfo('purchaseSubscriptionOption', {
       'productIdentifier': subscriptionOption.productId,
       'optionIdentifier': subscriptionOption.id,
-      'oldProductIdentifer':
-          productChangeInfo?.oldProductIdentifer ?? upgradeInfo?.oldSKU,
+      'oldProductIdentifer': productChangeInfo?.oldProductIdentifer,
       'prorationMode': prorationMode?.index,
       'isPersonalizedPrice': isPersonalizedPrice,
     });
@@ -986,6 +983,7 @@ class UpgradeInfo {
   ProrationMode? prorationMode;
 
   /// Constructs an UpgradeInfo
+  @Deprecated('Use ProductChangeInfo')
   UpgradeInfo(this.oldSKU, {this.prorationMode});
 }
 

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -272,6 +272,10 @@ class Purchases {
   /// [upgradeInfo] Android only. Optional UpgradeInfo you wish to upgrade from
   /// containing the oldSKU and the optional prorationMode.
   ///
+  /// [productChangeInfo] Android only. Optional ProductChangeInfo you wish to
+  /// change from containing the oldProductIdentifer and the
+  /// optional prorationMode.
+  ///
   /// [type] If the product is an Android INAPP, this needs to be
   /// PurchaseType.INAPP otherwise the product won't be found.
   /// PurchaseType.Subs by default. This parameter only has effect in Android.
@@ -285,13 +289,15 @@ class Purchases {
   static Future<CustomerInfo> purchaseProduct(
     String productIdentifier, {
     UpgradeInfo? upgradeInfo,
+    ProductChangeInfo? productChangeInfo,
     PurchaseType type = PurchaseType.subs,
     bool? isPersonalizedPrice,
   }) async {
     final prorationMode = upgradeInfo?.prorationMode;
     final customerInfo = await _invokeReturningCustomerInfo('purchaseProduct', {
       'productIdentifier': productIdentifier,
-      'oldSKU': upgradeInfo?.oldSKU,
+      'oldProductIdentifer':
+          productChangeInfo?.oldProductIdentifer ?? upgradeInfo?.oldSKU,
       'prorationMode': prorationMode?.index,
       'type': describeEnum(type),
       'isPersonalizedPrice': isPersonalizedPrice,
@@ -310,6 +316,10 @@ class Purchases {
   /// [upgradeInfo] Android only. Optional UpgradeInfo you wish to upgrade from
   /// containing the oldSKU and the optional prorationMode.
   ///
+  /// [productChangeInfo] Android only. Optional ProductChangeInfo you wish to
+  /// change from containing the oldProductIdentifer and the
+  /// optional prorationMode.
+  ///
   /// [isPersonalizedPrice] Android only. Optional isPersonalizedPrice indicates
   /// personalized pricing on products available for purchase in the EU.
   /// For compliance with EU regulations. User will see "This price has been
@@ -319,13 +329,15 @@ class Purchases {
   static Future<CustomerInfo> purchasePackage(
     Package packageToPurchase, {
     UpgradeInfo? upgradeInfo,
+    ProductChangeInfo? productChangeInfo,
     bool? isPersonalizedPrice,
   }) async {
     final prorationMode = upgradeInfo?.prorationMode;
     final customerInfo = await _invokeReturningCustomerInfo('purchasePackage', {
       'packageIdentifier': packageToPurchase.identifier,
       'offeringIdentifier': packageToPurchase.offeringIdentifier,
-      'oldSKU': upgradeInfo?.oldSKU,
+      'oldProductIdentifer':
+          productChangeInfo?.oldProductIdentifer ?? upgradeInfo?.oldSKU,
       'prorationMode': prorationMode?.index,
       'isPersonalizedPrice': isPersonalizedPrice,
     });
@@ -345,6 +357,10 @@ class Purchases {
   /// [upgradeInfo] Android only. Optional UpgradeInfo you wish to upgrade from
   /// containing the oldSKU and the optional prorationMode.
   ///
+  /// [productChangeInfo] Android only. Optional ProductChangeInfo you wish to
+  /// change from containing the oldProductIdentifer and the
+  /// optional prorationMode.
+  ///
   /// [isPersonalizedPrice] Android only. Optional isPersonalizedPrice indicates
   /// personalized pricing on products available for purchase in the EU.
   /// For compliance with EU regulations. User will see "This price has been
@@ -354,6 +370,7 @@ class Purchases {
   static Future<CustomerInfo> purchaseSubscriptionOption(
     SubscriptionOption subscriptionOption, {
     UpgradeInfo? upgradeInfo,
+    ProductChangeInfo? productChangeInfo,
     bool? isPersonalizedPrice,
   }) async {
     if (defaultTargetPlatform != TargetPlatform.android) {
@@ -365,7 +382,8 @@ class Purchases {
         await _invokeReturningCustomerInfo('purchaseSubscriptionOption', {
       'productIdentifier': subscriptionOption.productId,
       'optionIdentifier': subscriptionOption.id,
-      'oldSKU': upgradeInfo?.oldSKU,
+      'oldProductIdentifer':
+          productChangeInfo?.oldProductIdentifer ?? upgradeInfo?.oldSKU,
       'prorationMode': prorationMode?.index,
       'isPersonalizedPrice': isPersonalizedPrice,
     });
@@ -946,8 +964,20 @@ class Purchases {
   }
 }
 
+class ProductChangeInfo {
+  /// The oldProductIdentifer to change from.
+  String oldProductIdentifer;
+
+  /// The [ProrationMode] to use when changing from the given oldProductIdentifer.
+  ProrationMode? prorationMode;
+
+  /// Constructs an ProductChangeInfo
+  ProductChangeInfo(this.oldProductIdentifer, {this.prorationMode});
+}
+
 /// This class holds the information used when upgrading from another sku.
 /// To be used with purchaseProduct and purchasePackage.
+@Deprecated('Use ProductChangeInfo')
 class UpgradeInfo {
   /// The oldSKU to upgrade from.
   String oldSKU;
@@ -962,29 +992,33 @@ class UpgradeInfo {
 /// Replace SKU's ProrationMode.
 enum ProrationMode {
   /// The Upgrade or Downgrade policy is unknown.
+  @Deprecated('Use a supported ProrationMode')
   unknownSubscriptionUpgradeDowngradePolicy,
 
   /// Replacement takes effect immediately, and the remaining time will be
   /// prorated and credited to the user. This is the current default behavior.
   immediateWithTimeProration,
 
+  // LATER: Reenable when supported by Android V6
   /// Replacement takes effect immediately, and the billing cycle remains the
   /// same. The price for the remaining period will be charged. This option is
   /// only available for subscription upgrade.
-  immediateAndChargeProratedPrice,
+  // immediateAndChargeProratedPrice,
 
   /// Replacement takes effect immediately, and the new price will be charged on
   /// next recurrence time. The billing cycle stays the same.
   immediateWithoutProration,
 
+  // LATER: Reenable when supported by Android V6
   /// Replacement takes effect when the old plan expires, and the new price will
   /// be charged at the same time.
-  deferred,
+  // deferred,
 
+  // LATER: Reenable when supported by Android V6
   /// Replacement takes effect immediately, and the user is charged full price
   /// of new plan and is given a full billing cycle of subscription,
   /// plus remaining prorated time from the old plan.
-  immediateAndChargeFullPrice
+  // immediateAndChargeFullPrice
 }
 
 /// Supported SKU types.

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -3,13 +3,9 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
-import 'google_product_change.dart';
 import 'object_wrappers.dart';
-import 'upgrade_info.dart';
 
-export 'google_product_change.dart';
 export 'object_wrappers.dart';
-export 'upgrade_info.dart';
 
 /// Used to handle async updates from [Purchases].
 /// Should be implemented to receive updates when the [CustomerInfo] changes.

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -297,14 +297,14 @@ class Purchases {
     GoogleProductChangeInfo? googleProductChangeInfo,
     bool? googleIsPersonalizedPrice,
   }) async {
-    final prorationMode =
-        googleProductChangeInfo?.prorationMode ?? upgradeInfo?.prorationMode;
+    final prorationMode = googleProductChangeInfo?.prorationMode?.value ??
+        upgradeInfo?.prorationMode?.index;
     final customerInfo = await _invokeReturningCustomerInfo('purchaseProduct', {
       'productIdentifier': productIdentifier,
       'type': describeEnum(type),
       'googleOldProductIdentifier':
           googleProductChangeInfo?.oldProductIdentifier ?? upgradeInfo?.oldSKU,
-      'googleProrationMode': prorationMode?.index,
+      'googleProrationMode': prorationMode,
       'googleIsPersonalizedPrice': googleIsPersonalizedPrice,
     });
     return customerInfo;
@@ -337,14 +337,14 @@ class Purchases {
     GoogleProductChangeInfo? googleProductChangeInfo,
     bool? googleIsPersonalizedPrice,
   }) async {
-    final prorationMode =
-        googleProductChangeInfo?.prorationMode ?? upgradeInfo?.prorationMode;
+    final prorationMode = googleProductChangeInfo?.prorationMode?.value ??
+        upgradeInfo?.prorationMode?.index;
     final customerInfo = await _invokeReturningCustomerInfo('purchasePackage', {
       'packageIdentifier': packageToPurchase.identifier,
       'offeringIdentifier': packageToPurchase.offeringIdentifier,
       'googleOldProductIdentifier':
           googleProductChangeInfo?.oldProductIdentifier ?? upgradeInfo?.oldSKU,
-      'googleProrationMode': prorationMode?.index,
+      'googleProrationMode': prorationMode,
       'googleIsPersonalizedPrice': googleIsPersonalizedPrice,
     });
     return customerInfo;
@@ -379,14 +379,15 @@ class Purchases {
       throw UnsupportedPlatformException();
     }
 
-    final prorationMode = googleProductChangeInfo?.prorationMode;
+    final prorationMode = googleProductChangeInfo?.prorationMode?.value;
+
     final customerInfo =
         await _invokeReturningCustomerInfo('purchaseSubscriptionOption', {
       'productIdentifier': subscriptionOption.productId,
       'optionIdentifier': subscriptionOption.id,
       'googleOldProductIdentifier':
           googleProductChangeInfo?.oldProductIdentifier,
-      'googleProrationMode': prorationMode?.index,
+      'googleProrationMode': prorationMode,
       'googleIsPersonalizedPrice': googleIsPersonalizedPrice,
     });
     return customerInfo;

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -3,9 +3,13 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
+import 'google_product_change.dart';
 import 'object_wrappers.dart';
+import 'upgrade_info.dart';
 
+export 'google_product_change.dart';
 export 'object_wrappers.dart';
+export 'upgrade_info.dart';
 
 /// Used to handle async updates from [Purchases].
 /// Should be implemented to receive updates when the [CustomerInfo] changes.
@@ -269,18 +273,18 @@ class Purchases {
   /// [productIdentifier] The product identifier of the product you want to
   /// purchase.
   ///
-  /// [upgradeInfo] Android only. Optional UpgradeInfo you wish to upgrade from
+  /// [upgradeInfo] Android and Google Play only. Optional UpgradeInfo you wish to upgrade from
   /// containing the oldSKU and the optional prorationMode.
   ///
-  /// [productChangeInfo] Android only. Optional ProductChangeInfo you wish to
-  /// change from containing the oldProductIdentifer and the
+  /// [googleProductChangeInfo] Android and Google Play only. Optional GoogleProductChangeInfo you wish to
+  /// change from containing the googleOldProductIdentifer and the
   /// optional prorationMode.
   ///
   /// [type] If the product is an Android INAPP, this needs to be
   /// PurchaseType.INAPP otherwise the product won't be found.
   /// PurchaseType.Subs by default. This parameter only has effect in Android.
   ///
-  /// [isPersonalizedPrice] Android only. Optional isPersonalizedPrice indicates
+  /// [googleIsPersonalizedPrice] Android and Google Play only. Optional isPersonalizedPrice indicates
   /// personalized pricing on products available for purchase in the EU.
   /// For compliance with EU regulations. User will see "This price has been
   /// customize for you" in the purchase dialog when true.
@@ -288,20 +292,20 @@ class Purchases {
   /// for more info.
   static Future<CustomerInfo> purchaseProduct(
     String productIdentifier, {
-    @Deprecated('Use ProductChangeInfo') UpgradeInfo? upgradeInfo,
-    ProductChangeInfo? productChangeInfo,
+    @Deprecated('Use GoogleProductChangeInfo') UpgradeInfo? upgradeInfo,
     PurchaseType type = PurchaseType.subs,
-    bool? isPersonalizedPrice,
+    GoogleProductChangeInfo? googleProductChangeInfo,
+    bool? googleIsPersonalizedPrice,
   }) async {
     final prorationMode =
-        productChangeInfo?.prorationMode ?? upgradeInfo?.prorationMode;
+        googleProductChangeInfo?.prorationMode ?? upgradeInfo?.prorationMode;
     final customerInfo = await _invokeReturningCustomerInfo('purchaseProduct', {
       'productIdentifier': productIdentifier,
-      'oldProductIdentifer':
-          productChangeInfo?.oldProductIdentifer ?? upgradeInfo?.oldSKU,
-      'prorationMode': prorationMode?.index,
       'type': describeEnum(type),
-      'isPersonalizedPrice': isPersonalizedPrice,
+      'googleOldProductIdentifer':
+          googleProductChangeInfo?.oldProductIdentifer ?? upgradeInfo?.oldSKU,
+      'googleProrationMode': prorationMode?.index,
+      'googleIsPersonalizedPrice': googleIsPersonalizedPrice,
     });
     return customerInfo;
   }
@@ -314,14 +318,14 @@ class Purchases {
   ///
   /// [packageToPurchase] The Package you wish to purchase
   ///
-  /// [upgradeInfo] Android only. Optional UpgradeInfo you wish to upgrade from
+  /// [upgradeInfo] Android and Google Play only. Optional UpgradeInfo you wish to upgrade from
   /// containing the oldSKU and the optional prorationMode.
   ///
-  /// [productChangeInfo] Android only. Optional ProductChangeInfo you wish to
-  /// change from containing the oldProductIdentifer and the
+  /// [googleProductChangeInfo] Android and Google Play only. Optional GoogleProductChangeInfo you wish to
+  /// change from containing the googleOldProductIdentifer and the
   /// optional prorationMode.
   ///
-  /// [isPersonalizedPrice] Android only. Optional isPersonalizedPrice indicates
+  /// [googleIsPersonalizedPrice] Android and Google Play only. Optional isPersonalizedPrice indicates
   /// personalized pricing on products available for purchase in the EU.
   /// For compliance with EU regulations. User will see "This price has been
   /// customize for you" in the purchase dialog when true.
@@ -329,19 +333,19 @@ class Purchases {
   /// for more info.
   static Future<CustomerInfo> purchasePackage(
     Package packageToPurchase, {
-    @Deprecated('Use ProductChangeInfo') UpgradeInfo? upgradeInfo,
-    ProductChangeInfo? productChangeInfo,
-    bool? isPersonalizedPrice,
+    @Deprecated('Use GoogleProductChangeInfo') UpgradeInfo? upgradeInfo,
+    GoogleProductChangeInfo? googleProductChangeInfo,
+    bool? googleIsPersonalizedPrice,
   }) async {
     final prorationMode =
-        productChangeInfo?.prorationMode ?? upgradeInfo?.prorationMode;
+        googleProductChangeInfo?.prorationMode ?? upgradeInfo?.prorationMode;
     final customerInfo = await _invokeReturningCustomerInfo('purchasePackage', {
       'packageIdentifier': packageToPurchase.identifier,
       'offeringIdentifier': packageToPurchase.offeringIdentifier,
-      'oldProductIdentifer':
-          productChangeInfo?.oldProductIdentifer ?? upgradeInfo?.oldSKU,
-      'prorationMode': prorationMode?.index,
-      'isPersonalizedPrice': isPersonalizedPrice,
+      'googleOldProductIdentifer':
+          googleProductChangeInfo?.oldProductIdentifer ?? upgradeInfo?.oldSKU,
+      'googleProrationMode': prorationMode?.index,
+      'googleIsPersonalizedPrice': googleIsPersonalizedPrice,
     });
     return customerInfo;
   }
@@ -356,11 +360,11 @@ class Purchases {
   ///
   /// [packageToPurchase] The Package you wish to purchase
   ///
-  /// [productChangeInfo] Android only. Optional ProductChangeInfo you wish to
-  /// change from containing the oldProductIdentifer and the
+  /// [googleProductChangeInfo] Android and Google Play only. Optional GoogleProductChangeInfo you wish to
+  /// change from containing the googleOldProductIdentifer and the
   /// optional prorationMode.
   ///
-  /// [isPersonalizedPrice] Android only. Optional isPersonalizedPrice indicates
+  /// [googleIsPersonalizedPrice] Android and Google Play only. Optional isPersonalizedPrice indicates
   /// personalized pricing on products available for purchase in the EU.
   /// For compliance with EU regulations. User will see "This price has been
   /// customize for you" in the purchase dialog when true.
@@ -368,21 +372,21 @@ class Purchases {
   /// for more info.
   static Future<CustomerInfo> purchaseSubscriptionOption(
     SubscriptionOption subscriptionOption, {
-    ProductChangeInfo? productChangeInfo,
-    bool? isPersonalizedPrice,
+    GoogleProductChangeInfo? googleProductChangeInfo,
+    bool? googleIsPersonalizedPrice,
   }) async {
     if (defaultTargetPlatform != TargetPlatform.android) {
       throw UnsupportedPlatformException();
     }
 
-    final prorationMode = productChangeInfo?.prorationMode;
+    final prorationMode = googleProductChangeInfo?.prorationMode;
     final customerInfo =
         await _invokeReturningCustomerInfo('purchaseSubscriptionOption', {
       'productIdentifier': subscriptionOption.productId,
       'optionIdentifier': subscriptionOption.id,
-      'oldProductIdentifer': productChangeInfo?.oldProductIdentifer,
-      'prorationMode': prorationMode?.index,
-      'isPersonalizedPrice': isPersonalizedPrice,
+      'googleOldProductIdentifer': googleProductChangeInfo?.oldProductIdentifer,
+      'googleProrationMode': prorationMode?.index,
+      'googleIsPersonalizedPrice': googleIsPersonalizedPrice,
     });
     return customerInfo;
   }
@@ -959,64 +963,6 @@ class Purchases {
     final response = Map<String, dynamic>.from(result!);
     return response;
   }
-}
-
-class ProductChangeInfo {
-  /// The oldProductIdentifer to change from.
-  String oldProductIdentifer;
-
-  /// The [ProrationMode] to use when changing from the given oldProductIdentifer.
-  ProrationMode? prorationMode;
-
-  /// Constructs an ProductChangeInfo
-  ProductChangeInfo(this.oldProductIdentifer, {this.prorationMode});
-}
-
-/// This class holds the information used when upgrading from another sku.
-/// To be used with purchaseProduct and purchasePackage.
-@Deprecated('Use ProductChangeInfo')
-class UpgradeInfo {
-  /// The oldSKU to upgrade from.
-  String oldSKU;
-
-  /// The [ProrationMode] to use when upgrading the given oldSKU.
-  ProrationMode? prorationMode;
-
-  /// Constructs an UpgradeInfo
-  @Deprecated('Use ProductChangeInfo')
-  UpgradeInfo(this.oldSKU, {this.prorationMode});
-}
-
-/// Replace SKU's ProrationMode.
-enum ProrationMode {
-  /// The Upgrade or Downgrade policy is unknown.
-  @Deprecated('Use a supported ProrationMode')
-  unknownSubscriptionUpgradeDowngradePolicy,
-
-  /// Replacement takes effect immediately, and the remaining time will be
-  /// prorated and credited to the user. This is the current default behavior.
-  immediateWithTimeProration,
-
-  // LATER: Reenable when supported by Android V6
-  /// Replacement takes effect immediately, and the billing cycle remains the
-  /// same. The price for the remaining period will be charged. This option is
-  /// only available for subscription upgrade.
-  // immediateAndChargeProratedPrice,
-
-  /// Replacement takes effect immediately, and the new price will be charged on
-  /// next recurrence time. The billing cycle stays the same.
-  immediateWithoutProration,
-
-  // LATER: Reenable when supported by Android V6
-  /// Replacement takes effect when the old plan expires, and the new price will
-  /// be charged at the same time.
-  // deferred,
-
-  // LATER: Reenable when supported by Android V6
-  /// Replacement takes effect immediately, and the user is charged full price
-  /// of new plan and is given a full billing cycle of subscription,
-  /// plus remaining prorated time from the old plan.
-  // immediateAndChargeFullPrice
 }
 
 /// Supported SKU types.

--- a/lib/upgrade_info.dart
+++ b/lib/upgrade_info.dart
@@ -1,0 +1,43 @@
+/// This class holds the information used when upgrading from another sku.
+/// To be used with purchaseProduct and purchasePackage.
+@Deprecated('Use GoogleProductChangeInfo')
+class UpgradeInfo {
+  /// The oldSKU to upgrade from.
+  String oldSKU;
+
+  /// The [ProrationMode] to use when upgrading the given oldSKU.
+  ProrationMode? prorationMode;
+
+  /// Constructs an UpgradeInfo
+  @Deprecated('Use GoogleProductChangeInfo')
+  UpgradeInfo(this.oldSKU, {this.prorationMode});
+}
+
+/// Replace SKU's ProrationMode.
+@Deprecated('Use GoogleProrationMode on GoogleProductChangeInfo')
+enum ProrationMode {
+  /// The Upgrade or Downgrade policy is unknown.
+  unknownSubscriptionUpgradeDowngradePolicy,
+
+  /// Replacement takes effect immediately, and the remaining time will be
+  /// prorated and credited to the user. This is the current default behavior.
+  immediateWithTimeProration,
+
+  /// Replacement takes effect immediately, and the billing cycle remains the
+  /// same. The price for the remaining period will be charged. This option is
+  /// only available for subscription upgrade.
+  immediateAndChargeProratedPrice,
+
+  /// Replacement takes effect immediately, and the new price will be charged on
+  /// next recurrence time. The billing cycle stays the same.
+  immediateWithoutProration,
+
+  /// Replacement takes effect when the old plan expires, and the new price will
+  /// be charged at the same time.
+  deferred,
+
+  /// Replacement takes effect immediately, and the user is charged full price
+  /// of new plan and is given a full billing cycle of subscription,
+  /// plus remaining prorated time from the old plan.
+  immediateAndChargeFullPrice
+}

--- a/migrations/v5-MIGRATION.md
+++ b/migrations/v5-MIGRATION.md
@@ -7,7 +7,9 @@ This latest release updates the Android SDK dependency from v5 to [v6](https://g
   more thorough explanation of the new Google subscription model announced with BillingClient 5 and how to take
   advantage of it in Flutter v5. This guide includes tips on product setup with the new model.
 
-### Classes
+### New API
+
+#### Classes
 
 | New                        |
 |----------------------------|
@@ -17,6 +19,16 @@ This latest release updates the Android SDK dependency from v5 to [v6](https://g
 | `Price`                    |
 | `RecurrenceMode`           |
 | `Unit`                     |
+| `GoogleProductChange`      |
+| `ProductType`              |
+
+#### Methods
+
+| New                                                                                 |
+|-------------------------------------------------------------------------------------|
+| `purchaseStoreProduct(StoreProduct, {GoogleProductChangeInfo?, bool?})`             |
+| `purchaseSubscriptionOption(SubscriptionOption, {GoogleProductChangeInfo?, bool?})` |
+
 
 ### StoreProduct changes
 
@@ -53,9 +65,21 @@ When passing a `Package` or `StoreProduct` to `purchase()`, the SDK will use the
 
 For more control, find the `SubscriptionOption` to purchase on a `StoreProduct`.
 
-| New                                                            |
-|----------------------------------------------------------------|
-| `purchaseSubscriptionOption(SubscriptionOption, UpgradeInfo?)` |
+
+### API Deprecations
+
+#### Classes
+
+| Deprecated       | Replaced With             |
+|------------------|---------------------------|
+| `UpgradeInfo`    | `GoogleProductChangeInfo` |
+| `PurchaseType`   | `ProductType`             |
+
+#### Methods
+
+| Deprecated                                                                                                   | Replaced With            |
+|--------------------------------------------------------------------------------------------------------------|--------------------------|
+| `purchaseProduct(String {UpgradeInfo?, ProductType, PurchaseType, String?, GoogleProductChangeInfo? bool?})` | `purchaseStoreProduct()` |
 
 ### Reporting undocumented issues:
 

--- a/test/google_product_change_info_test.dart
+++ b/test/google_product_change_info_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:purchases_flutter/purchases_flutter.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+      'Test GoogleProrationMode.immediateWithTimeProration value matches Billing Client with 1',
+      () async {
+    expect(GoogleProrationMode.immediateWithTimeProration.value, 1);
+  });
+
+  test(
+      'Test GoogleProrationMode.immediateWithoutProration value matches Billing Client with 3',
+      () async {
+    expect(GoogleProrationMode.immediateWithoutProration.value, 3);
+  });
+}

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -475,6 +475,78 @@ void main() {
         purchasePackageResult,
         CustomerInfo.fromJson(mockCustomerInfoResponse),
       );
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall(
+            'purchasePackage',
+            arguments: <String, dynamic>{
+              'packageIdentifier': '\$rc_lifetime',
+              'offeringIdentifier': 'main',
+              'googleOldProductIdentifier': null,
+              'googleProrationMode': null,
+              'googleIsPersonalizedPrice': null
+            },
+          )
+        ],
+      );
+    } on PlatformException catch (e) {
+      fail('there was an exception ' + e.toString());
+    }
+  });
+
+  test(
+      'purchasePackage with GoogleProductChangeInfo and googleIsPersonalizedPrice calls successfully',
+      () async {
+    try {
+      response = {
+        'productIdentifier': 'product.identifier',
+        'customerInfo': mockCustomerInfoResponse
+      };
+      const mockStoreProduct = StoreProduct(
+        'com.revenuecat.lifetime',
+        'description',
+        'lifetime (PurchasesSample)',
+        199.99,
+        '\$199.99',
+        'USD',
+      );
+      const mockPackage = Package(
+        '\$rc_lifetime',
+        PackageType.lifetime,
+        mockStoreProduct,
+        'main',
+      );
+      final googleProductChangeInfo = GoogleProductChangeInfo(
+        'com.revenuecat.weekly',
+        prorationMode: GoogleProrationMode.immediateWithTimeProration,
+      );
+      final purchasePackageResult = await Purchases.purchasePackage(
+        mockPackage,
+        googleProductChangeInfo: googleProductChangeInfo,
+        googleIsPersonalizedPrice: true,
+      );
+      expect(
+        purchasePackageResult,
+        CustomerInfo.fromJson(mockCustomerInfoResponse),
+      );
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall(
+            'purchasePackage',
+            arguments: <String, dynamic>{
+              'packageIdentifier': '\$rc_lifetime',
+              'offeringIdentifier': 'main',
+              'googleOldProductIdentifier': 'com.revenuecat.weekly',
+              'googleProrationMode': 1,
+              'googleIsPersonalizedPrice': true
+            },
+          )
+        ],
+      );
     } on PlatformException catch (e) {
       fail('there was an exception ' + e.toString());
     }
@@ -540,6 +612,72 @@ void main() {
         purchasePackageResult,
         CustomerInfo.fromJson(mockCustomerInfoResponse),
       );
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall(
+            'purchaseProduct',
+            arguments: <String, dynamic>{
+              'productIdentifier': 'com.revenuecat.lifetime',
+              'type': 'subs',
+              'googleOldProductIdentifier': null,
+              'googleProrationMode': null,
+              'googleIsPersonalizedPrice': null
+            },
+          )
+        ],
+      );
+    } on PlatformException catch (e) {
+      fail('there was an exception ' + e.toString());
+    }
+  });
+
+  test(
+      'purchaseProduct with GoogleProductChangeInfo and googleIsPersonalizedPrice calls successfully',
+      () async {
+    try {
+      response = {
+        'productIdentifier': 'product.identifier',
+        'customerInfo': mockCustomerInfoResponse
+      };
+      const mockStoreProduct = StoreProduct(
+        'com.revenuecat.lifetime',
+        'description',
+        'lifetime (PurchasesSample)',
+        199.99,
+        '\$199.99',
+        'USD',
+      );
+      final googleProductChangeInfo = GoogleProductChangeInfo(
+        'com.revenuecat.halftime',
+        prorationMode: GoogleProrationMode.immediateWithTimeProration,
+      );
+      final purchasePackageResult = await Purchases.purchaseProduct(
+        mockStoreProduct.identifier,
+        googleProductChangeInfo: googleProductChangeInfo,
+        googleIsPersonalizedPrice: true,
+      );
+      expect(
+        purchasePackageResult,
+        CustomerInfo.fromJson(mockCustomerInfoResponse),
+      );
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall(
+            'purchaseProduct',
+            arguments: <String, dynamic>{
+              'productIdentifier': 'com.revenuecat.lifetime',
+              'type': 'subs',
+              'googleOldProductIdentifier': 'com.revenuecat.halftime',
+              'googleProrationMode': 1,
+              'googleIsPersonalizedPrice': true,
+            },
+          )
+        ],
+      );
     } on PlatformException catch (e) {
       fail('there was an exception ' + e.toString());
     }
@@ -584,7 +722,7 @@ void main() {
       debugDefaultTargetPlatformOverride = TargetPlatform.android;
 
       response = {
-        'productIdentifier': 'gold',
+        'productIdentifier': 'gold:monthly',
         'customerInfo': mockCustomerInfoResponse
       };
       const phase = PricingPhase(
@@ -610,6 +748,84 @@ void main() {
       expect(
         purchasePackageResult,
         CustomerInfo.fromJson(mockCustomerInfoResponse),
+      );
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall(
+            'purchaseSubscriptionOption',
+            arguments: <String, dynamic>{
+              'productIdentifier': 'gold',
+              'optionIdentifier': 'monthly',
+              'googleOldProductIdentifier': null,
+              'googleProrationMode': null,
+              'googleIsPersonalizedPrice': null
+            },
+          )
+        ],
+      );
+    } on PlatformException catch (e) {
+      fail('there was an exception ' + e.toString());
+    }
+  });
+
+  test(
+      'purchaseSubscriptionOption with GoogleProductChangeInfo and googleIsPersonalizedPrice calls successfully on Android',
+      () async {
+    try {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      response = {
+        'productIdentifier': 'gold:monthly',
+        'customerInfo': mockCustomerInfoResponse
+      };
+      const phase = PricingPhase(
+        Period(Unit.month, 1),
+        RecurrenceMode.infiniteRecurring,
+        1,
+        Price('4.99', 4990000, 'USD'),
+      );
+      const mockSubscriptionOption = SubscriptionOption(
+        'monthly',
+        'gold:monthly',
+        'gold',
+        [phase],
+        [],
+        true,
+        Period(Unit.month, 1),
+        phase,
+        null,
+        null,
+      );
+      final googleProductChangeInfo = GoogleProductChangeInfo(
+        'silver',
+        prorationMode: GoogleProrationMode.immediateWithoutProration,
+      );
+      final purchasePackageResult = await Purchases.purchaseSubscriptionOption(
+        mockSubscriptionOption,
+        googleProductChangeInfo: googleProductChangeInfo,
+        googleIsPersonalizedPrice: true,
+      );
+      expect(
+        purchasePackageResult,
+        CustomerInfo.fromJson(mockCustomerInfoResponse),
+      );
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall(
+            'purchaseSubscriptionOption',
+            arguments: <String, dynamic>{
+              'productIdentifier': 'gold',
+              'optionIdentifier': 'monthly',
+              'googleOldProductIdentifier': 'silver',
+              'googleProrationMode': 3,
+              'googleIsPersonalizedPrice': true,
+            },
+          )
+        ],
       );
     } on PlatformException catch (e) {
       fail('there was an exception ' + e.toString());

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -639,11 +639,10 @@ void main() {
         null,
         null,
       );
-      final purchasePackageResult =
-          await Purchases.purchaseSubscriptionOption(mockSubscriptionOption);
+      await Purchases.purchaseSubscriptionOption(mockSubscriptionOption);
 
       fail('an exception should have been thrown');
-    } on UnsupportedPlatformException catch (e) {
+    } on UnsupportedPlatformException catch (_) {
       catchCalled = true;
     }
 
@@ -924,7 +923,9 @@ void main() {
     ]);
   });
 
-  test('syncObserverModeAmazonPurchase calls channel correctly with null price and isoCurrencyCode', () async {
+  test(
+      'syncObserverModeAmazonPurchase calls channel correctly with null price and isoCurrencyCode',
+      () async {
     await Purchases.syncObserverModeAmazonPurchase(
       'productID_test',
       'receiptID_test',

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -606,8 +606,10 @@ void main() {
         '\$199.99',
         'USD',
       );
-      final purchasePackageResult =
-          await Purchases.purchaseProduct(mockStoreProduct.identifier);
+      final purchasePackageResult = await Purchases.purchaseProduct(
+        mockStoreProduct.identifier,
+        presentedOfferingIdentifier: 'my-offer',
+      );
       expect(
         purchasePackageResult,
         CustomerInfo.fromJson(mockCustomerInfoResponse),
@@ -623,7 +625,100 @@ void main() {
               'type': 'subs',
               'googleOldProductIdentifier': null,
               'googleProrationMode': null,
-              'googleIsPersonalizedPrice': null
+              'googleIsPersonalizedPrice': null,
+              'presentedOfferingIdentifier': 'my-offer',
+            },
+          )
+        ],
+      );
+    } on PlatformException catch (e) {
+      fail('there was an exception ' + e.toString());
+    }
+  });
+
+  test(
+      'purchaseProduct with the deprecated PurchaseType.inapp calls successfully',
+      () async {
+    try {
+      response = {
+        'productIdentifier': 'product.identifier',
+        'customerInfo': mockCustomerInfoResponse
+      };
+      const mockStoreProduct = StoreProduct(
+        'com.revenuecat.lifetime',
+        'description',
+        'lifetime (PurchasesSample)',
+        199.99,
+        '\$199.99',
+        'USD',
+      );
+      final purchasePackageResult = await Purchases.purchaseProduct(
+        mockStoreProduct.identifier,
+        type: PurchaseType.inapp,
+        presentedOfferingIdentifier: 'my-offer',
+      );
+      expect(
+        purchasePackageResult,
+        CustomerInfo.fromJson(mockCustomerInfoResponse),
+      );
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall(
+            'purchaseProduct',
+            arguments: <String, dynamic>{
+              'productIdentifier': 'com.revenuecat.lifetime',
+              'type': 'inapp',
+              'googleOldProductIdentifier': null,
+              'googleProrationMode': null,
+              'googleIsPersonalizedPrice': null,
+              'presentedOfferingIdentifier': 'my-offer',
+            },
+          )
+        ],
+      );
+    } on PlatformException catch (e) {
+      fail('there was an exception ' + e.toString());
+    }
+  });
+
+  test('purchaseProduct with ProductType.inapp calls successfully', () async {
+    try {
+      response = {
+        'productIdentifier': 'product.identifier',
+        'customerInfo': mockCustomerInfoResponse
+      };
+      const mockStoreProduct = StoreProduct(
+        'com.revenuecat.lifetime',
+        'description',
+        'lifetime (PurchasesSample)',
+        199.99,
+        '\$199.99',
+        'USD',
+      );
+      final purchasePackageResult = await Purchases.purchaseProduct(
+        mockStoreProduct.identifier,
+        productType: ProductType.inapp,
+        presentedOfferingIdentifier: 'my-offer',
+      );
+      expect(
+        purchasePackageResult,
+        CustomerInfo.fromJson(mockCustomerInfoResponse),
+      );
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall(
+            'purchaseProduct',
+            arguments: <String, dynamic>{
+              'productIdentifier': 'com.revenuecat.lifetime',
+              'type': 'inapp',
+              'googleOldProductIdentifier': null,
+              'googleProrationMode': null,
+              'googleIsPersonalizedPrice': null,
+              'presentedOfferingIdentifier': 'my-offer',
             },
           )
         ],
@@ -674,6 +769,51 @@ void main() {
               'googleOldProductIdentifier': 'com.revenuecat.halftime',
               'googleProrationMode': 1,
               'googleIsPersonalizedPrice': true,
+              'presentedOfferingIdentifier': null,
+            },
+          )
+        ],
+      );
+    } on PlatformException catch (e) {
+      fail('there was an exception ' + e.toString());
+    }
+  });
+
+  test('purchaseStoreProduct calls successfully', () async {
+    try {
+      response = {
+        'productIdentifier': 'product.identifier',
+        'customerInfo': mockCustomerInfoResponse
+      };
+      const mockStoreProduct = StoreProduct(
+        'com.revenuecat.lifetime',
+        'description',
+        'lifetime (PurchasesSample)',
+        199.99,
+        '\$199.99',
+        'USD',
+        productType: ProductType.subs,
+        presentedOfferingIdentifier: 'my-offer',
+      );
+      final purchasePackageResult =
+          await Purchases.purchaseStoreProduct(mockStoreProduct);
+      expect(
+        purchasePackageResult,
+        CustomerInfo.fromJson(mockCustomerInfoResponse),
+      );
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall(
+            'purchaseProduct',
+            arguments: <String, dynamic>{
+              'productIdentifier': 'com.revenuecat.lifetime',
+              'type': 'subs',
+              'googleOldProductIdentifier': null,
+              'googleProrationMode': null,
+              'googleIsPersonalizedPrice': null,
+              'presentedOfferingIdentifier': 'my-offer',
             },
           )
         ],
@@ -696,6 +836,7 @@ void main() {
         199.99,
         '\$199.99',
         'USD',
+        presentedOfferingIdentifier: 'my-offer',
       );
       const mockPaymentDiscount = PromotionalOffer(
         'aIdentifier',
@@ -711,6 +852,20 @@ void main() {
       expect(
         purchasePackageResult,
         CustomerInfo.fromJson(mockCustomerInfoResponse),
+      );
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall(
+            'purchaseProduct',
+            arguments: <String, dynamic>{
+              'productIdentifier': 'com.revenuecat.lifetime',
+              'signedDiscountTimestamp': '123456',
+              'presentedOfferingIdentifier': 'my-offer',
+            },
+          )
+        ],
       );
     } on PlatformException catch (e) {
       fail('there was an exception ' + e.toString());
@@ -730,6 +885,7 @@ void main() {
         RecurrenceMode.infiniteRecurring,
         1,
         Price('4.99', 4990000, 'USD'),
+        null,
       );
       const mockSubscriptionOption = SubscriptionOption(
         'monthly',
@@ -742,6 +898,7 @@ void main() {
         phase,
         null,
         null,
+        'my-offer',
       );
       final purchasePackageResult =
           await Purchases.purchaseSubscriptionOption(mockSubscriptionOption);
@@ -760,7 +917,8 @@ void main() {
               'optionIdentifier': 'monthly',
               'googleOldProductIdentifier': null,
               'googleProrationMode': null,
-              'googleIsPersonalizedPrice': null
+              'googleIsPersonalizedPrice': null,
+              'presentedOfferingIdentifier': 'my-offer',
             },
           )
         ],
@@ -785,6 +943,7 @@ void main() {
         RecurrenceMode.infiniteRecurring,
         1,
         Price('4.99', 4990000, 'USD'),
+        null,
       );
       const mockSubscriptionOption = SubscriptionOption(
         'monthly',
@@ -797,6 +956,7 @@ void main() {
         phase,
         null,
         null,
+        'my-offer',
       );
       final googleProductChangeInfo = GoogleProductChangeInfo(
         'silver',
@@ -823,6 +983,7 @@ void main() {
               'googleOldProductIdentifier': 'silver',
               'googleProrationMode': 3,
               'googleIsPersonalizedPrice': true,
+              'presentedOfferingIdentifier': 'my-offer',
             },
           )
         ],
@@ -842,6 +1003,7 @@ void main() {
         RecurrenceMode.infiniteRecurring,
         1,
         Price('4.99', 4990000, 'USD'),
+        null,
       );
       const mockSubscriptionOption = SubscriptionOption(
         'monthly',
@@ -852,6 +1014,7 @@ void main() {
         true,
         Period(Unit.month, 1),
         phase,
+        null,
         null,
         null,
       );


### PR DESCRIPTION
## Motivation

Replace `UpgradeInfo` with a new `ProductChangeInfo` 
- Android terminology is "changing products"
- The `UpgradeInfo` class used the term "sku" when we need to use "product identifier"

## Description

- Deprecated `UpgradeInfo` and `ProrationMode` for new `GoogleProductChangeInfo` and `GoogleProrationMode`
- Deprecated `UpgradeInfo` and added `GoogleProductChangeInfo` in `purchaseProduct()` and `purchasePackage()`
- Added `GoogleProductChangeInfo` to `purchaseSubscriptionOption()`

🔨 Also enabled `deprecated_member_use_from_same_package` in the analyze options so that `flutter analyze lib` and `flutter pub publish --dry-run` pass with the `@Deprecated UpgradeInfo? upgradeInfo` parameter

💪  Also updated tests that test the method call and arguments that are being sent to that native layer 

### Logic behind `GoogleProductChangeInfo` and  `GoogleProrationMode`

This naming with the "Google" prefix is to make it a little more clear to developers that these fields are for Google only without need to read the documentation 😇 

`GoogleProrationMode` also only allows `immediateWithTimeProration` and `immediateWithoutProration` and will add the others when Android V6 supports them 💪 
