### PR TITLE
Add `isPrepaid` to `SubscriptionOffering`

### DIFF
--- a/api_tester/lib/api_tests/models/subscription_option_wrapper_api_test.dart
+++ b/api_tester/lib/api_tests/models/subscription_option_wrapper_api_test.dart
@@ -19,6 +19,7 @@ class _SubscriptionOptionApiTest {
       List<String> tags,
       bool isBasePlan,
       Period? billingPeriod,
+      bool isPrepaid,
       PricingPhase? fullPricePhase,
       PricingPhase? freePhase,
       PricingPhase? introPhase,
@@ -31,6 +32,7 @@ class _SubscriptionOptionApiTest {
         tags,
         isBasePlan,
         billingPeriod,
+        isPrepaid,
         fullPricePhase,
         freePhase,
         introPhase,
@@ -45,6 +47,7 @@ class _SubscriptionOptionApiTest {
     List<String> tags = subscriptionOption.tags;
     bool isBasePlan = subscriptionOption.isBasePlan;
     Period? billingPeriod = subscriptionOption.billingPeriod;
+    bool isPrepaid = subscriptionOption.isPrepaid;
     PricingPhase? fullPricePhase = subscriptionOption.fullPricePhase;
     PricingPhase? freePhase = subscriptionOption.freePhase;
     PricingPhase? introPhase = subscriptionOption.introPhase;

--- a/lib/models/subscription_option_wrapper.dart
+++ b/lib/models/subscription_option_wrapper.dart
@@ -28,20 +28,21 @@ class SubscriptionOption with _$SubscriptionOption {
     /// Pricing phases defining a user's payment plan for the product over time.
     @JsonKey(name: 'pricingPhases') List<PricingPhase> pricingPhases,
 
-    /// Tags defined on the base plan or offer. Empty for Amazon.
+    /// Tags defined on the base plan or offer.
     @JsonKey(name: 'tags') List<String> tags,
 
     /// True if this SubscriptionOption represents a Google subscription base plan (rather than an offer).
-    /// Not applicable for Amazon subscriptions.
     @JsonKey(name: 'isBasePlan') bool isBasePlan,
 
     /// The subscription period of fullPricePhase (after free and intro trials).
     @JsonKey(name: 'billingPeriod') Period? billingPeriod,
 
+    /// True if the subscription is pre-paid.
+    @JsonKey(name: 'isPrepaid') bool isPrepaid,
+
     /// The full price PricingPhase of the subscription.
     /// Looks for the last price phase of the SubscriptionOption.
-    @JsonKey(name: 'fullPricePhase')
-        PricingPhase? fullPricePhase,
+    @JsonKey(name: 'fullPricePhase') PricingPhase? fullPricePhase,
 
     /// The free trial PricingPhase of the subscription.
     /// Looks for the first pricing phase of the SubscriptionOption where amountMicros is 0.
@@ -55,7 +56,7 @@ class SubscriptionOption with _$SubscriptionOption {
 
     // Offering identifier the subscriptioni option was presented from
     @JsonKey(name: 'presentedOfferingIdentifier')
-        String? presentedOfferingIdentifier,
+    String? presentedOfferingIdentifier,
   ) = _SubscriptionOption;
 
   factory SubscriptionOption.fromJson(Map<String, dynamic> json) =>

--- a/lib/models/subscription_option_wrapper.freezed.dart
+++ b/lib/models/subscription_option_wrapper.freezed.dart
@@ -40,18 +40,21 @@ mixin _$SubscriptionOption {
   @JsonKey(name: 'pricingPhases')
   List<PricingPhase> get pricingPhases => throw _privateConstructorUsedError;
 
-  /// Tags defined on the base plan or offer. Empty for Amazon.
+  /// Tags defined on the base plan or offer.
   @JsonKey(name: 'tags')
   List<String> get tags => throw _privateConstructorUsedError;
 
   /// True if this SubscriptionOption represents a Google subscription base plan (rather than an offer).
-  /// Not applicable for Amazon subscriptions.
   @JsonKey(name: 'isBasePlan')
   bool get isBasePlan => throw _privateConstructorUsedError;
 
   /// The subscription period of fullPricePhase (after free and intro trials).
   @JsonKey(name: 'billingPeriod')
   Period? get billingPeriod => throw _privateConstructorUsedError;
+
+  /// True if the subscription is pre-paid.
+  @JsonKey(name: 'isPrepaid')
+  bool get isPrepaid => throw _privateConstructorUsedError;
 
   /// The full price PricingPhase of the subscription.
   /// Looks for the last price phase of the SubscriptionOption.
@@ -100,6 +103,8 @@ abstract class $SubscriptionOptionCopyWith<$Res> {
           bool isBasePlan,
       @JsonKey(name: 'billingPeriod')
           Period? billingPeriod,
+      @JsonKey(name: 'isPrepaid')
+          bool isPrepaid,
       @JsonKey(name: 'fullPricePhase')
           PricingPhase? fullPricePhase,
       @JsonKey(name: 'freePhase')
@@ -135,6 +140,7 @@ class _$SubscriptionOptionCopyWithImpl<$Res, $Val extends SubscriptionOption>
     Object? tags = null,
     Object? isBasePlan = null,
     Object? billingPeriod = freezed,
+    Object? isPrepaid = null,
     Object? fullPricePhase = freezed,
     Object? freePhase = freezed,
     Object? introPhase = freezed,
@@ -169,6 +175,10 @@ class _$SubscriptionOptionCopyWithImpl<$Res, $Val extends SubscriptionOption>
           ? _value.billingPeriod
           : billingPeriod // ignore: cast_nullable_to_non_nullable
               as Period?,
+      isPrepaid: null == isPrepaid
+          ? _value.isPrepaid
+          : isPrepaid // ignore: cast_nullable_to_non_nullable
+              as bool,
       fullPricePhase: freezed == fullPricePhase
           ? _value.fullPricePhase
           : fullPricePhase // ignore: cast_nullable_to_non_nullable
@@ -260,6 +270,8 @@ abstract class _$$_SubscriptionOptionCopyWith<$Res>
           bool isBasePlan,
       @JsonKey(name: 'billingPeriod')
           Period? billingPeriod,
+      @JsonKey(name: 'isPrepaid')
+          bool isPrepaid,
       @JsonKey(name: 'fullPricePhase')
           PricingPhase? fullPricePhase,
       @JsonKey(name: 'freePhase')
@@ -297,6 +309,7 @@ class __$$_SubscriptionOptionCopyWithImpl<$Res>
     Object? tags = null,
     Object? isBasePlan = null,
     Object? billingPeriod = freezed,
+    Object? isPrepaid = null,
     Object? fullPricePhase = freezed,
     Object? freePhase = freezed,
     Object? introPhase = freezed,
@@ -331,6 +344,10 @@ class __$$_SubscriptionOptionCopyWithImpl<$Res>
           ? _value.billingPeriod
           : billingPeriod // ignore: cast_nullable_to_non_nullable
               as Period?,
+      null == isPrepaid
+          ? _value.isPrepaid
+          : isPrepaid // ignore: cast_nullable_to_non_nullable
+              as bool,
       freezed == fullPricePhase
           ? _value.fullPricePhase
           : fullPricePhase // ignore: cast_nullable_to_non_nullable
@@ -369,6 +386,8 @@ class _$_SubscriptionOption implements _SubscriptionOption {
           this.isBasePlan,
       @JsonKey(name: 'billingPeriod')
           this.billingPeriod,
+      @JsonKey(name: 'isPrepaid')
+          this.isPrepaid,
       @JsonKey(name: 'fullPricePhase')
           this.fullPricePhase,
       @JsonKey(name: 'freePhase')
@@ -414,10 +433,10 @@ class _$_SubscriptionOption implements _SubscriptionOption {
     return EqualUnmodifiableListView(_pricingPhases);
   }
 
-  /// Tags defined on the base plan or offer. Empty for Amazon.
+  /// Tags defined on the base plan or offer.
   final List<String> _tags;
 
-  /// Tags defined on the base plan or offer. Empty for Amazon.
+  /// Tags defined on the base plan or offer.
   @override
   @JsonKey(name: 'tags')
   List<String> get tags {
@@ -427,7 +446,6 @@ class _$_SubscriptionOption implements _SubscriptionOption {
   }
 
   /// True if this SubscriptionOption represents a Google subscription base plan (rather than an offer).
-  /// Not applicable for Amazon subscriptions.
   @override
   @JsonKey(name: 'isBasePlan')
   final bool isBasePlan;
@@ -436,6 +454,11 @@ class _$_SubscriptionOption implements _SubscriptionOption {
   @override
   @JsonKey(name: 'billingPeriod')
   final Period? billingPeriod;
+
+  /// True if the subscription is pre-paid.
+  @override
+  @JsonKey(name: 'isPrepaid')
+  final bool isPrepaid;
 
   /// The full price PricingPhase of the subscription.
   /// Looks for the last price phase of the SubscriptionOption.
@@ -463,7 +486,7 @@ class _$_SubscriptionOption implements _SubscriptionOption {
 
   @override
   String toString() {
-    return 'SubscriptionOption(id: $id, storeProductId: $storeProductId, productId: $productId, pricingPhases: $pricingPhases, tags: $tags, isBasePlan: $isBasePlan, billingPeriod: $billingPeriod, fullPricePhase: $fullPricePhase, freePhase: $freePhase, introPhase: $introPhase, presentedOfferingIdentifier: $presentedOfferingIdentifier)';
+    return 'SubscriptionOption(id: $id, storeProductId: $storeProductId, productId: $productId, pricingPhases: $pricingPhases, tags: $tags, isBasePlan: $isBasePlan, billingPeriod: $billingPeriod, isPrepaid: $isPrepaid, fullPricePhase: $fullPricePhase, freePhase: $freePhase, introPhase: $introPhase, presentedOfferingIdentifier: $presentedOfferingIdentifier)';
   }
 
   @override
@@ -483,6 +506,8 @@ class _$_SubscriptionOption implements _SubscriptionOption {
                 other.isBasePlan == isBasePlan) &&
             (identical(other.billingPeriod, billingPeriod) ||
                 other.billingPeriod == billingPeriod) &&
+            (identical(other.isPrepaid, isPrepaid) ||
+                other.isPrepaid == isPrepaid) &&
             (identical(other.fullPricePhase, fullPricePhase) ||
                 other.fullPricePhase == fullPricePhase) &&
             (identical(other.freePhase, freePhase) ||
@@ -506,6 +531,7 @@ class _$_SubscriptionOption implements _SubscriptionOption {
       const DeepCollectionEquality().hash(_tags),
       isBasePlan,
       billingPeriod,
+      isPrepaid,
       fullPricePhase,
       freePhase,
       introPhase,
@@ -542,6 +568,8 @@ abstract class _SubscriptionOption implements SubscriptionOption {
           final bool isBasePlan,
       @JsonKey(name: 'billingPeriod')
           final Period? billingPeriod,
+      @JsonKey(name: 'isPrepaid')
+          final bool isPrepaid,
       @JsonKey(name: 'fullPricePhase')
           final PricingPhase? fullPricePhase,
       @JsonKey(name: 'freePhase')
@@ -580,13 +608,12 @@ abstract class _SubscriptionOption implements SubscriptionOption {
   List<PricingPhase> get pricingPhases;
   @override
 
-  /// Tags defined on the base plan or offer. Empty for Amazon.
+  /// Tags defined on the base plan or offer.
   @JsonKey(name: 'tags')
   List<String> get tags;
   @override
 
   /// True if this SubscriptionOption represents a Google subscription base plan (rather than an offer).
-  /// Not applicable for Amazon subscriptions.
   @JsonKey(name: 'isBasePlan')
   bool get isBasePlan;
   @override
@@ -594,6 +621,11 @@ abstract class _SubscriptionOption implements SubscriptionOption {
   /// The subscription period of fullPricePhase (after free and intro trials).
   @JsonKey(name: 'billingPeriod')
   Period? get billingPeriod;
+  @override
+
+  /// True if the subscription is pre-paid.
+  @JsonKey(name: 'isPrepaid')
+  bool get isPrepaid;
   @override
 
   /// The full price PricingPhase of the subscription.

--- a/lib/models/subscription_option_wrapper.g.dart
+++ b/lib/models/subscription_option_wrapper.g.dart
@@ -21,6 +21,7 @@ _$_SubscriptionOption _$$_SubscriptionOptionFromJson(Map json) =>
           ? null
           : Period.fromJson(
               Map<String, dynamic>.from(json['billingPeriod'] as Map)),
+      json['isPrepaid'] as bool,
       json['fullPricePhase'] == null
           ? null
           : PricingPhase.fromJson(
@@ -46,6 +47,7 @@ Map<String, dynamic> _$$_SubscriptionOptionToJson(
       'tags': instance.tags,
       'isBasePlan': instance.isBasePlan,
       'billingPeriod': instance.billingPeriod?.toJson(),
+      'isPrepaid': instance.isPrepaid,
       'fullPricePhase': instance.fullPricePhase?.toJson(),
       'freePhase': instance.freePhase?.toJson(),
       'introPhase': instance.introPhase?.toJson(),

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -43,14 +43,16 @@ void main() {
   };
 
   setUp(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, (call) async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
       log.add(call);
       return response;
     });
   });
 
   tearDown(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
     log.clear();
     response = null;
   });
@@ -94,7 +96,8 @@ void main() {
       'addCustomerInfoUpdateListener calls each listener immediately if it has an existing customer info',
       () async {
     /// Making sure we don't mock the MethodChannel before mocking native to Flutter calls.
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
     _performDartSideChannelMethodCall(
       'Purchases-CustomerInfoUpdated',
       mockCustomerInfoResponse,
@@ -117,7 +120,8 @@ void main() {
       'addCustomerInfoUpdateListener calls each listener immediately with latest customer info',
       () async {
     /// Making sure we don't mock the MethodChannel before mocking native to Flutter calls.
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
     _performDartSideChannelMethodCall(
       'Purchases-CustomerInfoUpdated',
       mockCustomerInfoResponse,
@@ -797,6 +801,7 @@ void main() {
         [],
         true,
         Period(PeriodUnit.month, 1, 'P1M'),
+        false,
         phase,
         null,
         null,
@@ -855,6 +860,7 @@ void main() {
         [],
         true,
         Period(PeriodUnit.month, 1, 'P1M'),
+        false,
         phase,
         null,
         null,
@@ -915,6 +921,7 @@ void main() {
         [],
         true,
         Period(PeriodUnit.month, 1, 'P1M'),
+        false,
         phase,
         null,
         null,


### PR DESCRIPTION
## Description

- Adds `isPrepaid: bool` to `SubscriptionOffering`

### Demo

![Screenshot 2023-06-09 at 1 36 34 PM](https://github.com/RevenueCat/purchases-flutter/assets/401294/0652c934-ecda-4493-b422-6294510c519e)
