### PR TITLE
Adds package back to AndroidManifest.xml

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,2 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.revenuecat.purchases_flutter">
 </manifest>


### PR DESCRIPTION
Fixes #748 

We removed this property from the AndroidManifest.xml in #698 because we migrated to use the namespace gradle property. We added a conditional in the build.gradle to support AGP < 4.2 by checking if the namespace property exists, but if that happens, the package property is missing from the AndroidManifest.xml, which prevents compilation

I tried building this using AGP 8.0.2 and it works fine