### PR TITLE
Fix purchase tester reconfiguring the SDK

### DIFF
--- a/revenuecat_examples/MagicWeather/lib/main.dart
+++ b/revenuecat_examples/MagicWeather/lib/main.dart
@@ -3,22 +3,50 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:magic_weather_flutter/src/app.dart';
 import 'package:magic_weather_flutter/src/constant.dart';
+import 'package:purchases_flutter/purchases_flutter.dart';
 
 import 'store_config.dart';
 
-void main() {
+void main() async {
   if (Platform.isIOS || Platform.isMacOS) {
     StoreConfig(
-      store: Store.appleStore,
+      store: Store.appStore,
       apiKey: appleApiKey,
     );
   } else if (Platform.isAndroid) {
     // Run the app passing --dart-define=AMAZON=true
     const useAmazon = bool.fromEnvironment("amazon");
     StoreConfig(
-      store: useAmazon ? Store.amazonAppstore : Store.googlePlay,
+      store: useAmazon ? Store.amazon : Store.playStore,
       apiKey: useAmazon ? amazonApiKey : googleApiKey,
     );
   }
+
+  WidgetsFlutterBinding.ensureInitialized();
+
+  await _configureSDK();
+
   runApp(const MagicWeatherFlutter());
+}
+
+Future<void> _configureSDK() async {
+  // Enable debug logs before calling `configure`.
+  await Purchases.setLogLevel(LogLevel.debug);
+
+  /*
+    - appUserID is nil, so an anonymous ID will be generated automatically by the Purchases SDK. Read more about Identifying Users here: https://docs.revenuecat.com/docs/user-ids
+
+    - observerMode is false, so Purchases will automatically handle finishing transactions. Read more about Observer Mode here: https://docs.revenuecat.com/docs/observer-mode
+    */
+  PurchasesConfiguration configuration;
+  if (StoreConfig.isForAmazonAppstore()) {
+    configuration = AmazonConfiguration(StoreConfig.instance.apiKey)
+      ..appUserID = null
+      ..observerMode = false;
+  } else {
+    configuration = PurchasesConfiguration(StoreConfig.instance.apiKey)
+      ..appUserID = null
+      ..observerMode = false;
+  }
+  await Purchases.configure(configuration);
 }

--- a/revenuecat_examples/MagicWeather/lib/src/views/home.dart
+++ b/revenuecat_examples/MagicWeather/lib/src/views/home.dart
@@ -1,13 +1,11 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:magic_weather_flutter/src/constant.dart';
-import 'package:magic_weather_flutter/src/views/weather.dart';
-import 'package:magic_weather_flutter/src/views/user.dart';
-import 'package:purchases_flutter/purchases_flutter.dart';
 import 'package:magic_weather_flutter/src/model/singletons_data.dart';
 import 'package:magic_weather_flutter/src/model/styles.dart';
-
-import '../../store_config.dart';
+import 'package:magic_weather_flutter/src/views/user.dart';
+import 'package:magic_weather_flutter/src/views/weather.dart';
+import 'package:purchases_flutter/purchases_flutter.dart';
 
 final GlobalKey<NavigatorState> firstTabNavKey = GlobalKey<NavigatorState>();
 final GlobalKey<NavigatorState> secondTabNavKey = GlobalKey<NavigatorState>();
@@ -29,26 +27,6 @@ class AppContainerState extends State<AppContainer> {
   }
 
   Future<void> initPlatformState() async {
-    // Enable debug logs before calling `configure`.
-    await Purchases.setLogLevel(LogLevel.debug);
-
-    /*
-    - appUserID is nil, so an anonymous ID will be generated automatically by the Purchases SDK. Read more about Identifying Users here: https://docs.revenuecat.com/docs/user-ids
-
-    - observerMode is false, so Purchases will automatically handle finishing transactions. Read more about Observer Mode here: https://docs.revenuecat.com/docs/observer-mode
-    */
-    PurchasesConfiguration configuration;
-    if (StoreConfig.isForAmazonAppstore()) {
-      configuration = AmazonConfiguration(StoreConfig.instance.apiKey)
-        ..appUserID = null
-        ..observerMode = false;
-    } else {
-      configuration = PurchasesConfiguration(StoreConfig.instance.apiKey)
-        ..appUserID = null
-        ..observerMode = false;
-    }
-    await Purchases.configure(configuration);
-
     appData.appUserID = await Purchases.appUserID;
 
     Purchases.addCustomerInfoUpdateListener((customerInfo) async {

--- a/revenuecat_examples/MagicWeather/lib/store_config.dart
+++ b/revenuecat_examples/MagicWeather/lib/store_config.dart
@@ -1,4 +1,4 @@
-enum Store { appleStore, googlePlay, amazonAppstore }
+import 'package:purchases_flutter/purchases_flutter.dart';
 
 class StoreConfig {
   final Store store;
@@ -16,9 +16,9 @@ class StoreConfig {
     return _instance!;
   }
 
-  static bool isForAppleStore() => instance.store == Store.appleStore;
+  static bool isForAppleStore() => instance.store == Store.appStore;
 
-  static bool isForGooglePlay() => instance.store == Store.googlePlay;
+  static bool isForGooglePlay() => instance.store == Store.playStore;
 
-  static bool isForAmazonAppstore() => instance.store == Store.amazonAppstore;
+  static bool isForAmazonAppstore() => instance.store == Store.amazon;
 }

--- a/revenuecat_examples/purchase_tester/lib/main.dart
+++ b/revenuecat_examples/purchase_tester/lib/main.dart
@@ -1,25 +1,42 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:purchases_flutter/purchases_flutter.dart';
 import 'package:purchases_flutter_example/src/constant.dart';
 
 import 'store_config.dart';
 import 'src/app.dart';
 
-void main() {
+void main() async {
   if (Platform.isIOS || Platform.isMacOS) {
     StoreConfig(
-      store: Store.appleStore,
+      store: TesterStore.appleStore,
       apiKey: appleApiKey,
     );
   } else if (Platform.isAndroid) {
     // Run the app passing --dart-define=AMAZON=true
     const useAmazon = bool.fromEnvironment("amazon");
     StoreConfig(
-      store: useAmazon ? Store.amazonAppstore : Store.googlePlay,
+      store: useAmazon ? TesterStore.amazonAppstore : TesterStore.googlePlay,
       apiKey: useAmazon ? amazonApiKey : googleApiKey,
     );
   }
+  WidgetsFlutterBinding.ensureInitialized();
 
+  await _configureSDK();
   runApp(const PurchaseTester());
+}
+
+Future<void> _configureSDK() async {
+  await Purchases.setLogLevel(LogLevel.debug);
+
+  PurchasesConfiguration configuration;
+  if (StoreConfig.isForAmazonAppstore()) {
+    configuration = AmazonConfiguration(StoreConfig.instance.apiKey);
+  } else {
+    configuration = PurchasesConfiguration(StoreConfig.instance.apiKey);
+  }
+  await Purchases.configure(configuration);
+
+  await Purchases.enableAdServicesAttributionTokenCollection();
 }

--- a/revenuecat_examples/purchase_tester/lib/main.dart
+++ b/revenuecat_examples/purchase_tester/lib/main.dart
@@ -10,14 +10,14 @@ import 'src/app.dart';
 void main() async {
   if (Platform.isIOS || Platform.isMacOS) {
     StoreConfig(
-      store: TesterStore.appleStore,
+      store: Store.appStore,
       apiKey: appleApiKey,
     );
   } else if (Platform.isAndroid) {
     // Run the app passing --dart-define=AMAZON=true
     const useAmazon = bool.fromEnvironment("amazon");
     StoreConfig(
-      store: useAmazon ? TesterStore.amazonAppstore : TesterStore.googlePlay,
+      store: useAmazon ? Store.amazon : Store.playStore,
       apiKey: useAmazon ? amazonApiKey : googleApiKey,
     );
   }

--- a/revenuecat_examples/purchase_tester/lib/src/app.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/app.dart
@@ -5,7 +5,6 @@ import 'package:flutter/services.dart';
 import 'package:purchases_flutter/purchases_flutter.dart';
 
 import './constant.dart';
-import '../store_config.dart';
 
 class PurchaseTester extends StatelessWidget {
   const PurchaseTester({Key? key}) : super(key: key);
@@ -38,18 +37,6 @@ class _MyAppState extends State<InitialScreen> {
 
   // Platform messages are asynchronous, so we initialize in an async method.
   Future<void> initPlatformState() async {
-    await Purchases.setLogLevel(LogLevel.debug);
-
-    PurchasesConfiguration configuration;
-    if (StoreConfig.isForAmazonAppstore()) {
-      configuration = AmazonConfiguration(StoreConfig.instance.apiKey);
-    } else {
-      configuration = PurchasesConfiguration(StoreConfig.instance.apiKey);
-    }
-    await Purchases.configure(configuration);
-
-    await Purchases.enableAdServicesAttributionTokenCollection();
-
     final customerInfo = await Purchases.getCustomerInfo();
 
     Purchases.addReadyForPromotedProductPurchaseListener(
@@ -291,10 +278,6 @@ class _PurchaseSubscriptionOptionButton extends StatelessWidget {
               print('Payment is pending');
             }
           }
-          Navigator.pushReplacement(
-            context,
-            MaterialPageRoute(builder: (context) => const InitialScreen()),
-          );
         },
         child:
             Text('Buy Option: - (${option.id}\n${option.pricingPhases.map((e) {

--- a/revenuecat_examples/purchase_tester/lib/store_config.dart
+++ b/revenuecat_examples/purchase_tester/lib/store_config.dart
@@ -1,11 +1,11 @@
-enum Store { appleStore, googlePlay, amazonAppstore }
+enum TesterStore { appleStore, googlePlay, amazonAppstore }
 
 class StoreConfig {
-  final Store store;
+  final TesterStore store;
   final String apiKey;
   static StoreConfig? _instance;
 
-  factory StoreConfig({required Store store, required String apiKey}) {
+  factory StoreConfig({required TesterStore store, required String apiKey}) {
     _instance ??= StoreConfig._internal(store, apiKey);
     return _instance!;
   }
@@ -16,9 +16,10 @@ class StoreConfig {
     return _instance!;
   }
 
-  static bool isForAppleStore() => instance.store == Store.appleStore;
+  static bool isForAppleStore() => instance.store == TesterStore.appleStore;
 
-  static bool isForGooglePlay() => instance.store == Store.googlePlay;
+  static bool isForGooglePlay() => instance.store == TesterStore.googlePlay;
 
-  static bool isForAmazonAppstore() => instance.store == Store.amazonAppstore;
+  static bool isForAmazonAppstore() =>
+      instance.store == TesterStore.amazonAppstore;
 }

--- a/revenuecat_examples/purchase_tester/lib/store_config.dart
+++ b/revenuecat_examples/purchase_tester/lib/store_config.dart
@@ -1,11 +1,11 @@
-enum TesterStore { appleStore, googlePlay, amazonAppstore }
+import 'package:purchases_flutter/purchases_flutter.dart';
 
 class StoreConfig {
-  final TesterStore store;
+  final Store store;
   final String apiKey;
   static StoreConfig? _instance;
 
-  factory StoreConfig({required TesterStore store, required String apiKey}) {
+  factory StoreConfig({required Store store, required String apiKey}) {
     _instance ??= StoreConfig._internal(store, apiKey);
     return _instance!;
   }
@@ -16,10 +16,11 @@ class StoreConfig {
     return _instance!;
   }
 
-  static bool isForAppleStore() => instance.store == TesterStore.appleStore;
+  static bool isForAppleStore() => instance.store == Store.appStore
+      || instance.store == Store.macAppStore;
 
-  static bool isForGooglePlay() => instance.store == TesterStore.googlePlay;
+  static bool isForGooglePlay() => instance.store == Store.playStore;
 
   static bool isForAmazonAppstore() =>
-      instance.store == TesterStore.amazonAppstore;
+      instance.store == Store.amazon;
 }


### PR DESCRIPTION
Purchase tester currently reconfigures the RC SDK on every InitialScreen instantiation. Due to the way we do navigation, we instantiate that screen after a purchase and possibly in some other situations. This PR does the following changes:
- Makes it so we don't recreate the `InitialScreen` without need in purchase tester.
- Moves the SDK initialization to the `main.dart` file so we ensure it's executed only once (This is done both in purchase tester and MagicWeather)
