### PR TITLE
Adding metadata to offering

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ version '5.0.0-beta.2'
 
 buildscript {
     ext.kotlin_version = '1.7.21'
-    ext.common_version = '5.0.0-beta.6'
+    ext.common_version = '5.0.0-rc.1'
     repositories {
         google()
         mavenCentral()

--- a/api_tester/lib/api_tests/models/offering_wrapper_api_test.dart
+++ b/api_tester/lib/api_tests/models/offering_wrapper_api_test.dart
@@ -14,6 +14,7 @@ class _OfferingApiTest {
   void _checkConstructor(
       String identifier,
       String serverDescription,
+      Map<String, Object> metadata,
       List<Package> availablePackages,
       Package? lifetime,
       Package? annual,
@@ -23,8 +24,9 @@ class _OfferingApiTest {
       Package? monthly,
       Package? weekly) {
     Offering offering =
-        Offering(identifier, serverDescription, availablePackages);
-    offering = Offering(identifier, serverDescription, availablePackages,
+        Offering(identifier, serverDescription, metadata, availablePackages);
+    offering = Offering(
+        identifier, serverDescription, metadata, availablePackages,
         lifetime: lifetime,
         annual: annual,
         sixMonth: sixMonth,

--- a/api_tester/lib/api_tests/models/offering_wrapper_api_test.dart
+++ b/api_tester/lib/api_tests/models/offering_wrapper_api_test.dart
@@ -46,6 +46,8 @@ class _OfferingApiTest {
     Package? twoMonth = offering.twoMonth;
     Package? monthly = offering.monthly;
     Package? weekly = offering.weekly;
+
+    String value = offering.getMetadataString('key', 'default value');
   }
 
   void _checkListOfPackagesExtension(List<Package> packages) {

--- a/api_tester/lib/api_tests/models/offering_wrapper_api_test.dart
+++ b/api_tester/lib/api_tests/models/offering_wrapper_api_test.dart
@@ -37,6 +37,7 @@ class _OfferingApiTest {
   void _checkProperties(Offering offering) {
     String identifier = offering.identifier;
     String serverDescription = offering.serverDescription;
+    Map<String, Object> metadata = offering.metadata;
     List<Package> availablePackages = offering.availablePackages;
     Package? lifetime = offering.lifetime;
     Package? annual = offering.annual;

--- a/ios/purchases_flutter.podspec
+++ b/ios/purchases_flutter.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'PurchasesHybridCommon', '5.0.0-beta.6'
+  s.dependency 'PurchasesHybridCommon', '5.0.0-rc.1'
   s.ios.deployment_target = '11.0'
   s.swift_version         = '5.0'
 

--- a/lib/models/offering_wrapper.dart
+++ b/lib/models/offering_wrapper.dart
@@ -18,9 +18,11 @@ class Offering with _$Offering {
     /// Offering description defined in RevenueCat dashboard.
     @JsonKey(name: 'serverDescription') String serverDescription,
 
+    /// Offering metadata defined in RevenueCat dashboard.
+    @JsonKey(name: 'metadata') Map<String, Object> metadata,
+
     /// Array of [Package] objects available for purchase.
     @JsonKey(name: 'availablePackages') List<Package> availablePackages, {
-
     /// Lifetime package type configured in the RevenueCat dashboard, if available.
     @JsonKey(name: 'lifetime') Package? lifetime,
 

--- a/lib/models/offering_wrapper.dart
+++ b/lib/models/offering_wrapper.dart
@@ -54,6 +54,16 @@ class Offering with _$Offering {
       _$OfferingFromJson(json);
 }
 
+extension OfferingX on Offering {
+  String getMetadataString(String key, String defaultValue) {
+    final value = metadata[key];
+    if (value is String) {
+      return value;
+    }
+    return defaultValue;
+  }
+}
+
 // Extension needed because this was a deprecation from freezed 1.x that
 // was removed in 2.x. Freezed is no longer including package:collection
 extension PackageListX on List<Package> {

--- a/lib/models/offering_wrapper.dart
+++ b/lib/models/offering_wrapper.dart
@@ -55,6 +55,13 @@ class Offering with _$Offering {
 }
 
 extension OfferingX on Offering {
+  /// Returns the [metadata] value associated to [key] for the expected [String] type
+  /// or [defaultValue] if not found, or it's not the expected [String] type.
+  ///
+  /// [key] The metadata key to lookup
+  ///
+  /// [defaultValue] The default value if a key isn't found or if not
+  /// the expected String type
   String getMetadataString(String key, String defaultValue) {
     final value = metadata[key];
     if (value != null && value is String) {

--- a/lib/models/offering_wrapper.dart
+++ b/lib/models/offering_wrapper.dart
@@ -57,7 +57,7 @@ class Offering with _$Offering {
 extension OfferingX on Offering {
   String getMetadataString(String key, String defaultValue) {
     final value = metadata[key];
-    if (value is String) {
+    if (value != null && value is String) {
       return value;
     }
     return defaultValue;

--- a/lib/models/offering_wrapper.freezed.dart
+++ b/lib/models/offering_wrapper.freezed.dart
@@ -28,6 +28,10 @@ mixin _$Offering {
   @JsonKey(name: 'serverDescription')
   String get serverDescription => throw _privateConstructorUsedError;
 
+  /// Offering metadata defined in RevenueCat dashboard.
+  @JsonKey(name: 'metadata')
+  Map<String, Object> get metadata => throw _privateConstructorUsedError;
+
   /// Array of [Package] objects available for purchase.
   @JsonKey(name: 'availablePackages')
   List<Package> get availablePackages => throw _privateConstructorUsedError;
@@ -74,6 +78,7 @@ abstract class $OfferingCopyWith<$Res> {
   $Res call(
       {@JsonKey(name: 'identifier') String identifier,
       @JsonKey(name: 'serverDescription') String serverDescription,
+      @JsonKey(name: 'metadata') Map<String, Object> metadata,
       @JsonKey(name: 'availablePackages') List<Package> availablePackages,
       @JsonKey(name: 'lifetime') Package? lifetime,
       @JsonKey(name: 'annual') Package? annual,
@@ -107,6 +112,7 @@ class _$OfferingCopyWithImpl<$Res, $Val extends Offering>
   $Res call({
     Object? identifier = null,
     Object? serverDescription = null,
+    Object? metadata = null,
     Object? availablePackages = null,
     Object? lifetime = freezed,
     Object? annual = freezed,
@@ -125,6 +131,10 @@ class _$OfferingCopyWithImpl<$Res, $Val extends Offering>
           ? _value.serverDescription
           : serverDescription // ignore: cast_nullable_to_non_nullable
               as String,
+      metadata: null == metadata
+          ? _value.metadata
+          : metadata // ignore: cast_nullable_to_non_nullable
+              as Map<String, Object>,
       availablePackages: null == availablePackages
           ? _value.availablePackages
           : availablePackages // ignore: cast_nullable_to_non_nullable
@@ -255,6 +265,7 @@ abstract class _$$_OfferingCopyWith<$Res> implements $OfferingCopyWith<$Res> {
   $Res call(
       {@JsonKey(name: 'identifier') String identifier,
       @JsonKey(name: 'serverDescription') String serverDescription,
+      @JsonKey(name: 'metadata') Map<String, Object> metadata,
       @JsonKey(name: 'availablePackages') List<Package> availablePackages,
       @JsonKey(name: 'lifetime') Package? lifetime,
       @JsonKey(name: 'annual') Package? annual,
@@ -293,6 +304,7 @@ class __$$_OfferingCopyWithImpl<$Res>
   $Res call({
     Object? identifier = null,
     Object? serverDescription = null,
+    Object? metadata = null,
     Object? availablePackages = null,
     Object? lifetime = freezed,
     Object? annual = freezed,
@@ -311,6 +323,10 @@ class __$$_OfferingCopyWithImpl<$Res>
           ? _value.serverDescription
           : serverDescription // ignore: cast_nullable_to_non_nullable
               as String,
+      null == metadata
+          ? _value._metadata
+          : metadata // ignore: cast_nullable_to_non_nullable
+              as Map<String, Object>,
       null == availablePackages
           ? _value._availablePackages
           : availablePackages // ignore: cast_nullable_to_non_nullable
@@ -353,6 +369,7 @@ class _$_Offering extends _Offering {
   const _$_Offering(
       @JsonKey(name: 'identifier') this.identifier,
       @JsonKey(name: 'serverDescription') this.serverDescription,
+      @JsonKey(name: 'metadata') final Map<String, Object> metadata,
       @JsonKey(name: 'availablePackages') final List<Package> availablePackages,
       {@JsonKey(name: 'lifetime') this.lifetime,
       @JsonKey(name: 'annual') this.annual,
@@ -361,7 +378,8 @@ class _$_Offering extends _Offering {
       @JsonKey(name: 'twoMonth') this.twoMonth,
       @JsonKey(name: 'monthly') this.monthly,
       @JsonKey(name: 'weekly') this.weekly})
-      : _availablePackages = availablePackages,
+      : _metadata = metadata,
+        _availablePackages = availablePackages,
         super._();
 
   factory _$_Offering.fromJson(Map<String, dynamic> json) =>
@@ -376,6 +394,18 @@ class _$_Offering extends _Offering {
   @override
   @JsonKey(name: 'serverDescription')
   final String serverDescription;
+
+  /// Offering metadata defined in RevenueCat dashboard.
+  final Map<String, Object> _metadata;
+
+  /// Offering metadata defined in RevenueCat dashboard.
+  @override
+  @JsonKey(name: 'metadata')
+  Map<String, Object> get metadata {
+    if (_metadata is EqualUnmodifiableMapView) return _metadata;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(_metadata);
+  }
 
   /// Array of [Package] objects available for purchase.
   final List<Package> _availablePackages;
@@ -427,7 +457,7 @@ class _$_Offering extends _Offering {
 
   @override
   String toString() {
-    return 'Offering(identifier: $identifier, serverDescription: $serverDescription, availablePackages: $availablePackages, lifetime: $lifetime, annual: $annual, sixMonth: $sixMonth, threeMonth: $threeMonth, twoMonth: $twoMonth, monthly: $monthly, weekly: $weekly)';
+    return 'Offering(identifier: $identifier, serverDescription: $serverDescription, metadata: $metadata, availablePackages: $availablePackages, lifetime: $lifetime, annual: $annual, sixMonth: $sixMonth, threeMonth: $threeMonth, twoMonth: $twoMonth, monthly: $monthly, weekly: $weekly)';
   }
 
   @override
@@ -439,6 +469,7 @@ class _$_Offering extends _Offering {
                 other.identifier == identifier) &&
             (identical(other.serverDescription, serverDescription) ||
                 other.serverDescription == serverDescription) &&
+            const DeepCollectionEquality().equals(other._metadata, _metadata) &&
             const DeepCollectionEquality()
                 .equals(other._availablePackages, _availablePackages) &&
             (identical(other.lifetime, lifetime) ||
@@ -460,6 +491,7 @@ class _$_Offering extends _Offering {
       runtimeType,
       identifier,
       serverDescription,
+      const DeepCollectionEquality().hash(_metadata),
       const DeepCollectionEquality().hash(_availablePackages),
       lifetime,
       annual,
@@ -487,6 +519,7 @@ abstract class _Offering extends Offering {
   const factory _Offering(
       @JsonKey(name: 'identifier') final String identifier,
       @JsonKey(name: 'serverDescription') final String serverDescription,
+      @JsonKey(name: 'metadata') final Map<String, Object> metadata,
       @JsonKey(name: 'availablePackages') final List<Package> availablePackages,
       {@JsonKey(name: 'lifetime') final Package? lifetime,
       @JsonKey(name: 'annual') final Package? annual,
@@ -509,6 +542,11 @@ abstract class _Offering extends Offering {
   /// Offering description defined in RevenueCat dashboard.
   @JsonKey(name: 'serverDescription')
   String get serverDescription;
+  @override
+
+  /// Offering metadata defined in RevenueCat dashboard.
+  @JsonKey(name: 'metadata')
+  Map<String, Object> get metadata;
   @override
 
   /// Array of [Package] objects available for purchase.

--- a/lib/models/offering_wrapper.g.dart
+++ b/lib/models/offering_wrapper.g.dart
@@ -9,6 +9,9 @@ part of 'offering_wrapper.dart';
 _$_Offering _$$_OfferingFromJson(Map json) => _$_Offering(
       json['identifier'] as String,
       json['serverDescription'] as String,
+      (json['metadata'] as Map).map(
+        (k, e) => MapEntry(k as String, e as Object),
+      ),
       (json['availablePackages'] as List<dynamic>)
           .map((e) => Package.fromJson(Map<String, dynamic>.from(e as Map)))
           .toList(),
@@ -43,6 +46,7 @@ Map<String, dynamic> _$$_OfferingToJson(_$_Offering instance) =>
     <String, dynamic>{
       'identifier': instance.identifier,
       'serverDescription': instance.serverDescription,
+      'metadata': instance.metadata,
       'availablePackages':
           instance.availablePackages.map((e) => e.toJson()).toList(),
       'lifetime': instance.lifetime?.toJson(),

--- a/macos/purchases_flutter.podspec
+++ b/macos/purchases_flutter.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files     = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'FlutterMacOS'
-  s.dependency 'PurchasesHybridCommon', '5.0.0-beta.6'
+  s.dependency 'PurchasesHybridCommon', '5.0.0-rc.1'
   s.platform = :osx, '10.12'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.0'

--- a/test/offering_test.dart
+++ b/test/offering_test.dart
@@ -58,4 +58,49 @@ void main() {
     final offering = Offering.fromJson(offeringJSON);
     expect(offering.metadata, metadata);
   });
+
+  test('getMetadataString finds key with value', () {
+    const metadata = {
+      'int': 5,
+      'double': 5.5,
+      'boolean': true,
+      'string': 'five',
+      'array': ['five'],
+      'dictionary': {'string': 'five'}
+    };
+
+    final offeringJSON = generateOfferingJSON(metadata);
+    final offering = Offering.fromJson(offeringJSON);
+    expect(offering.getMetadataString('string', 'NOT THIS'), 'five');
+  });
+
+  test('getMetadataString uses default for non-existent key', () {
+    const metadata = {
+      'int': 5,
+      'double': 5.5,
+      'boolean': true,
+      'string': 'five',
+      'array': ['five'],
+      'dictionary': {'string': 'five'}
+    };
+
+    final offeringJSON = generateOfferingJSON(metadata);
+    final offering = Offering.fromJson(offeringJSON);
+    expect(offering.getMetadataString('pizza', 'cheese'), 'cheese');
+  });
+
+  test('getMetadataString uses default for key with value of non-string', () {
+    const metadata = {
+      'int': 5,
+      'double': 5.5,
+      'boolean': true,
+      'string': 'five',
+      'array': ['five'],
+      'dictionary': {'string': 'five'}
+    };
+
+    final offeringJSON = generateOfferingJSON(metadata);
+    final offering = Offering.fromJson(offeringJSON);
+    expect(offering.getMetadataString('int', 'ope'), 'ope');
+  });
 }

--- a/test/offering_test.dart
+++ b/test/offering_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:purchases_flutter/models/offering_wrapper.dart';
+
+void main() {
+  Map<String, Object?> generateOfferingJSON(Map<String, Object> metadata) => {
+        'identifier': 'almost_pro',
+        'serverDescription': '',
+        'metadata': metadata,
+        'periodType': 'NORMAL',
+        'availablePackages': [
+          {
+            'identifier': 'thepackage',
+            'packageType': 'ANNUAL',
+            'product': {
+              'identifier': 'identifier',
+              'description': 'desc',
+              'title': 'Title',
+              'price': 4900000,
+              'priceString': '\$4.99',
+              'currencyCode': 'USD',
+              'introPrice': null,
+              'discounts': null,
+              'productCategory': null,
+              'defaultOption': null,
+              'subscriptionOptions': null,
+              'presentedOfferingIdentifier': null,
+              'subscriptionPeriod': null,
+            },
+            'offeringIdentifier': 'theoffering',
+          }
+        ],
+        'lifetime': null,
+        'annual': null,
+        'sixMonth': null,
+        'threeMonth': null,
+        'twoMonth': null,
+        'monthly': null,
+        'weekly': null,
+      };
+
+  test('metadata matches empty dictionary', () {
+    final offeringJSON = generateOfferingJSON({});
+    final offering = Offering.fromJson(offeringJSON);
+    expect(offering.metadata, {});
+  });
+
+  test('metadata matches dictionary with values', () {
+    const metadata = {
+      'int': 5,
+      'double': 5.5,
+      'boolean': true,
+      'string': 'five',
+      'array': ['five'],
+      'dictionary': {'string': 'five'}
+    };
+
+    final offeringJSON = generateOfferingJSON(metadata);
+    final offering = Offering.fromJson(offeringJSON);
+    expect(offering.metadata, metadata);
+  });
+}


### PR DESCRIPTION
## Motivation

Add `metadata` to `Offering`

## Description

- Bumped Android, iOS, and macOS to hybrid common `5.0.0-rc.1`
- Added `metadata: Map<String, Object>` to `Offering`
- Updated API tester
- Added `getMetadataString(String key, String defaultValue)` to `Offering`
  - This is the same that native Android has