### PR TITLE
Fix deprecation warning

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -452,7 +452,8 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
     }
 
     private void setDebugLogsEnabled(boolean enabled, final Result result) {
-        CommonKt.setDebugLogsEnabled(enabled);
+        String logLevel = enabled ? "DEBUG" : "INFO";
+        CommonKt.setLogLevel(logLevel);
         result.success(null);
     }
 


### PR DESCRIPTION
Fixes #690. 
Fixes a warning about us using a deprecated API. The API as actually in our own PurchasesHybridCommon package, this fixes it by passing in the log level manually. 