### PR TITLE
Remove hold/test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,14 +19,6 @@ aliases:
         ignore: /.*/
       branches:
         only: main
-  except-main-and-release: &except-main-and-release
-    filters:
-      tags:
-        ignore: /.*/
-      branches:
-        ignore:
-          - /^release\/.*/
-          - main
 
 orbs:
   android: circleci/android@0.2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,15 +376,7 @@ workflows:
       - ios-integration-test
       - macos-integration-test
       - android-integration-test-build
-      - hold:
-          type: approval
-          requires:
-            - android-integration-test-build
-          <<: *except-main-and-release
-      - run-firebase-tests:
-          requires:
-            - hold
-          <<: *except-main-and-release
+      - run-firebase-tests
 
   deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,7 +376,6 @@ workflows:
       - ios-integration-test
       - macos-integration-test
       - android-integration-test-build
-      - run-firebase-tests
 
   deploy:
     when:


### PR DESCRIPTION
I noticed the `run-firebase-tests` job is a requirement to merge a branch into `main`, but this test is behind a hold job. I think we should remove the hold job and just always run that `run-firebase-tests` on deploy, same way we do in purchases-android