### PR TITLE
[BC5] Update to PHC beta.6

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ version '5.0.0-beta.1'
 
 buildscript {
     ext.kotlin_version = '1.6.21'
-    ext.common_version = '5.0.0-beta.4'
+    ext.common_version = '5.0.0-beta.6'
     repositories {
         google()
         mavenCentral()

--- a/api_tester/lib/api_tests/models/period_wrapper_api_test.dart
+++ b/api_tester/lib/api_tests/models/period_wrapper_api_test.dart
@@ -12,7 +12,7 @@ class _PeriodApiTest {
   }
 
   void _checkConstructor(
-    Unit unit,
+    PeriodUnit unit,
     int value,
     String iso8601,
   ) {
@@ -20,7 +20,7 @@ class _PeriodApiTest {
   }
 
   void _checkProperties(Period period) {
-    Unit unit = period.unit;
+    PeriodUnit unit = period.unit;
     int value = period.value;
     String iso8601 = period.iso8601;
   }

--- a/api_tester/lib/api_tests/models/store_product_wrapper_api_test.dart
+++ b/api_tester/lib/api_tests/models/store_product_wrapper_api_test.dart
@@ -20,7 +20,7 @@ class _StoreProductApiTest {
       String currencyCode,
       IntroductoryPrice? introductoryPrice,
       List<StoreProductDiscount>? discounts,
-      ProductType? productType,
+      ProductCategory? productCategory,
       String? subscriptionPeriod,
       String? presentedOfferingIdentifier) {
     StoreProduct product = StoreProduct(
@@ -29,7 +29,7 @@ class _StoreProductApiTest {
         identifier, description, title, price, priceString, currencyCode,
         introductoryPrice: introductoryPrice,
         discounts: discounts,
-        productType: productType,
+        productCategory: productCategory,
         subscriptionPeriod: subscriptionPeriod,
         presentedOfferingIdentifier: presentedOfferingIdentifier);
   }
@@ -43,7 +43,7 @@ class _StoreProductApiTest {
     String currencyCode = product.currencyCode;
     IntroductoryPrice? introductoryPrice = product.introductoryPrice;
     List<StoreProductDiscount>? discounts = product.discounts;
-    ProductType? productType = product.productType;
+    ProductCategory? productType = product.productCategory;
     SubscriptionOption? defaultOption = product.defaultOption;
     List<SubscriptionOption>? subscriptionOptions = product.subscriptionOptions;
     String? subscriptionPeriod = product.subscriptionPeriod;

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -74,24 +74,13 @@ class _PurchasesFlutterApiTest {
     UpgradeInfo? upgradeInfo;
     GoogleProductChangeInfo? googleProductChangeInfo;
     PurchaseType purchaseType = PurchaseType.subs;
-    ProductType productType = ProductType.subs;
+    ProductCategory productType = ProductCategory.subscription;
     CustomerInfo customerInfo = await Purchases.purchaseProduct(
         productIdentifier,
         type: purchaseType,
-        upgradeInfo: upgradeInfo,
-        googleIsPersonalizedPrice: true);
-    customerInfo = await Purchases.purchaseProduct(productIdentifier,
-        productType: productType,
-        upgradeInfo: upgradeInfo,
-        googleIsPersonalizedPrice: true);
-    customerInfo = await Purchases.purchaseProduct(productIdentifier,
-        upgradeInfo: upgradeInfo, type: purchaseType);
-    customerInfo = await Purchases.purchaseProduct(productIdentifier,
-        googleProductChangeInfo: googleProductChangeInfo);
-    customerInfo = await Purchases.purchaseProduct(productIdentifier,
         upgradeInfo: upgradeInfo);
     customerInfo = await Purchases.purchaseProduct(productIdentifier,
-        googleIsPersonalizedPrice: true);
+        upgradeInfo: upgradeInfo);
     customerInfo = await Purchases.purchaseProduct(productIdentifier);
   }
 
@@ -409,10 +398,10 @@ class _PurchasesFlutterApiTest {
     }
   }
 
-  void _checkProductType(ProductType type) {
+  void _checkProductCategory(ProductCategory type) {
     switch (type) {
-      case ProductType.subs:
-      case ProductType.inapp:
+      case ProductCategory.subscription:
+      case ProductCategory.nonSubscription:
         break;
     }
   }

--- a/ios/purchases_flutter.podspec
+++ b/ios/purchases_flutter.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'PurchasesHybridCommon', '5.0.0-beta.4'
+  s.dependency 'PurchasesHybridCommon', '6'
   s.ios.deployment_target = '11.0'
   s.swift_version         = '5.0'
 

--- a/ios/purchases_flutter.podspec
+++ b/ios/purchases_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'purchases_flutter'
-  s.version          = '5.0.0-beta.1'
+  s.version          = '5.0.0-alpha.1'
   s.summary          = 'Cross-platform subscriptions framework for Flutter.'
   s.description      = <<-DESC
   Client for the RevenueCat subscription and purchase tracking system, making implementing in-app subscriptions in Flutter easy - receipt validation and status tracking included!
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'PurchasesHybridCommon', '6'
+  s.dependency 'PurchasesHybridCommon', '5.0.0-beta.6'
   s.ios.deployment_target = '11.0'
   s.swift_version         = '5.0'
 

--- a/lib/models/introductory_price.dart
+++ b/lib/models/introductory_price.dart
@@ -1,19 +1,9 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import 'period_unit.dart';
+
 part 'introductory_price.freezed.dart';
 part 'introductory_price.g.dart';
-
-enum PeriodUnit {
-  @JsonValue('DAY')
-  day,
-  @JsonValue('WEEK')
-  week,
-  @JsonValue('MONTH')
-  month,
-  @JsonValue('YEAR')
-  year,
-  unknown
-}
 
 @freezed
 

--- a/lib/models/period_unit.dart
+++ b/lib/models/period_unit.dart
@@ -1,0 +1,14 @@
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+enum PeriodUnit {
+  @JsonValue('DAY')
+  day,
+  @JsonValue('WEEK')
+  week,
+  @JsonValue('MONTH')
+  month,
+  @JsonValue('YEAR')
+  year,
+  unknown
+}

--- a/lib/models/period_wrapper.dart
+++ b/lib/models/period_wrapper.dart
@@ -1,5 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import 'period_unit.dart';
+
 part 'period_wrapper.freezed.dart';
 part 'period_wrapper.g.dart';
 
@@ -9,7 +11,7 @@ part 'period_wrapper.g.dart';
 class Period with _$Period {
   const factory Period(
     /// The number of period units: day, week, month, year, unknown
-    @JsonKey(name: 'unit') Unit unit,
+    @JsonKey(name: 'unit') PeriodUnit unit,
 
     /// The increment of time that a subscription period is specified in
     @JsonKey(name: 'value') int value,
@@ -21,17 +23,4 @@ class Period with _$Period {
   ) = _Period;
 
   factory Period.fromJson(Map<String, dynamic> json) => _$PeriodFromJson(json);
-}
-
-enum Unit {
-  @JsonValue('DAY')
-  day,
-  @JsonValue('WEEK')
-  week,
-  @JsonValue('MONTH')
-  month,
-  @JsonValue('YEAR')
-  year,
-  @JsonValue('UNKNOWN')
-  unknown,
 }

--- a/lib/models/period_wrapper.freezed.dart
+++ b/lib/models/period_wrapper.freezed.dart
@@ -22,7 +22,7 @@ Period _$PeriodFromJson(Map<String, dynamic> json) {
 mixin _$Period {
   /// The number of period units: day, week, month, year, unknown
   @JsonKey(name: 'unit')
-  Unit get unit => throw _privateConstructorUsedError;
+  PeriodUnit get unit => throw _privateConstructorUsedError;
 
   /// The increment of time that a subscription period is specified in
   @JsonKey(name: 'value')
@@ -45,7 +45,7 @@ abstract class $PeriodCopyWith<$Res> {
       _$PeriodCopyWithImpl<$Res, Period>;
   @useResult
   $Res call(
-      {@JsonKey(name: 'unit') Unit unit,
+      {@JsonKey(name: 'unit') PeriodUnit unit,
       @JsonKey(name: 'value') int value,
       @JsonKey(name: 'iso8601') String iso8601});
 }
@@ -71,7 +71,7 @@ class _$PeriodCopyWithImpl<$Res, $Val extends Period>
       unit: null == unit
           ? _value.unit
           : unit // ignore: cast_nullable_to_non_nullable
-              as Unit,
+              as PeriodUnit,
       value: null == value
           ? _value.value
           : value // ignore: cast_nullable_to_non_nullable
@@ -91,7 +91,7 @@ abstract class _$$_PeriodCopyWith<$Res> implements $PeriodCopyWith<$Res> {
   @override
   @useResult
   $Res call(
-      {@JsonKey(name: 'unit') Unit unit,
+      {@JsonKey(name: 'unit') PeriodUnit unit,
       @JsonKey(name: 'value') int value,
       @JsonKey(name: 'iso8601') String iso8601});
 }
@@ -114,7 +114,7 @@ class __$$_PeriodCopyWithImpl<$Res>
       null == unit
           ? _value.unit
           : unit // ignore: cast_nullable_to_non_nullable
-              as Unit,
+              as PeriodUnit,
       null == value
           ? _value.value
           : value // ignore: cast_nullable_to_non_nullable
@@ -141,7 +141,7 @@ class _$_Period implements _Period {
   /// The number of period units: day, week, month, year, unknown
   @override
   @JsonKey(name: 'unit')
-  final Unit unit;
+  final PeriodUnit unit;
 
   /// The increment of time that a subscription period is specified in
   @override
@@ -190,7 +190,7 @@ class _$_Period implements _Period {
 
 abstract class _Period implements Period {
   const factory _Period(
-      @JsonKey(name: 'unit') final Unit unit,
+      @JsonKey(name: 'unit') final PeriodUnit unit,
       @JsonKey(name: 'value') final int value,
       @JsonKey(name: 'iso8601') final String iso8601) = _$_Period;
 
@@ -200,7 +200,7 @@ abstract class _Period implements Period {
 
   /// The number of period units: day, week, month, year, unknown
   @JsonKey(name: 'unit')
-  Unit get unit;
+  PeriodUnit get unit;
   @override
 
   /// The increment of time that a subscription period is specified in

--- a/lib/models/period_wrapper.g.dart
+++ b/lib/models/period_wrapper.g.dart
@@ -7,21 +7,21 @@ part of 'period_wrapper.dart';
 // **************************************************************************
 
 _$_Period _$$_PeriodFromJson(Map json) => _$_Period(
-      $enumDecode(_$UnitEnumMap, json['unit']),
+      $enumDecode(_$PeriodUnitEnumMap, json['unit']),
       json['value'] as int,
       json['iso8601'] as String,
     );
 
 Map<String, dynamic> _$$_PeriodToJson(_$_Period instance) => <String, dynamic>{
-      'unit': _$UnitEnumMap[instance.unit]!,
+      'unit': _$PeriodUnitEnumMap[instance.unit]!,
       'value': instance.value,
       'iso8601': instance.iso8601,
     };
 
-const _$UnitEnumMap = {
-  Unit.day: 'DAY',
-  Unit.week: 'WEEK',
-  Unit.month: 'MONTH',
-  Unit.year: 'YEAR',
-  Unit.unknown: 'UNKNOWN',
+const _$PeriodUnitEnumMap = {
+  PeriodUnit.day: 'DAY',
+  PeriodUnit.week: 'WEEK',
+  PeriodUnit.month: 'MONTH',
+  PeriodUnit.year: 'YEAR',
+  PeriodUnit.unknown: 'unknown',
 };

--- a/lib/models/store_product_wrapper.dart
+++ b/lib/models/store_product_wrapper.dart
@@ -38,7 +38,7 @@ class StoreProduct with _$StoreProduct {
     @JsonKey(name: 'discounts', nullable: true)
         List<StoreProductDiscount>? discounts,
 
-    /// Product type. Null for iOS.
+    /// Product category.
     @JsonKey(name: 'productCategory', nullable: true)
         ProductCategory? productCategory,
 

--- a/lib/models/store_product_wrapper.dart
+++ b/lib/models/store_product_wrapper.dart
@@ -1,6 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
-import '../product_type.dart';
+import '../product_category.dart';
 import 'introductory_price.dart';
 import 'store_product_discount.dart';
 import 'subscription_option_wrapper.dart';
@@ -39,7 +39,8 @@ class StoreProduct with _$StoreProduct {
         List<StoreProductDiscount>? discounts,
 
     /// Product type. Null for iOS.
-    @JsonKey(name: 'productCategory', nullable: true) ProductType? productType,
+    @JsonKey(name: 'productCategory', nullable: true)
+        ProductCategory? productCategory,
 
     /// Default subscription option for a product. Google Play only.
     @JsonKey(name: 'defaultOption', nullable: true)

--- a/lib/models/store_product_wrapper.freezed.dart
+++ b/lib/models/store_product_wrapper.freezed.dart
@@ -54,7 +54,7 @@ mixin _$StoreProduct {
   List<StoreProductDiscount>? get discounts =>
       throw _privateConstructorUsedError;
 
-  /// Product type. Null for iOS.
+  /// Product category.
   @JsonKey(name: 'productCategory', nullable: true)
   ProductCategory? get productCategory => throw _privateConstructorUsedError;
 
@@ -441,7 +441,7 @@ class _$_StoreProduct implements _StoreProduct {
     return EqualUnmodifiableListView(value);
   }
 
-  /// Product type. Null for iOS.
+  /// Product category.
   @override
   @JsonKey(name: 'productCategory', nullable: true)
   final ProductCategory? productCategory;
@@ -625,7 +625,7 @@ abstract class _StoreProduct implements StoreProduct {
   List<StoreProductDiscount>? get discounts;
   @override
 
-  /// Product type. Null for iOS.
+  /// Product category.
   @JsonKey(name: 'productCategory', nullable: true)
   ProductCategory? get productCategory;
   @override

--- a/lib/models/store_product_wrapper.freezed.dart
+++ b/lib/models/store_product_wrapper.freezed.dart
@@ -56,7 +56,7 @@ mixin _$StoreProduct {
 
   /// Product type. Null for iOS.
   @JsonKey(name: 'productCategory', nullable: true)
-  ProductType? get productType => throw _privateConstructorUsedError;
+  ProductCategory? get productCategory => throw _privateConstructorUsedError;
 
   /// Default subscription option for a product. Google Play only.
   @JsonKey(name: 'defaultOption', nullable: true)
@@ -110,7 +110,7 @@ abstract class $StoreProductCopyWith<$Res> {
       @JsonKey(name: 'discounts', nullable: true)
           List<StoreProductDiscount>? discounts,
       @JsonKey(name: 'productCategory', nullable: true)
-          ProductType? productType,
+          ProductCategory? productCategory,
       @JsonKey(name: 'defaultOption', nullable: true)
           SubscriptionOption? defaultOption,
       @JsonKey(name: 'subscriptionOptions', nullable: true)
@@ -145,7 +145,7 @@ class _$StoreProductCopyWithImpl<$Res, $Val extends StoreProduct>
     Object? currencyCode = null,
     Object? introductoryPrice = freezed,
     Object? discounts = freezed,
-    Object? productType = freezed,
+    Object? productCategory = freezed,
     Object? defaultOption = freezed,
     Object? subscriptionOptions = freezed,
     Object? presentedOfferingIdentifier = freezed,
@@ -184,10 +184,10 @@ class _$StoreProductCopyWithImpl<$Res, $Val extends StoreProduct>
           ? _value.discounts
           : discounts // ignore: cast_nullable_to_non_nullable
               as List<StoreProductDiscount>?,
-      productType: freezed == productType
-          ? _value.productType
-          : productType // ignore: cast_nullable_to_non_nullable
-              as ProductType?,
+      productCategory: freezed == productCategory
+          ? _value.productCategory
+          : productCategory // ignore: cast_nullable_to_non_nullable
+              as ProductCategory?,
       defaultOption: freezed == defaultOption
           ? _value.defaultOption
           : defaultOption // ignore: cast_nullable_to_non_nullable
@@ -258,7 +258,7 @@ abstract class _$$_StoreProductCopyWith<$Res>
       @JsonKey(name: 'discounts', nullable: true)
           List<StoreProductDiscount>? discounts,
       @JsonKey(name: 'productCategory', nullable: true)
-          ProductType? productType,
+          ProductCategory? productCategory,
       @JsonKey(name: 'defaultOption', nullable: true)
           SubscriptionOption? defaultOption,
       @JsonKey(name: 'subscriptionOptions', nullable: true)
@@ -293,7 +293,7 @@ class __$$_StoreProductCopyWithImpl<$Res>
     Object? currencyCode = null,
     Object? introductoryPrice = freezed,
     Object? discounts = freezed,
-    Object? productType = freezed,
+    Object? productCategory = freezed,
     Object? defaultOption = freezed,
     Object? subscriptionOptions = freezed,
     Object? presentedOfferingIdentifier = freezed,
@@ -332,10 +332,10 @@ class __$$_StoreProductCopyWithImpl<$Res>
           ? _value._discounts
           : discounts // ignore: cast_nullable_to_non_nullable
               as List<StoreProductDiscount>?,
-      productType: freezed == productType
-          ? _value.productType
-          : productType // ignore: cast_nullable_to_non_nullable
-              as ProductType?,
+      productCategory: freezed == productCategory
+          ? _value.productCategory
+          : productCategory // ignore: cast_nullable_to_non_nullable
+              as ProductCategory?,
       defaultOption: freezed == defaultOption
           ? _value.defaultOption
           : defaultOption // ignore: cast_nullable_to_non_nullable
@@ -377,7 +377,7 @@ class _$_StoreProduct implements _StoreProduct {
       @JsonKey(name: 'discounts', nullable: true)
           final List<StoreProductDiscount>? discounts,
       @JsonKey(name: 'productCategory', nullable: true)
-          this.productType,
+          this.productCategory,
       @JsonKey(name: 'defaultOption', nullable: true)
           this.defaultOption,
       @JsonKey(name: 'subscriptionOptions', nullable: true)
@@ -444,7 +444,7 @@ class _$_StoreProduct implements _StoreProduct {
   /// Product type. Null for iOS.
   @override
   @JsonKey(name: 'productCategory', nullable: true)
-  final ProductType? productType;
+  final ProductCategory? productCategory;
 
   /// Default subscription option for a product. Google Play only.
   @override
@@ -483,7 +483,7 @@ class _$_StoreProduct implements _StoreProduct {
 
   @override
   String toString() {
-    return 'StoreProduct(identifier: $identifier, description: $description, title: $title, price: $price, priceString: $priceString, currencyCode: $currencyCode, introductoryPrice: $introductoryPrice, discounts: $discounts, productType: $productType, defaultOption: $defaultOption, subscriptionOptions: $subscriptionOptions, presentedOfferingIdentifier: $presentedOfferingIdentifier, subscriptionPeriod: $subscriptionPeriod)';
+    return 'StoreProduct(identifier: $identifier, description: $description, title: $title, price: $price, priceString: $priceString, currencyCode: $currencyCode, introductoryPrice: $introductoryPrice, discounts: $discounts, productCategory: $productCategory, defaultOption: $defaultOption, subscriptionOptions: $subscriptionOptions, presentedOfferingIdentifier: $presentedOfferingIdentifier, subscriptionPeriod: $subscriptionPeriod)';
   }
 
   @override
@@ -505,8 +505,8 @@ class _$_StoreProduct implements _StoreProduct {
                 other.introductoryPrice == introductoryPrice) &&
             const DeepCollectionEquality()
                 .equals(other._discounts, _discounts) &&
-            (identical(other.productType, productType) ||
-                other.productType == productType) &&
+            (identical(other.productCategory, productCategory) ||
+                other.productCategory == productCategory) &&
             (identical(other.defaultOption, defaultOption) ||
                 other.defaultOption == defaultOption) &&
             const DeepCollectionEquality()
@@ -531,7 +531,7 @@ class _$_StoreProduct implements _StoreProduct {
       currencyCode,
       introductoryPrice,
       const DeepCollectionEquality().hash(_discounts),
-      productType,
+      productCategory,
       defaultOption,
       const DeepCollectionEquality().hash(_subscriptionOptions),
       presentedOfferingIdentifier,
@@ -570,7 +570,7 @@ abstract class _StoreProduct implements StoreProduct {
       @JsonKey(name: 'discounts', nullable: true)
           final List<StoreProductDiscount>? discounts,
       @JsonKey(name: 'productCategory', nullable: true)
-          final ProductType? productType,
+          final ProductCategory? productCategory,
       @JsonKey(name: 'defaultOption', nullable: true)
           final SubscriptionOption? defaultOption,
       @JsonKey(name: 'subscriptionOptions', nullable: true)
@@ -627,7 +627,7 @@ abstract class _StoreProduct implements StoreProduct {
 
   /// Product type. Null for iOS.
   @JsonKey(name: 'productCategory', nullable: true)
-  ProductType? get productType;
+  ProductCategory? get productCategory;
   @override
 
   /// Default subscription option for a product. Google Play only.

--- a/lib/models/store_product_wrapper.g.dart
+++ b/lib/models/store_product_wrapper.g.dart
@@ -21,8 +21,8 @@ _$_StoreProduct _$$_StoreProductFromJson(Map json) => _$_StoreProduct(
           ?.map((e) => StoreProductDiscount.fromJson(
               Map<String, dynamic>.from(e as Map)))
           .toList(),
-      productType:
-          $enumDecodeNullable(_$ProductTypeEnumMap, json['productCategory']),
+      productCategory: $enumDecodeNullable(
+          _$ProductCategoryEnumMap, json['productCategory']),
       defaultOption: json['defaultOption'] == null
           ? null
           : SubscriptionOption.fromJson(
@@ -46,7 +46,7 @@ Map<String, dynamic> _$$_StoreProductToJson(_$_StoreProduct instance) =>
       'currencyCode': instance.currencyCode,
       'introPrice': instance.introductoryPrice?.toJson(),
       'discounts': instance.discounts?.map((e) => e.toJson()).toList(),
-      'productCategory': _$ProductTypeEnumMap[instance.productType],
+      'productCategory': _$ProductCategoryEnumMap[instance.productCategory],
       'defaultOption': instance.defaultOption?.toJson(),
       'subscriptionOptions':
           instance.subscriptionOptions?.map((e) => e.toJson()).toList(),
@@ -54,7 +54,7 @@ Map<String, dynamic> _$$_StoreProductToJson(_$_StoreProduct instance) =>
       'subscriptionPeriod': instance.subscriptionPeriod,
     };
 
-const _$ProductTypeEnumMap = {
-  ProductType.inapp: 'NON_SUBSCRIPTION',
-  ProductType.subs: 'SUBSCRIPTION',
+const _$ProductCategoryEnumMap = {
+  ProductCategory.nonSubscription: 'NON_SUBSCRIPTION',
+  ProductCategory.subscription: 'SUBSCRIPTION',
 };

--- a/lib/object_wrappers.dart
+++ b/lib/object_wrappers.dart
@@ -17,5 +17,5 @@ export 'models/store_product_discount.dart';
 export 'models/store_product_wrapper.dart';
 export 'models/store_transaction.dart';
 export 'models/subscription_option_wrapper.dart';
-export 'product_type.dart';
+export 'product_category.dart';
 export 'upgrade_info.dart';

--- a/lib/object_wrappers.dart
+++ b/lib/object_wrappers.dart
@@ -7,6 +7,7 @@ export 'models/introductory_price.dart';
 export 'models/offering_wrapper.dart';
 export 'models/offerings_wrapper.dart';
 export 'models/package_wrapper.dart';
+export 'models/period_unit.dart';
 export 'models/period_wrapper.dart';
 export 'models/price_wrapper.dart';
 export 'models/pricing_phase_wrapper.dart';

--- a/lib/product_category.dart
+++ b/lib/product_category.dart
@@ -1,14 +1,14 @@
 import 'package:json_annotation/json_annotation.dart';
 
 /// Supported [StoreProduct] types.
-enum ProductType {
+enum ProductCategory {
   /// A type of [StoreProduct] for in-app products.
   @JsonValue('NON_SUBSCRIPTION')
-  inapp,
+  nonSubscription,
 
   /// A type of [StoreProduct] for subscriptions.
   @JsonValue('SUBSCRIPTION')
-  subs
+  subscription
 }
 
 /// Supported SKU types.

--- a/macos/purchases_flutter.podspec
+++ b/macos/purchases_flutter.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files     = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'FlutterMacOS'
-  s.dependency 'PurchasesHybridCommon', '5.0.0-beta.4'
+  s.dependency 'PurchasesHybridCommon', '5.0.0-beta.6'
   s.platform = :osx, '10.12'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.0'

--- a/migrations/v5-MIGRATION.md
+++ b/migrations/v5-MIGRATION.md
@@ -18,9 +18,8 @@ This latest release updates the Android SDK dependency from v5 to [v6](https://g
 | `Period`                   |
 | `Price`                    |
 | `RecurrenceMode`           |
-| `Unit`                     |
 | `GoogleProductChange`      |
-| `ProductType`              |
+| `ProductCategory`          |
 
 #### Methods
 

--- a/revenuecat_examples/purchase_tester/ios/RevenueCast_PurchaseTesterTypescriptConfiguration.storekit
+++ b/revenuecat_examples/purchase_tester/ios/RevenueCast_PurchaseTesterTypescriptConfiguration.storekit
@@ -1,0 +1,190 @@
+{
+  "identifier" : "3B56BC8C",
+  "nonRenewingSubscriptions" : [
+
+  ],
+  "products" : [
+    {
+      "displayPrice" : "",
+      "familyShareable" : false,
+      "internalID" : "931F117D",
+      "localizations" : [
+        {
+          "description" : "",
+          "displayName" : "Non-renewing sub $59.99",
+          "locale" : "en_US"
+        }
+      ],
+      "productID" : "rc_5999_non_renewing",
+      "referenceName" : "Non-renewing sub $59.99",
+      "type" : "NonConsumable"
+    },
+    {
+      "displayPrice" : "",
+      "familyShareable" : false,
+      "internalID" : "55D0883A",
+      "localizations" : [
+        {
+          "description" : "",
+          "displayName" : "lifetime",
+          "locale" : "en_US"
+        }
+      ],
+      "productID" : "com.revenuecat.lifetime.199.99",
+      "referenceName" : "lifetime",
+      "type" : "NonConsumable"
+    },
+    {
+      "displayPrice" : "",
+      "familyShareable" : false,
+      "internalID" : "02FF3395",
+      "localizations" : [
+        {
+          "description" : "",
+          "displayName" : "lifetime",
+          "locale" : "en_US"
+        }
+      ],
+      "productID" : "com.revenuecat.500coins.1.99",
+      "referenceName" : "500 coins",
+      "type" : "Consumable"
+    }
+  ],
+  "settings" : {
+
+  },
+  "subscriptionGroups" : [
+    {
+      "id" : "D833F705",
+      "localizations" : [
+
+      ],
+      "name" : "main subscription group",
+      "subscriptions" : [
+        {
+          "adHocOffers" : [
+
+          ],
+          "displayPrice" : "",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "BBE38D09",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "",
+              "displayName" : "Test Increase 29.99 -> 49.99",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "rc_price_increase_2999_4999",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Test Increase 29.99 -> 49.99",
+          "subscriptionGroupID" : "D833F705",
+          "type" : "RecurringSubscription"
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "displayPrice" : "",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "80F61C70",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "",
+              "displayName" : "Monthly $10.99",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "rc_1099_1m",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Monthly $10.99",
+          "subscriptionGroupID" : "D833F705",
+          "type" : "RecurringSubscription"
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "displayPrice" : "",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "9D3DBCD0",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "",
+              "displayName" : "Monthly $4.99, 1-week free",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "com.revenuecat.monthly_4.99.1_week_intro",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Monthly $4.99, 1-week free",
+          "subscriptionGroupID" : "D833F705",
+          "type" : "RecurringSubscription"
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "displayPrice" : "",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "7C0D128E",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "",
+              "displayName" : "Annual $39.99, 2-weeks free",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "com.revenuecat.annual_39.99.2_week_intro",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Annual $39.99, 2-weeks free",
+          "subscriptionGroupID" : "D833F705",
+          "type" : "RecurringSubscription"
+        }
+      ]
+    },
+    {
+      "id" : "CAB34497",
+      "localizations" : [
+
+      ],
+      "name" : "$39.99 Annual Group",
+      "subscriptions" : [
+        {
+          "adHocOffers" : [
+
+          ],
+          "displayPrice" : "",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "07F509CC",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "",
+              "displayName" : "Annual $39.99, 1-week free",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "rc_3999_1y_1w0",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Annual $39.99, 1-week free",
+          "subscriptionGroupID" : "CAB34497",
+          "type" : "RecurringSubscription"
+        }
+      ]
+    }
+  ],
+  "version" : {
+    "major" : 1,
+    "minor" : 1
+  }
+}

--- a/revenuecat_examples/purchase_tester/ios/Runner.xcodeproj/project.pbxproj
+++ b/revenuecat_examples/purchase_tester/ios/Runner.xcodeproj/project.pbxproj
@@ -3,11 +3,12 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
+		2CD301FF29E9BFAF005B985D /* RevenueCast_PurchaseTesterTypescriptConfiguration.storekit in Resources */ = {isa = PBXBuildFile; fileRef = 2CD301FE29E9BFAF005B985D /* RevenueCast_PurchaseTesterTypescriptConfiguration.storekit */; };
 		2D1ACC0125152FE800AFB3F4 /* Runner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1ACC0025152FE800AFB3F4 /* Runner.swift */; };
 		34C20D1C7B48D2B45AF2F07F /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 306D644898C47E3CDF95379B /* Pods_Runner.framework */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
@@ -35,6 +36,7 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		2CD301FE29E9BFAF005B985D /* RevenueCast_PurchaseTesterTypescriptConfiguration.storekit */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = RevenueCast_PurchaseTesterTypescriptConfiguration.storekit; sourceTree = "<group>"; };
 		2D1ACBF6251523C800AFB3F4 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		2D1ACC0025152FE800AFB3F4 /* Runner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Runner.swift; sourceTree = "<group>"; };
 		306D644898C47E3CDF95379B /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -99,6 +101,7 @@
 		97C146E51CF9000F007C117D = {
 			isa = PBXGroup;
 			children = (
+				2CD301FE29E9BFAF005B985D /* RevenueCast_PurchaseTesterTypescriptConfiguration.storekit */,
 				2D1ACC0025152FE800AFB3F4 /* Runner.swift */,
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
@@ -216,6 +219,7 @@
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
 				9740EEB41CF90195004384FC /* Debug.xcconfig in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
+				2CD301FF29E9BFAF005B985D /* RevenueCast_PurchaseTesterTypescriptConfiguration.storekit in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -249,6 +253,7 @@
 		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -285,6 +290,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -397,7 +403,10 @@
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
@@ -528,7 +537,10 @@
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
@@ -560,7 +572,10 @@
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",

--- a/revenuecat_examples/purchase_tester/lib/src/app.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/app.dart
@@ -91,11 +91,11 @@ class _MyAppState extends State<InitialScreen> {
     } else {
       final isPro =
           _customerInfo.entitlements.active.containsKey(entitlementKey);
-      if (isPro) {
-        return const CatsScreen();
-      } else {
-        return const UpsellScreen();
-      }
+      // if (isPro) {
+      //   return const CatsScreen();
+      // } else {
+      return const UpsellScreen();
+      // }
     }
   }
 }
@@ -141,6 +141,7 @@ class _UpsellScreenState extends State<UpsellScreen> {
             .map((package) {
               List<Widget> buttons = [
                 _PurchaseButton(package: package),
+                _PurchaseStoreProductButton(storeProduct: package.storeProduct)
               ];
 
               List<Widget> optionButtons =
@@ -208,6 +209,42 @@ class _PurchaseButton extends StatelessWidget {
         },
         child: Text(
             'Buy Package: ${package.storeProduct.subscriptionPeriod ?? package.storeProduct.title}\n${package.storeProduct.priceString}'),
+      );
+}
+
+class _PurchaseStoreProductButton extends StatelessWidget {
+  final StoreProduct storeProduct;
+
+  // ignore: public_member_api_docs
+  const _PurchaseStoreProductButton({Key key, @required this.storeProduct})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) => ElevatedButton(
+        onPressed: () async {
+          try {
+            final customerInfo =
+                await Purchases.purchaseStoreProduct(storeProduct);
+            final isPro =
+                customerInfo.entitlements.active.containsKey(entitlementKey);
+            if (isPro) {
+              return const CatsScreen();
+            }
+          } on PlatformException catch (e) {
+            final errorCode = PurchasesErrorHelper.getErrorCode(e);
+            if (errorCode == PurchasesErrorCode.purchaseCancelledError) {
+              print('User cancelled');
+            } else if (errorCode ==
+                PurchasesErrorCode.purchaseNotAllowedError) {
+              print('User not allowed to purchase');
+            } else if (errorCode == PurchasesErrorCode.paymentPendingError) {
+              print('Payment is pending');
+            }
+          }
+          return const InitialScreen();
+        },
+        child: Text(
+            'Buy StoreProduct (${storeProduct.productCategory}): ${storeProduct.subscriptionPeriod ?? storeProduct.title}\n${storeProduct.priceString}'),
       );
 }
 

--- a/revenuecat_examples/purchase_tester/lib/src/app.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/app.dart
@@ -91,11 +91,11 @@ class _MyAppState extends State<InitialScreen> {
     } else {
       final isPro =
           _customerInfo.entitlements.active.containsKey(entitlementKey);
-      // if (isPro) {
-      //   return const CatsScreen();
-      // } else {
-      return const UpsellScreen();
-      // }
+      if (isPro) {
+        return const CatsScreen();
+      } else {
+        return const UpsellScreen();
+      }
     }
   }
 }

--- a/test/introductory_price_test.dart
+++ b/test/introductory_price_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:purchases_flutter/models/introductory_price.dart';
+import 'package:purchases_flutter/models/period_unit.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -608,7 +608,6 @@ void main() {
       );
       final purchasePackageResult = await Purchases.purchaseProduct(
         mockStoreProduct.identifier,
-        presentedOfferingIdentifier: 'my-offer',
       );
       expect(
         purchasePackageResult,
@@ -626,7 +625,7 @@ void main() {
               'googleOldProductIdentifier': null,
               'googleProrationMode': null,
               'googleIsPersonalizedPrice': null,
-              'presentedOfferingIdentifier': 'my-offer',
+              'presentedOfferingIdentifier': null,
             },
           )
         ],
@@ -655,7 +654,6 @@ void main() {
       final purchasePackageResult = await Purchases.purchaseProduct(
         mockStoreProduct.identifier,
         type: PurchaseType.inapp,
-        presentedOfferingIdentifier: 'my-offer',
       );
       expect(
         purchasePackageResult,
@@ -673,102 +671,6 @@ void main() {
               'googleOldProductIdentifier': null,
               'googleProrationMode': null,
               'googleIsPersonalizedPrice': null,
-              'presentedOfferingIdentifier': 'my-offer',
-            },
-          )
-        ],
-      );
-    } on PlatformException catch (e) {
-      fail('there was an exception ' + e.toString());
-    }
-  });
-
-  test('purchaseProduct with ProductType.inapp calls successfully', () async {
-    try {
-      response = {
-        'productIdentifier': 'product.identifier',
-        'customerInfo': mockCustomerInfoResponse
-      };
-      const mockStoreProduct = StoreProduct(
-        'com.revenuecat.lifetime',
-        'description',
-        'lifetime (PurchasesSample)',
-        199.99,
-        '\$199.99',
-        'USD',
-      );
-      final purchasePackageResult = await Purchases.purchaseProduct(
-        mockStoreProduct.identifier,
-        productType: ProductType.inapp,
-        presentedOfferingIdentifier: 'my-offer',
-      );
-      expect(
-        purchasePackageResult,
-        CustomerInfo.fromJson(mockCustomerInfoResponse),
-      );
-
-      expect(
-        log,
-        <Matcher>[
-          isMethodCall(
-            'purchaseProduct',
-            arguments: <String, dynamic>{
-              'productIdentifier': 'com.revenuecat.lifetime',
-              'type': 'inapp',
-              'googleOldProductIdentifier': null,
-              'googleProrationMode': null,
-              'googleIsPersonalizedPrice': null,
-              'presentedOfferingIdentifier': 'my-offer',
-            },
-          )
-        ],
-      );
-    } on PlatformException catch (e) {
-      fail('there was an exception ' + e.toString());
-    }
-  });
-
-  test(
-      'purchaseProduct with GoogleProductChangeInfo and googleIsPersonalizedPrice calls successfully',
-      () async {
-    try {
-      response = {
-        'productIdentifier': 'product.identifier',
-        'customerInfo': mockCustomerInfoResponse
-      };
-      const mockStoreProduct = StoreProduct(
-        'com.revenuecat.lifetime',
-        'description',
-        'lifetime (PurchasesSample)',
-        199.99,
-        '\$199.99',
-        'USD',
-      );
-      final googleProductChangeInfo = GoogleProductChangeInfo(
-        'com.revenuecat.halftime',
-        prorationMode: GoogleProrationMode.immediateWithTimeProration,
-      );
-      final purchasePackageResult = await Purchases.purchaseProduct(
-        mockStoreProduct.identifier,
-        googleProductChangeInfo: googleProductChangeInfo,
-        googleIsPersonalizedPrice: true,
-      );
-      expect(
-        purchasePackageResult,
-        CustomerInfo.fromJson(mockCustomerInfoResponse),
-      );
-
-      expect(
-        log,
-        <Matcher>[
-          isMethodCall(
-            'purchaseProduct',
-            arguments: <String, dynamic>{
-              'productIdentifier': 'com.revenuecat.lifetime',
-              'type': 'subs',
-              'googleOldProductIdentifier': 'com.revenuecat.halftime',
-              'googleProrationMode': 1,
-              'googleIsPersonalizedPrice': true,
               'presentedOfferingIdentifier': null,
             },
           )
@@ -792,7 +694,7 @@ void main() {
         199.99,
         '\$199.99',
         'USD',
-        productType: ProductType.subs,
+        productCategory: ProductCategory.subscription,
         presentedOfferingIdentifier: 'my-offer',
       );
       final purchasePackageResult =
@@ -809,7 +711,7 @@ void main() {
             'purchaseProduct',
             arguments: <String, dynamic>{
               'productIdentifier': 'com.revenuecat.lifetime',
-              'type': 'subs',
+              'type': 'subscription',
               'googleOldProductIdentifier': null,
               'googleProrationMode': null,
               'googleIsPersonalizedPrice': null,

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -783,7 +783,7 @@ void main() {
         'customerInfo': mockCustomerInfoResponse
       };
       const phase = PricingPhase(
-        Period(Unit.month, 1, 'P1M'),
+        Period(PeriodUnit.month, 1, 'P1M'),
         RecurrenceMode.infiniteRecurring,
         1,
         Price('4.99', 4990000, 'USD'),
@@ -796,7 +796,7 @@ void main() {
         [phase],
         [],
         true,
-        Period(Unit.month, 1, 'P1M'),
+        Period(PeriodUnit.month, 1, 'P1M'),
         phase,
         null,
         null,
@@ -841,7 +841,7 @@ void main() {
         'customerInfo': mockCustomerInfoResponse
       };
       const phase = PricingPhase(
-        Period(Unit.month, 1, 'P1M'),
+        Period(PeriodUnit.month, 1, 'P1M'),
         RecurrenceMode.infiniteRecurring,
         1,
         Price('4.99', 4990000, 'USD'),
@@ -854,7 +854,7 @@ void main() {
         [phase],
         [],
         true,
-        Period(Unit.month, 1, 'P1M'),
+        Period(PeriodUnit.month, 1, 'P1M'),
         phase,
         null,
         null,
@@ -901,7 +901,7 @@ void main() {
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
 
       const phase = PricingPhase(
-        Period(Unit.month, 1, 'P1M'),
+        Period(PeriodUnit.month, 1, 'P1M'),
         RecurrenceMode.infiniteRecurring,
         1,
         Price('4.99', 4990000, 'USD'),
@@ -914,7 +914,7 @@ void main() {
         [phase],
         [],
         true,
-        Period(Unit.month, 1, 'P1M'),
+        Period(PeriodUnit.month, 1, 'P1M'),
         phase,
         null,
         null,


### PR DESCRIPTION
## Motivation

Update to Purchases Hybrid Common Beta 6 which undid breaking change `productType`

## Description

- Rename `ProductType` to `ProductCategory` (unbreaking change)
- Undid deprecated parameters and removed new types in `purchaseProduct()`
  - The whole method is deprecated so need to add new parameter types to it since developer should use `purchaseStoreProduct()` anyway
  - Removed some tests that were no longer with this undo
- Removed duplicate `Unit` and replaced with already existing `PeriodUnit`
  -  Also moved this into its own file