### PR TITLE
[EXTERNAL] v5-MIGRATION.md: replace defaultOffer w/ defaultOption (#728)

### DIFF
--- a/migrations/v5-MIGRATION.md
+++ b/migrations/v5-MIGRATION.md
@@ -46,7 +46,7 @@ be found through `subscriptionOptions` on `StoreProduct`:
 
 ```dart
 final basePlan = storeProduct.subscriptionOptions?.firstWhere((option) => option.isBasePlan);
-final defaultOffer = storeProduct.defaultOffer
+final defaultOffer = storeProduct.defaultOption
 final freeOffer = storeProduct.subscriptionOptions?.firstWhere((option) => option.freePhase != null);
 final trialOffer = storeProduct.subscriptionOptions?.firstWhere((option) => option.introPhase != null);
 ```

--- a/migrations/v5-MIGRATION.md
+++ b/migrations/v5-MIGRATION.md
@@ -46,7 +46,7 @@ be found through `subscriptionOptions` on `StoreProduct`:
 
 ```dart
 final basePlan = storeProduct.subscriptionOptions?.firstWhere((option) => option.isBasePlan);
-final defaultOffer = storeProduct.defaultOption
+final defaultOption = storeProduct.defaultOption
 final freeOffer = storeProduct.subscriptionOptions?.firstWhere((option) => option.freePhase != null);
 final trialOffer = storeProduct.subscriptionOptions?.firstWhere((option) => option.introPhase != null);
 ```


### PR DESCRIPTION
storeProduct.defaultOffer doesn't exist, it is replaced by defaultOption.

Thank you for contributing to Purchases. Before pressing the "Create Pull Request" button, please provide the following:

- [x] A description about what and why you are contributing, even if it's trivial.

- [ ] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [ ] If applicable, unit tests.

Contributed by @nader138 in #728 