### PR TITLE
Update freezed generated classes after freezed update

### DIFF
--- a/lib/models/entitlement_info_wrapper.freezed.dart
+++ b/lib/models/entitlement_info_wrapper.freezed.dart
@@ -95,11 +95,10 @@ abstract class $EntitlementInfoCopyWith<$Res> {
       String productIdentifier,
       bool isSandbox,
       @JsonKey(name: 'ownershipType', unknownEnumValue: OwnershipType.unknown)
-          OwnershipType ownershipType,
-      @JsonKey(name: 'store', unknownEnumValue: Store.unknownStore)
-          Store store,
+      OwnershipType ownershipType,
+      @JsonKey(name: 'store', unknownEnumValue: Store.unknownStore) Store store,
       @JsonKey(name: 'periodType', unknownEnumValue: PeriodType.unknown)
-          PeriodType periodType,
+      PeriodType periodType,
       String? expirationDate,
       String? unsubscribeDetectedAt,
       String? billingIssueDetectedAt});
@@ -206,11 +205,10 @@ abstract class _$$_EntitlementInfoCopyWith<$Res>
       String productIdentifier,
       bool isSandbox,
       @JsonKey(name: 'ownershipType', unknownEnumValue: OwnershipType.unknown)
-          OwnershipType ownershipType,
-      @JsonKey(name: 'store', unknownEnumValue: Store.unknownStore)
-          Store store,
+      OwnershipType ownershipType,
+      @JsonKey(name: 'store', unknownEnumValue: Store.unknownStore) Store store,
       @JsonKey(name: 'periodType', unknownEnumValue: PeriodType.unknown)
-          PeriodType periodType,
+      PeriodType periodType,
       String? expirationDate,
       String? unsubscribeDetectedAt,
       String? billingIssueDetectedAt});
@@ -310,11 +308,11 @@ class _$_EntitlementInfo implements _EntitlementInfo {
       this.productIdentifier,
       this.isSandbox,
       {@JsonKey(name: 'ownershipType', unknownEnumValue: OwnershipType.unknown)
-          this.ownershipType = OwnershipType.unknown,
+      this.ownershipType = OwnershipType.unknown,
       @JsonKey(name: 'store', unknownEnumValue: Store.unknownStore)
-          this.store = Store.unknownStore,
+      this.store = Store.unknownStore,
       @JsonKey(name: 'periodType', unknownEnumValue: PeriodType.unknown)
-          this.periodType = PeriodType.unknown,
+      this.periodType = PeriodType.unknown,
       this.expirationDate,
       this.unsubscribeDetectedAt,
       this.billingIssueDetectedAt});
@@ -468,11 +466,11 @@ abstract class _EntitlementInfo implements EntitlementInfo {
       final String productIdentifier,
       final bool isSandbox,
       {@JsonKey(name: 'ownershipType', unknownEnumValue: OwnershipType.unknown)
-          final OwnershipType ownershipType,
+      final OwnershipType ownershipType,
       @JsonKey(name: 'store', unknownEnumValue: Store.unknownStore)
-          final Store store,
+      final Store store,
       @JsonKey(name: 'periodType', unknownEnumValue: PeriodType.unknown)
-          final PeriodType periodType,
+      final PeriodType periodType,
       final String? expirationDate,
       final String? unsubscribeDetectedAt,
       final String? billingIssueDetectedAt}) = _$_EntitlementInfo;

--- a/lib/models/introductory_price.freezed.dart
+++ b/lib/models/introductory_price.freezed.dart
@@ -62,7 +62,7 @@ abstract class $IntroductoryPriceCopyWith<$Res> {
       String period,
       int cycles,
       @JsonKey(name: 'periodUnit', unknownEnumValue: PeriodUnit.unknown)
-          PeriodUnit periodUnit,
+      PeriodUnit periodUnit,
       int periodNumberOfUnits});
 }
 
