### PR TITLE
Fix linter warnings using Flutter 3.10.2 

### DIFF
--- a/lib/models/customer_info_wrapper.dart
+++ b/lib/models/customer_info_wrapper.dart
@@ -43,12 +43,12 @@ class CustomerInfo with _$CustomerInfo {
     @JsonKey(name: 'requestDate') String requestDate, {
 
     /// The latest expiration date of all purchased skus
-    @JsonKey(name: 'latestExpirationDate', nullable: true)
+    @JsonKey(name: 'latestExpirationDate')
         String? latestExpirationDate,
 
     /// Returns the purchase date for the version of the application when the user bought the app.
     /// Use this for grandfathering users when migrating to subscriptions.
-    @JsonKey(name: 'originalPurchaseDate', nullable: true)
+    @JsonKey(name: 'originalPurchaseDate')
         String? originalPurchaseDate,
 
     /// Returns the version number for the version of the application when the
@@ -58,7 +58,7 @@ class CustomerInfo with _$CustomerInfo {
     /// This corresponds to the value of CFBundleVersion (in iOS) in the
     /// Info.plist file when the purchase was originally made. This is always null
     /// in Android
-    @JsonKey(name: 'originalApplicationVersion', nullable: true)
+    @JsonKey(name: 'originalApplicationVersion')
         String? originalApplicationVersion,
 
     /// URL to manage the active subscription of the user. If this user has an active iOS

--- a/lib/models/customer_info_wrapper.freezed.dart
+++ b/lib/models/customer_info_wrapper.freezed.dart
@@ -62,12 +62,12 @@ mixin _$CustomerInfo {
   String get requestDate => throw _privateConstructorUsedError;
 
   /// The latest expiration date of all purchased skus
-  @JsonKey(name: 'latestExpirationDate', nullable: true)
+  @JsonKey(name: 'latestExpirationDate')
   String? get latestExpirationDate => throw _privateConstructorUsedError;
 
   /// Returns the purchase date for the version of the application when the user bought the app.
   /// Use this for grandfathering users when migrating to subscriptions.
-  @JsonKey(name: 'originalPurchaseDate', nullable: true)
+  @JsonKey(name: 'originalPurchaseDate')
   String? get originalPurchaseDate => throw _privateConstructorUsedError;
 
   /// Returns the version number for the version of the application when the
@@ -77,7 +77,7 @@ mixin _$CustomerInfo {
   /// This corresponds to the value of CFBundleVersion (in iOS) in the
   /// Info.plist file when the purchase was originally made. This is always null
   /// in Android
-  @JsonKey(name: 'originalApplicationVersion', nullable: true)
+  @JsonKey(name: 'originalApplicationVersion')
   String? get originalApplicationVersion => throw _privateConstructorUsedError;
 
   /// URL to manage the active subscription of the user. If this user has an active iOS
@@ -118,11 +118,11 @@ abstract class $CustomerInfoCopyWith<$Res> {
           Map<String, String?> allExpirationDates,
       @JsonKey(name: 'requestDate')
           String requestDate,
-      @JsonKey(name: 'latestExpirationDate', nullable: true)
+      @JsonKey(name: 'latestExpirationDate')
           String? latestExpirationDate,
-      @JsonKey(name: 'originalPurchaseDate', nullable: true)
+      @JsonKey(name: 'originalPurchaseDate')
           String? originalPurchaseDate,
-      @JsonKey(name: 'originalApplicationVersion', nullable: true)
+      @JsonKey(name: 'originalApplicationVersion')
           String? originalApplicationVersion,
       @JsonKey(name: 'managementURL')
           String? managementURL});
@@ -249,11 +249,11 @@ abstract class _$$_CustomerInfoCopyWith<$Res>
           Map<String, String?> allExpirationDates,
       @JsonKey(name: 'requestDate')
           String requestDate,
-      @JsonKey(name: 'latestExpirationDate', nullable: true)
+      @JsonKey(name: 'latestExpirationDate')
           String? latestExpirationDate,
-      @JsonKey(name: 'originalPurchaseDate', nullable: true)
+      @JsonKey(name: 'originalPurchaseDate')
           String? originalPurchaseDate,
-      @JsonKey(name: 'originalApplicationVersion', nullable: true)
+      @JsonKey(name: 'originalApplicationVersion')
           String? originalApplicationVersion,
       @JsonKey(name: 'managementURL')
           String? managementURL});
@@ -366,11 +366,11 @@ class _$_CustomerInfo implements _CustomerInfo {
           final Map<String, String?> allExpirationDates,
       @JsonKey(name: 'requestDate')
           this.requestDate,
-      {@JsonKey(name: 'latestExpirationDate', nullable: true)
+      {@JsonKey(name: 'latestExpirationDate')
           this.latestExpirationDate,
-      @JsonKey(name: 'originalPurchaseDate', nullable: true)
+      @JsonKey(name: 'originalPurchaseDate')
           this.originalPurchaseDate,
-      @JsonKey(name: 'originalApplicationVersion', nullable: true)
+      @JsonKey(name: 'originalApplicationVersion')
           this.originalApplicationVersion,
       @JsonKey(name: 'managementURL')
           this.managementURL})
@@ -471,13 +471,13 @@ class _$_CustomerInfo implements _CustomerInfo {
 
   /// The latest expiration date of all purchased skus
   @override
-  @JsonKey(name: 'latestExpirationDate', nullable: true)
+  @JsonKey(name: 'latestExpirationDate')
   final String? latestExpirationDate;
 
   /// Returns the purchase date for the version of the application when the user bought the app.
   /// Use this for grandfathering users when migrating to subscriptions.
   @override
-  @JsonKey(name: 'originalPurchaseDate', nullable: true)
+  @JsonKey(name: 'originalPurchaseDate')
   final String? originalPurchaseDate;
 
   /// Returns the version number for the version of the application when the
@@ -488,7 +488,7 @@ class _$_CustomerInfo implements _CustomerInfo {
   /// Info.plist file when the purchase was originally made. This is always null
   /// in Android
   @override
-  @JsonKey(name: 'originalApplicationVersion', nullable: true)
+  @JsonKey(name: 'originalApplicationVersion')
   final String? originalApplicationVersion;
 
   /// URL to manage the active subscription of the user. If this user has an active iOS
@@ -593,11 +593,11 @@ abstract class _CustomerInfo implements CustomerInfo {
           final Map<String, String?> allExpirationDates,
       @JsonKey(name: 'requestDate')
           final String requestDate,
-      {@JsonKey(name: 'latestExpirationDate', nullable: true)
+      {@JsonKey(name: 'latestExpirationDate')
           final String? latestExpirationDate,
-      @JsonKey(name: 'originalPurchaseDate', nullable: true)
+      @JsonKey(name: 'originalPurchaseDate')
           final String? originalPurchaseDate,
-      @JsonKey(name: 'originalApplicationVersion', nullable: true)
+      @JsonKey(name: 'originalApplicationVersion')
           final String? originalApplicationVersion,
       @JsonKey(name: 'managementURL')
           final String? managementURL}) = _$_CustomerInfo;
@@ -654,13 +654,13 @@ abstract class _CustomerInfo implements CustomerInfo {
   @override
 
   /// The latest expiration date of all purchased skus
-  @JsonKey(name: 'latestExpirationDate', nullable: true)
+  @JsonKey(name: 'latestExpirationDate')
   String? get latestExpirationDate;
   @override
 
   /// Returns the purchase date for the version of the application when the user bought the app.
   /// Use this for grandfathering users when migrating to subscriptions.
-  @JsonKey(name: 'originalPurchaseDate', nullable: true)
+  @JsonKey(name: 'originalPurchaseDate')
   String? get originalPurchaseDate;
   @override
 
@@ -671,7 +671,7 @@ abstract class _CustomerInfo implements CustomerInfo {
   /// This corresponds to the value of CFBundleVersion (in iOS) in the
   /// Info.plist file when the purchase was originally made. This is always null
   /// in Android
-  @JsonKey(name: 'originalApplicationVersion', nullable: true)
+  @JsonKey(name: 'originalApplicationVersion')
   String? get originalApplicationVersion;
   @override
 

--- a/lib/models/entitlement_info_wrapper.dart
+++ b/lib/models/entitlement_info_wrapper.dart
@@ -101,21 +101,21 @@ class EntitlementInfo with _$EntitlementInfo {
     /// The expiration date for the entitlement, can be null for lifetime access.
     /// If the [periodType] is [PeriodType.trial],
     /// this is the trial expiration date.
-    @JsonKey(name: 'expirationDate', nullable: true)
+    @JsonKey(name: 'expirationDate')
         String? expirationDate,
 
     /// The date an unsubscribe was detected. Can be null if it's still
     /// subscribed or product is not a subscription.
     /// @note: Entitlement may still be active even if user has unsubscribed.
     /// Check the [isActive] property.
-    @JsonKey(name: 'unsubscribeDetectedAt', nullable: true)
+    @JsonKey(name: 'unsubscribeDetectedAt')
         String? unsubscribeDetectedAt,
 
     /// The date a billing issue was detected. Can be null if there is no
     /// billing issue or an issue has been resolved.
     /// @note: Entitlement may still be active even if there is a billing issue.
     /// Check the [isActive] property.
-    @JsonKey(name: 'billingIssueDetectedAt', nullable: true)
+    @JsonKey(name: 'billingIssueDetectedAt')
         String? billingIssueDetectedAt,
   }) = _EntitlementInfo;
 

--- a/lib/models/entitlement_info_wrapper.freezed.dart
+++ b/lib/models/entitlement_info_wrapper.freezed.dart
@@ -67,21 +67,21 @@ mixin _$EntitlementInfo {
   /// The expiration date for the entitlement, can be null for lifetime access.
   /// If the [periodType] is [PeriodType.trial],
   /// this is the trial expiration date.
-  @JsonKey(name: 'expirationDate', nullable: true)
+  @JsonKey(name: 'expirationDate')
   String? get expirationDate => throw _privateConstructorUsedError;
 
   /// The date an unsubscribe was detected. Can be null if it's still
   /// subscribed or product is not a subscription.
   /// @note: Entitlement may still be active even if user has unsubscribed.
   /// Check the [isActive] property.
-  @JsonKey(name: 'unsubscribeDetectedAt', nullable: true)
+  @JsonKey(name: 'unsubscribeDetectedAt')
   String? get unsubscribeDetectedAt => throw _privateConstructorUsedError;
 
   /// The date a billing issue was detected. Can be null if there is no
   /// billing issue or an issue has been resolved.
   /// @note: Entitlement may still be active even if there is a billing issue.
   /// Check the [isActive] property.
-  @JsonKey(name: 'billingIssueDetectedAt', nullable: true)
+  @JsonKey(name: 'billingIssueDetectedAt')
   String? get billingIssueDetectedAt => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -117,11 +117,11 @@ abstract class $EntitlementInfoCopyWith<$Res> {
           Store store,
       @JsonKey(name: 'periodType', unknownEnumValue: PeriodType.unknown)
           PeriodType periodType,
-      @JsonKey(name: 'expirationDate', nullable: true)
+      @JsonKey(name: 'expirationDate')
           String? expirationDate,
-      @JsonKey(name: 'unsubscribeDetectedAt', nullable: true)
+      @JsonKey(name: 'unsubscribeDetectedAt')
           String? unsubscribeDetectedAt,
-      @JsonKey(name: 'billingIssueDetectedAt', nullable: true)
+      @JsonKey(name: 'billingIssueDetectedAt')
           String? billingIssueDetectedAt});
 }
 
@@ -238,11 +238,11 @@ abstract class _$$_EntitlementInfoCopyWith<$Res>
           Store store,
       @JsonKey(name: 'periodType', unknownEnumValue: PeriodType.unknown)
           PeriodType periodType,
-      @JsonKey(name: 'expirationDate', nullable: true)
+      @JsonKey(name: 'expirationDate')
           String? expirationDate,
-      @JsonKey(name: 'unsubscribeDetectedAt', nullable: true)
+      @JsonKey(name: 'unsubscribeDetectedAt')
           String? unsubscribeDetectedAt,
-      @JsonKey(name: 'billingIssueDetectedAt', nullable: true)
+      @JsonKey(name: 'billingIssueDetectedAt')
           String? billingIssueDetectedAt});
 }
 
@@ -352,11 +352,11 @@ class _$_EntitlementInfo implements _EntitlementInfo {
           this.store = Store.unknownStore,
       @JsonKey(name: 'periodType', unknownEnumValue: PeriodType.unknown)
           this.periodType = PeriodType.unknown,
-      @JsonKey(name: 'expirationDate', nullable: true)
+      @JsonKey(name: 'expirationDate')
           this.expirationDate,
-      @JsonKey(name: 'unsubscribeDetectedAt', nullable: true)
+      @JsonKey(name: 'unsubscribeDetectedAt')
           this.unsubscribeDetectedAt,
-      @JsonKey(name: 'billingIssueDetectedAt', nullable: true)
+      @JsonKey(name: 'billingIssueDetectedAt')
           this.billingIssueDetectedAt});
 
   factory _$_EntitlementInfo.fromJson(Map<String, dynamic> json) =>
@@ -420,7 +420,7 @@ class _$_EntitlementInfo implements _EntitlementInfo {
   /// If the [periodType] is [PeriodType.trial],
   /// this is the trial expiration date.
   @override
-  @JsonKey(name: 'expirationDate', nullable: true)
+  @JsonKey(name: 'expirationDate')
   final String? expirationDate;
 
   /// The date an unsubscribe was detected. Can be null if it's still
@@ -428,7 +428,7 @@ class _$_EntitlementInfo implements _EntitlementInfo {
   /// @note: Entitlement may still be active even if user has unsubscribed.
   /// Check the [isActive] property.
   @override
-  @JsonKey(name: 'unsubscribeDetectedAt', nullable: true)
+  @JsonKey(name: 'unsubscribeDetectedAt')
   final String? unsubscribeDetectedAt;
 
   /// The date a billing issue was detected. Can be null if there is no
@@ -436,7 +436,7 @@ class _$_EntitlementInfo implements _EntitlementInfo {
   /// @note: Entitlement may still be active even if there is a billing issue.
   /// Check the [isActive] property.
   @override
-  @JsonKey(name: 'billingIssueDetectedAt', nullable: true)
+  @JsonKey(name: 'billingIssueDetectedAt')
   final String? billingIssueDetectedAt;
 
   @override
@@ -530,11 +530,11 @@ abstract class _EntitlementInfo implements EntitlementInfo {
           final Store store,
       @JsonKey(name: 'periodType', unknownEnumValue: PeriodType.unknown)
           final PeriodType periodType,
-      @JsonKey(name: 'expirationDate', nullable: true)
+      @JsonKey(name: 'expirationDate')
           final String? expirationDate,
-      @JsonKey(name: 'unsubscribeDetectedAt', nullable: true)
+      @JsonKey(name: 'unsubscribeDetectedAt')
           final String? unsubscribeDetectedAt,
-      @JsonKey(name: 'billingIssueDetectedAt', nullable: true)
+      @JsonKey(name: 'billingIssueDetectedAt')
           final String? billingIssueDetectedAt}) = _$_EntitlementInfo;
 
   factory _EntitlementInfo.fromJson(Map<String, dynamic> json) =
@@ -599,7 +599,7 @@ abstract class _EntitlementInfo implements EntitlementInfo {
   /// The expiration date for the entitlement, can be null for lifetime access.
   /// If the [periodType] is [PeriodType.trial],
   /// this is the trial expiration date.
-  @JsonKey(name: 'expirationDate', nullable: true)
+  @JsonKey(name: 'expirationDate')
   String? get expirationDate;
   @override
 
@@ -607,7 +607,7 @@ abstract class _EntitlementInfo implements EntitlementInfo {
   /// subscribed or product is not a subscription.
   /// @note: Entitlement may still be active even if user has unsubscribed.
   /// Check the [isActive] property.
-  @JsonKey(name: 'unsubscribeDetectedAt', nullable: true)
+  @JsonKey(name: 'unsubscribeDetectedAt')
   String? get unsubscribeDetectedAt;
   @override
 
@@ -615,7 +615,7 @@ abstract class _EntitlementInfo implements EntitlementInfo {
   /// billing issue or an issue has been resolved.
   /// @note: Entitlement may still be active even if there is a billing issue.
   /// Check the [isActive] property.
-  @JsonKey(name: 'billingIssueDetectedAt', nullable: true)
+  @JsonKey(name: 'billingIssueDetectedAt')
   String? get billingIssueDetectedAt;
   @override
   @JsonKey(ignore: true)

--- a/lib/models/offerings_wrapper.dart
+++ b/lib/models/offerings_wrapper.dart
@@ -16,7 +16,7 @@ class Offerings with _$Offerings {
     @JsonKey(name: 'all') Map<String, Offering> all, {
 
     /// Current offering configured in the RevenueCat dashboard.
-    @JsonKey(name: 'current', nullable: true) Offering? current,
+    @JsonKey(name: 'current') Offering? current,
   }) = _Offerings;
 
   /// Retrieves an specific offering by its identifier.

--- a/lib/models/offerings_wrapper.freezed.dart
+++ b/lib/models/offerings_wrapper.freezed.dart
@@ -25,7 +25,7 @@ mixin _$Offerings {
   Map<String, Offering> get all => throw _privateConstructorUsedError;
 
   /// Current offering configured in the RevenueCat dashboard.
-  @JsonKey(name: 'current', nullable: true)
+  @JsonKey(name: 'current')
   Offering? get current => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -41,7 +41,7 @@ abstract class $OfferingsCopyWith<$Res> {
   @useResult
   $Res call(
       {@JsonKey(name: 'all') Map<String, Offering> all,
-      @JsonKey(name: 'current', nullable: true) Offering? current});
+      @JsonKey(name: 'current') Offering? current});
 
   $OfferingCopyWith<$Res>? get current;
 }
@@ -96,7 +96,7 @@ abstract class _$$_OfferingsCopyWith<$Res> implements $OfferingsCopyWith<$Res> {
   @useResult
   $Res call(
       {@JsonKey(name: 'all') Map<String, Offering> all,
-      @JsonKey(name: 'current', nullable: true) Offering? current});
+      @JsonKey(name: 'current') Offering? current});
 
   @override
   $OfferingCopyWith<$Res>? get current;
@@ -133,7 +133,7 @@ class __$$_OfferingsCopyWithImpl<$Res>
 @JsonSerializable()
 class _$_Offerings extends _Offerings {
   const _$_Offerings(@JsonKey(name: 'all') final Map<String, Offering> all,
-      {@JsonKey(name: 'current', nullable: true) this.current})
+      {@JsonKey(name: 'current') this.current})
       : _all = all,
         super._();
 
@@ -154,7 +154,7 @@ class _$_Offerings extends _Offerings {
 
   /// Current offering configured in the RevenueCat dashboard.
   @override
-  @JsonKey(name: 'current', nullable: true)
+  @JsonKey(name: 'current')
   final Offering? current;
 
   @override
@@ -192,9 +192,8 @@ class _$_Offerings extends _Offerings {
 
 abstract class _Offerings extends Offerings {
   const factory _Offerings(
-          @JsonKey(name: 'all') final Map<String, Offering> all,
-          {@JsonKey(name: 'current', nullable: true) final Offering? current}) =
-      _$_Offerings;
+      @JsonKey(name: 'all') final Map<String, Offering> all,
+      {@JsonKey(name: 'current') final Offering? current}) = _$_Offerings;
   const _Offerings._() : super._();
 
   factory _Offerings.fromJson(Map<String, dynamic> json) =
@@ -208,7 +207,7 @@ abstract class _Offerings extends Offerings {
   @override
 
   /// Current offering configured in the RevenueCat dashboard.
-  @JsonKey(name: 'current', nullable: true)
+  @JsonKey(name: 'current')
   Offering? get current;
   @override
   @JsonKey(ignore: true)

--- a/lib/models/store_product_wrapper.dart
+++ b/lib/models/store_product_wrapper.dart
@@ -30,11 +30,11 @@ class StoreProduct with _$StoreProduct {
     @JsonKey(name: 'currencyCode') String currencyCode, {
 
     /// Introductory price for product. Can be null.
-    @JsonKey(name: 'introPrice', nullable: true)
+    @JsonKey(name: 'introPrice')
         IntroductoryPrice? introductoryPrice,
 
     /// Collection of discount offers for a product. Null for Android.
-    @JsonKey(name: 'discounts', nullable: true)
+    @JsonKey(name: 'discounts')
         List<StoreProductDiscount>? discounts,
 
     /// Subscription period, specified in ISO 8601 format. For example,
@@ -42,7 +42,7 @@ class StoreProduct with _$StoreProduct {
     /// P3M equates to three months, P6M equates to six months,
     /// and P1Y equates to one year.
     /// Note: Not available for Amazon.
-    @JsonKey(name: 'subscriptionPeriod', nullable: true)
+    @JsonKey(name: 'subscriptionPeriod')
         String? subscriptionPeriod,
   }) = _StoreProduct;
 

--- a/lib/models/store_product_wrapper.freezed.dart
+++ b/lib/models/store_product_wrapper.freezed.dart
@@ -45,12 +45,12 @@ mixin _$StoreProduct {
   String get currencyCode => throw _privateConstructorUsedError;
 
   /// Introductory price for product. Can be null.
-  @JsonKey(name: 'introPrice', nullable: true)
+  @JsonKey(name: 'introPrice')
   IntroductoryPrice? get introductoryPrice =>
       throw _privateConstructorUsedError;
 
   /// Collection of discount offers for a product. Null for Android.
-  @JsonKey(name: 'discounts', nullable: true)
+  @JsonKey(name: 'discounts')
   List<StoreProductDiscount>? get discounts =>
       throw _privateConstructorUsedError;
 
@@ -59,7 +59,7 @@ mixin _$StoreProduct {
   /// P3M equates to three months, P6M equates to six months,
   /// and P1Y equates to one year.
   /// Note: Not available for Amazon.
-  @JsonKey(name: 'subscriptionPeriod', nullable: true)
+  @JsonKey(name: 'subscriptionPeriod')
   String? get subscriptionPeriod => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -75,24 +75,15 @@ abstract class $StoreProductCopyWith<$Res> {
       _$StoreProductCopyWithImpl<$Res, StoreProduct>;
   @useResult
   $Res call(
-      {@JsonKey(name: 'identifier')
-          String identifier,
-      @JsonKey(name: 'description')
-          String description,
-      @JsonKey(name: 'title')
-          String title,
-      @JsonKey(name: 'price')
-          double price,
-      @JsonKey(name: 'priceString')
-          String priceString,
-      @JsonKey(name: 'currencyCode')
-          String currencyCode,
-      @JsonKey(name: 'introPrice', nullable: true)
-          IntroductoryPrice? introductoryPrice,
-      @JsonKey(name: 'discounts', nullable: true)
-          List<StoreProductDiscount>? discounts,
-      @JsonKey(name: 'subscriptionPeriod', nullable: true)
-          String? subscriptionPeriod});
+      {@JsonKey(name: 'identifier') String identifier,
+      @JsonKey(name: 'description') String description,
+      @JsonKey(name: 'title') String title,
+      @JsonKey(name: 'price') double price,
+      @JsonKey(name: 'priceString') String priceString,
+      @JsonKey(name: 'currencyCode') String currencyCode,
+      @JsonKey(name: 'introPrice') IntroductoryPrice? introductoryPrice,
+      @JsonKey(name: 'discounts') List<StoreProductDiscount>? discounts,
+      @JsonKey(name: 'subscriptionPeriod') String? subscriptionPeriod});
 
   $IntroductoryPriceCopyWith<$Res>? get introductoryPrice;
 }
@@ -182,24 +173,15 @@ abstract class _$$_StoreProductCopyWith<$Res>
   @override
   @useResult
   $Res call(
-      {@JsonKey(name: 'identifier')
-          String identifier,
-      @JsonKey(name: 'description')
-          String description,
-      @JsonKey(name: 'title')
-          String title,
-      @JsonKey(name: 'price')
-          double price,
-      @JsonKey(name: 'priceString')
-          String priceString,
-      @JsonKey(name: 'currencyCode')
-          String currencyCode,
-      @JsonKey(name: 'introPrice', nullable: true)
-          IntroductoryPrice? introductoryPrice,
-      @JsonKey(name: 'discounts', nullable: true)
-          List<StoreProductDiscount>? discounts,
-      @JsonKey(name: 'subscriptionPeriod', nullable: true)
-          String? subscriptionPeriod});
+      {@JsonKey(name: 'identifier') String identifier,
+      @JsonKey(name: 'description') String description,
+      @JsonKey(name: 'title') String title,
+      @JsonKey(name: 'price') double price,
+      @JsonKey(name: 'priceString') String priceString,
+      @JsonKey(name: 'currencyCode') String currencyCode,
+      @JsonKey(name: 'introPrice') IntroductoryPrice? introductoryPrice,
+      @JsonKey(name: 'discounts') List<StoreProductDiscount>? discounts,
+      @JsonKey(name: 'subscriptionPeriod') String? subscriptionPeriod});
 
   @override
   $IntroductoryPriceCopyWith<$Res>? get introductoryPrice;
@@ -271,24 +253,15 @@ class __$$_StoreProductCopyWithImpl<$Res>
 @JsonSerializable()
 class _$_StoreProduct implements _StoreProduct {
   const _$_StoreProduct(
-      @JsonKey(name: 'identifier')
-          this.identifier,
-      @JsonKey(name: 'description')
-          this.description,
-      @JsonKey(name: 'title')
-          this.title,
-      @JsonKey(name: 'price')
-          this.price,
-      @JsonKey(name: 'priceString')
-          this.priceString,
-      @JsonKey(name: 'currencyCode')
-          this.currencyCode,
-      {@JsonKey(name: 'introPrice', nullable: true)
-          this.introductoryPrice,
-      @JsonKey(name: 'discounts', nullable: true)
-          final List<StoreProductDiscount>? discounts,
-      @JsonKey(name: 'subscriptionPeriod', nullable: true)
-          this.subscriptionPeriod})
+      @JsonKey(name: 'identifier') this.identifier,
+      @JsonKey(name: 'description') this.description,
+      @JsonKey(name: 'title') this.title,
+      @JsonKey(name: 'price') this.price,
+      @JsonKey(name: 'priceString') this.priceString,
+      @JsonKey(name: 'currencyCode') this.currencyCode,
+      {@JsonKey(name: 'introPrice') this.introductoryPrice,
+      @JsonKey(name: 'discounts') final List<StoreProductDiscount>? discounts,
+      @JsonKey(name: 'subscriptionPeriod') this.subscriptionPeriod})
       : _discounts = discounts;
 
   factory _$_StoreProduct.fromJson(Map<String, dynamic> json) =>
@@ -326,7 +299,7 @@ class _$_StoreProduct implements _StoreProduct {
 
   /// Introductory price for product. Can be null.
   @override
-  @JsonKey(name: 'introPrice', nullable: true)
+  @JsonKey(name: 'introPrice')
   final IntroductoryPrice? introductoryPrice;
 
   /// Collection of discount offers for a product. Null for Android.
@@ -334,7 +307,7 @@ class _$_StoreProduct implements _StoreProduct {
 
   /// Collection of discount offers for a product. Null for Android.
   @override
-  @JsonKey(name: 'discounts', nullable: true)
+  @JsonKey(name: 'discounts')
   List<StoreProductDiscount>? get discounts {
     final value = _discounts;
     if (value == null) return null;
@@ -349,7 +322,7 @@ class _$_StoreProduct implements _StoreProduct {
   /// and P1Y equates to one year.
   /// Note: Not available for Amazon.
   @override
-  @JsonKey(name: 'subscriptionPeriod', nullable: true)
+  @JsonKey(name: 'subscriptionPeriod')
   final String? subscriptionPeriod;
 
   @override
@@ -422,11 +395,11 @@ abstract class _StoreProduct implements StoreProduct {
           final String priceString,
       @JsonKey(name: 'currencyCode')
           final String currencyCode,
-      {@JsonKey(name: 'introPrice', nullable: true)
+      {@JsonKey(name: 'introPrice')
           final IntroductoryPrice? introductoryPrice,
-      @JsonKey(name: 'discounts', nullable: true)
+      @JsonKey(name: 'discounts')
           final List<StoreProductDiscount>? discounts,
-      @JsonKey(name: 'subscriptionPeriod', nullable: true)
+      @JsonKey(name: 'subscriptionPeriod')
           final String? subscriptionPeriod}) = _$_StoreProduct;
 
   factory _StoreProduct.fromJson(Map<String, dynamic> json) =
@@ -465,12 +438,12 @@ abstract class _StoreProduct implements StoreProduct {
   @override
 
   /// Introductory price for product. Can be null.
-  @JsonKey(name: 'introPrice', nullable: true)
+  @JsonKey(name: 'introPrice')
   IntroductoryPrice? get introductoryPrice;
   @override
 
   /// Collection of discount offers for a product. Null for Android.
-  @JsonKey(name: 'discounts', nullable: true)
+  @JsonKey(name: 'discounts')
   List<StoreProductDiscount>? get discounts;
   @override
 
@@ -479,7 +452,7 @@ abstract class _StoreProduct implements StoreProduct {
   /// P3M equates to three months, P6M equates to six months,
   /// and P1Y equates to one year.
   /// Note: Not available for Amazon.
-  @JsonKey(name: 'subscriptionPeriod', nullable: true)
+  @JsonKey(name: 'subscriptionPeriod')
   String? get subscriptionPeriod;
   @override
   @JsonKey(ignore: true)

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -414,8 +414,10 @@ class Purchases {
   /// Configures log level
   /// Used to set the log level. Useful for debugging issues with the lovely team @RevenueCat.
   /// The default is {LOG_LEVEL.INFO} in release builds and {LOG_LEVEL.DEBUG} in debug builds.
-  static Future<void> setLogLevel(LogLevel level) =>
-      _channel.invokeMethod('setLogLevel', {'level': level.name.toUpperCase()});
+  static Future<void> setLogLevel(LogLevel level) => _channel.invokeMethod(
+        'setLogLevel',
+        {'level': describeEnum(level).toUpperCase()},
+      );
 
   ///
   /// iOS only. Set this property to true *only* when testing the ask-to-buy / SCA purchases flow.
@@ -802,7 +804,10 @@ class Purchases {
   static void handleLogHandlerEvent(MethodCall call) {
     final args = Map<String, dynamic>.from(call.arguments);
     final logLevelName = args['logLevel'];
-    final logLevel = LogLevel.values.firstWhere((e) => e.name.toUpperCase() == logLevelName, orElse: () => LogLevel.info);
+    final logLevel = LogLevel.values.firstWhere(
+      (e) => describeEnum(e).toUpperCase() == logLevelName,
+      orElse: () => LogLevel.info,
+    );
     final msg = args['message'];
     _logHandler?.call(logLevel, msg);
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -297,10 +297,10 @@ packages:
     dependency: "direct main"
     description:
       name: json_annotation
-      sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
+      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "4.8.1"
   json_serializable:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter:
     sdk: flutter
   freezed_annotation: ^2.0.1
-  json_annotation: ^4.6.0
+  json_annotation: ^4.8.1
 
 dev_dependencies:
   build_runner: ^2.1.10


### PR DESCRIPTION
See failures in https://circleci.com/gh/RevenueCat/purchases-flutter/8654

```
Analyzing lib...                                                

   info • 'nullable' is deprecated and shouldn't be used. Has no effect • lib/models/customer_info_wrapper.dart:46:44 • deprecated_member_use
   info • 'nullable' is deprecated and shouldn't be used. Has no effect • lib/models/customer_info_wrapper.dart:51:44 • deprecated_member_use
   info • 'nullable' is deprecated and shouldn't be used. Has no effect • lib/models/customer_info_wrapper.dart:61:50 • deprecated_member_use
   info • 'nullable' is deprecated and shouldn't be used. Has no effect • lib/models/entitlement_info_wrapper.dart:104:38 • deprecated_member_use
   info • 'nullable' is deprecated and shouldn't be used. Has no effect • lib/models/entitlement_info_wrapper.dart:111:45 • deprecated_member_use
   info • 'nullable' is deprecated and shouldn't be used. Has no effect • lib/models/entitlement_info_wrapper.dart:118:46 • deprecated_member_use
   info • 'nullable' is deprecated and shouldn't be used. Has no effect • lib/models/offerings_wrapper.dart:19:31 • deprecated_member_use
   info • 'nullable' is deprecated and shouldn't be used. Has no effect • lib/models/store_product_wrapper.dart:33:34 • deprecated_member_use
   info • 'nullable' is deprecated and shouldn't be used. Has no effect • lib/models/store_product_wrapper.dart:37:33 • deprecated_member_use
   info • 'nullable' is deprecated and shouldn't be used. Has no effect • lib/models/store_product_wrapper.dart:45:42 • deprecated_member_use
warning • This API is available since SDK 2.15.0, but constraints '>=2.12.0 <3.0.0' don't guarantee it • lib/purchases_flutter.dart:418:60 • sdk_version_since
warning • This API is available since SDK 2.15.0, but constraints '>=2.12.0 <3.0.0' don't guarantee it • lib/purchases_flutter.dart:805:58 • sdk_version_since

12 issues found. (ran in 4.8s)
```

