### PR TITLE
Support Gradle 8+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,6 +28,11 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 31
 
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.revenuecat.purchases_flutter'
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,1 +1,3 @@
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536M

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip

--- a/revenuecat_examples/purchase_tester/android/app/build.gradle
+++ b/revenuecat_examples/purchase_tester/android/app/build.gradle
@@ -27,11 +27,12 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 31
 
-    namespace 'com.revenuecat.purchases_sample'
-
     lint {
         disable 'InvalidPackage'
     }
+
+    namespace 'com.revenuecat.purchases_sample'
+
 
     defaultConfig {
         applicationId "com.revenuecat.purchases_sample"

--- a/revenuecat_examples/purchase_tester/android/app/build.gradle
+++ b/revenuecat_examples/purchase_tester/android/app/build.gradle
@@ -32,8 +32,7 @@ android {
     }
 
     namespace 'com.revenuecat.purchases_sample'
-
-
+    
     defaultConfig {
         applicationId "com.revenuecat.purchases_sample"
         minSdkVersion 16
@@ -56,8 +55,6 @@ android {
             signingConfig signingConfigs.debug
         }
     }
-
-    
 }
 
 flutter {

--- a/revenuecat_examples/purchase_tester/android/app/build.gradle
+++ b/revenuecat_examples/purchase_tester/android/app/build.gradle
@@ -32,7 +32,7 @@ android {
     }
 
     namespace 'com.revenuecat.purchases_sample'
-    
+
     defaultConfig {
         applicationId "com.revenuecat.purchases_sample"
         minSdkVersion 16

--- a/revenuecat_examples/purchase_tester/android/app/build.gradle
+++ b/revenuecat_examples/purchase_tester/android/app/build.gradle
@@ -29,6 +29,10 @@ android {
 
     namespace 'com.revenuecat.purchases_sample'
 
+    lint {
+        disable 'InvalidPackage'
+    }
+
     defaultConfig {
         applicationId "com.revenuecat.purchases_sample"
         minSdkVersion 16
@@ -52,9 +56,7 @@ android {
         }
     }
 
-    lint {
-        disable 'InvalidPackage'
-    }
+    
 }
 
 flutter {

--- a/revenuecat_examples/purchase_tester/android/app/build.gradle
+++ b/revenuecat_examples/purchase_tester/android/app/build.gradle
@@ -27,9 +27,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 31
 
-    lintOptions {
-        disable 'InvalidPackage'
-    }
+    namespace 'com.revenuecat.purchases_sample'
 
     defaultConfig {
         applicationId "com.revenuecat.purchases_sample"
@@ -52,6 +50,10 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
         }
+    }
+
+    lint {
+        disable 'InvalidPackage'
     }
 }
 

--- a/revenuecat_examples/purchase_tester/android/app/src/debug/AndroidManifest.xml
+++ b/revenuecat_examples/purchase_tester/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.revenuecat.purchases_sample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/revenuecat_examples/purchase_tester/android/app/src/main/AndroidManifest.xml
+++ b/revenuecat_examples/purchase_tester/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.revenuecat.purchases_sample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.

--- a/revenuecat_examples/purchase_tester/android/app/src/profile/AndroidManifest.xml
+++ b/revenuecat_examples/purchase_tester/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.revenuecat.purchases_sample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/revenuecat_examples/purchase_tester/android/build.gradle
+++ b/revenuecat_examples/purchase_tester/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:7.4.2'
     }
 }
 

--- a/revenuecat_examples/purchase_tester/android/gradle.properties
+++ b/revenuecat_examples/purchase_tester/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
-android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true

--- a/revenuecat_examples/purchase_tester/android/gradle/wrapper/gradle-wrapper.properties
+++ b/revenuecat_examples/purchase_tester/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip


### PR DESCRIPTION
Hello, currently the plugin doesn't build when Gradle 8+ is used. That is because the property `namespace` is mandatory.

* I updated the Android example project.
* I included the namespace property with backwards compatibility