@@ -129,7 +129,7 @@ abstract class _$$_IntroductoryPriceCopyWith<$Res>
       String period,
       int cycles,
       @JsonKey(name: 'periodUnit', unknownEnumValue: PeriodUnit.unknown)
-          PeriodUnit periodUnit,
+      PeriodUnit periodUnit,
       int periodNumberOfUnits});
 }
 
@@ -189,7 +189,7 @@ class _$_IntroductoryPrice implements _IntroductoryPrice {
       this.period,
       this.cycles,
       @JsonKey(name: 'periodUnit', unknownEnumValue: PeriodUnit.unknown)
-          this.periodUnit,
+      this.periodUnit,
       this.periodNumberOfUnits);
 
   factory _$_IntroductoryPrice.fromJson(Map<String, dynamic> json) =>
@@ -273,7 +273,7 @@ abstract class _IntroductoryPrice implements IntroductoryPrice {
       final String period,
       final int cycles,
       @JsonKey(name: 'periodUnit', unknownEnumValue: PeriodUnit.unknown)
-          final PeriodUnit periodUnit,
+      final PeriodUnit periodUnit,
       final int periodNumberOfUnits) = _$_IntroductoryPrice;
 
   factory _IntroductoryPrice.fromJson(Map<String, dynamic> json) =

