### PR TITLE
Update CircleCI Xcode version to 14.3.0 and update iOS runtime to 16.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,11 +229,6 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
-      - install-and-create-sim:
-          install-simulator-name: iOS 16.4 Simulator
-          sim-device-type: iPhone-14
-          sim-device-runtime: iOS-16-4
-          sim-name: iPhone 14 (16.4)
       - macos/preboot-simulator:
           device: iPhone 14
           version: '16.4'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,29 +109,6 @@ commands:
       - run:
           name: Flutter doctor
           command: flutter doctor
-  
-  install-and-create-sim:
-    parameters:
-      install-simulator-name:
-        type: string
-      sim-device-type:
-        type: string
-      sim-device-runtime:
-        type: string
-      sim-name:
-        type: string
-    steps:
-      - run:
-          name: Install xcode-install
-          command: gem install xcode-install
-      - run:
-          name: Install simulator
-          command: | # Print all available simulators and install required one
-              xcversion simulators
-              xcversion simulators --install="<< parameters.install-simulator-name >>"
-      - run:
-          name: Create simulator
-          command: xcrun simctl create '<< parameters.sim-name >>' com.apple.CoreSimulator.SimDeviceType.<< parameters.sim-device-type >> com.apple.CoreSimulator.SimRuntime.<< parameters.sim-device-runtime >>
 
 jobs:
   lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,13 +230,13 @@ jobs:
     steps:
       - checkout
       - install-and-create-sim:
-          install-simulator-name: iOS 15.4 Simulator
-          sim-device-type: iPhone-13
-          sim-device-runtime: iOS-15-4
-          sim-name: iPhone 13 (15.4)
+          install-simulator-name: iOS 16.4 Simulator
+          sim-device-type: iPhone-14
+          sim-device-runtime: iOS-16-4
+          sim-name: iPhone 14 (16.4)
       - macos/preboot-simulator:
-          device: iPhone 13
-          version: '15.4'
+          device: iPhone 14
+          version: '16.4'
       - setup-flutter
       - replace-api-key
       - build-flutter-project:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,7 @@ jobs:
     description: "Run integration tests for Flutter"
     resource_class: macos.x86.medium.gen2
     macos:
-      xcode: 13.4.1
+      xcode: 14.3.0
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
@@ -252,7 +252,7 @@ jobs:
     description: "Run integration tests for Flutter"
     resource_class: macos.x86.medium.gen2
     macos:
-      xcode: 13.4.1
+      xcode: 14.3.0
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout


### PR DESCRIPTION
Update to latest supported Xcode (14.3.0) and iOS (16.4) versions. 

https://circleci.com/docs/using-macos/#supported-xcode-versions

Installing iOS simulator runtime took a long time in the latest CircleCI run because iOS 15.4 runtime was not preinstalled. 

https://app.circleci.com/pipelines/github/RevenueCat/purchases-flutter/1781/workflows/213ae4a8-c87c-486c-b79f-67b69b37fd82/jobs/7847

Integration tests were run in a separate test-only branch: https://github.com/RevenueCat/purchases-flutter/pull/659