--- a/lib/models/package_wrapper.freezed.dart
+++ b/lib/models/package_wrapper.freezed.dart
@@ -50,9 +50,8 @@ abstract class $PackageCopyWith<$Res> {
   $Res call(
       {String identifier,
       @JsonKey(name: 'packageType', unknownEnumValue: PackageType.unknown)
-          PackageType packageType,
-      @JsonKey(name: 'product')
-          StoreProduct storeProduct,
+      PackageType packageType,
+      @JsonKey(name: 'product') StoreProduct storeProduct,
       String offeringIdentifier});
 
   $StoreProductCopyWith<$Res> get storeProduct;
@@ -115,9 +114,8 @@ abstract class _$$_PackageCopyWith<$Res> implements $PackageCopyWith<$Res> {
   $Res call(
       {String identifier,
       @JsonKey(name: 'packageType', unknownEnumValue: PackageType.unknown)
-          PackageType packageType,
-      @JsonKey(name: 'product')
-          StoreProduct storeProduct,
+      PackageType packageType,
+      @JsonKey(name: 'product') StoreProduct storeProduct,
       String offeringIdentifier});
 
   @override
@@ -166,9 +164,8 @@ class _$_Package implements _Package {
   const _$_Package(
       this.identifier,
       @JsonKey(name: 'packageType', unknownEnumValue: PackageType.unknown)
-          this.packageType,
-      @JsonKey(name: 'product')
-          this.storeProduct,
+      this.packageType,
+      @JsonKey(name: 'product') this.storeProduct,
       this.offeringIdentifier);
 
   factory _$_Package.fromJson(Map<String, dynamic> json) =>
@@ -238,9 +235,8 @@ abstract class _Package implements Package {
   const factory _Package(
       final String identifier,
       @JsonKey(name: 'packageType', unknownEnumValue: PackageType.unknown)
-          final PackageType packageType,
-      @JsonKey(name: 'product')
-          final StoreProduct storeProduct,
+      final PackageType packageType,
+      @JsonKey(name: 'product') final StoreProduct storeProduct,
       final String offeringIdentifier) = _$_Package;
 
   factory _Package.fromJson(Map<String, dynamic> json) = _$_Package.fromJson;

--- a/lib/models/store_transaction.freezed.dart
+++ b/lib/models/store_transaction.freezed.dart
@@ -39,7 +39,7 @@ mixin _$StoreTransaction {
             String transactionIdentifier,
             @Deprecated('Use transactionIdentifier instead.')
             @JsonKey(readValue: _readRevenueCatIdentifier)
-                String revenueCatIdentifier,
+            String revenueCatIdentifier,
             String productIdentifier,
             String purchaseDate)
         create,
@@ -51,7 +51,7 @@ mixin _$StoreTransaction {
             String transactionIdentifier,
             @Deprecated('Use transactionIdentifier instead.')
             @JsonKey(readValue: _readRevenueCatIdentifier)
-                String revenueCatIdentifier,
+            String revenueCatIdentifier,
             String productIdentifier,
             String purchaseDate)?
         create,
@@ -63,7 +63,7 @@ mixin _$StoreTransaction {
             String transactionIdentifier,
             @Deprecated('Use transactionIdentifier instead.')
             @JsonKey(readValue: _readRevenueCatIdentifier)
-                String revenueCatIdentifier,
+            String revenueCatIdentifier,
             String productIdentifier,
             String purchaseDate)?
         create,
@@ -102,7 +102,7 @@ abstract class $StoreTransactionCopyWith<$Res> {
       {String transactionIdentifier,
       @Deprecated('Use transactionIdentifier instead.')
       @JsonKey(readValue: _readRevenueCatIdentifier)
-          String revenueCatIdentifier,
+      String revenueCatIdentifier,
       String productIdentifier,
       String purchaseDate});
 }
@@ -158,7 +158,7 @@ abstract class _$$_StoreTransactionCopyWith<$Res>
       {String transactionIdentifier,
       @Deprecated('Use transactionIdentifier instead.')
       @JsonKey(readValue: _readRevenueCatIdentifier)
-          String revenueCatIdentifier,
+      String revenueCatIdentifier,
       String productIdentifier,
       String purchaseDate});
 }
@@ -207,7 +207,7 @@ class _$_StoreTransaction implements _StoreTransaction {
       this.transactionIdentifier,
       @Deprecated('Use transactionIdentifier instead.')
       @JsonKey(readValue: _readRevenueCatIdentifier)
-          this.revenueCatIdentifier,
+      this.revenueCatIdentifier,
       this.productIdentifier,
       this.purchaseDate);
 
@@ -270,7 +270,7 @@ class _$_StoreTransaction implements _StoreTransaction {
             String transactionIdentifier,
             @Deprecated('Use transactionIdentifier instead.')
             @JsonKey(readValue: _readRevenueCatIdentifier)
-                String revenueCatIdentifier,
+            String revenueCatIdentifier,
             String productIdentifier,
             String purchaseDate)
         create,
@@ -286,7 +286,7 @@ class _$_StoreTransaction implements _StoreTransaction {
             String transactionIdentifier,
             @Deprecated('Use transactionIdentifier instead.')
             @JsonKey(readValue: _readRevenueCatIdentifier)
-                String revenueCatIdentifier,
+            String revenueCatIdentifier,
             String productIdentifier,
             String purchaseDate)?
         create,
@@ -302,7 +302,7 @@ class _$_StoreTransaction implements _StoreTransaction {
             String transactionIdentifier,
             @Deprecated('Use transactionIdentifier instead.')
             @JsonKey(readValue: _readRevenueCatIdentifier)
-                String revenueCatIdentifier,
+            String revenueCatIdentifier,
             String productIdentifier,
             String purchaseDate)?
         create,
@@ -356,7 +356,7 @@ abstract class _StoreTransaction implements StoreTransaction {
       final String transactionIdentifier,
       @Deprecated('Use transactionIdentifier instead.')
       @JsonKey(readValue: _readRevenueCatIdentifier)
-          final String revenueCatIdentifier,
+      final String revenueCatIdentifier,
       final String productIdentifier,
       final String purchaseDate) = _$_StoreTransaction;
 


### PR DESCRIPTION
Looks like the `freezed` job started failing because the indentation of some of the generated files changed: https://app.circleci.com/pipelines/github/RevenueCat/purchases-flutter/2140/workflows/84918ad6-cafa-47cd-8503-8472f1067d5d/jobs/10670.

I was able to repro locally after running `flutter pub upgrade` to update to the latest versions of our dependencies.