### PR TITLE
`CI`: disable `prepare-next-version`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,20 +317,6 @@ jobs:
           name: Dry Run Release
           command: flutter pub publish --dry-run
 
-  prepare-next-version:
-    description: "Creates a PR with the new snapshot version"
-    docker:
-      - image: cimg/ruby:3.1.2
-    steps:
-      - checkout
-      - revenuecat/install-gem-unix-dependencies:
-          cache-version: v1
-      - revenuecat/trust-github-key
-      - revenuecat/setup-git-credentials
-      - run:
-          name: Prepare next version
-          command: bundle exec fastlane prepare_next_version
-
   update-hybrid-common-versions:
     description: "Creates a PR updating purchases-hybrid-common to latest release"
     docker:
@@ -403,13 +389,6 @@ workflows:
             - hold
           <<: *release-branches
       - make-release: *release-tags
-  snapshot-bump:
-    when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-    jobs:
-      - prepare-next-version:
-          <<: *only-main-branch
   weekly-run-workflow:
     when:
       and:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -106,17 +106,6 @@ lane :github_release do |options|
   )
 end
 
-desc "Creates PR changing version to next minor adding a -SNAPSHOT suffix"
-lane :prepare_next_version do |options|
-  create_next_snapshot_version(
-    current_version: current_version_number,
-    repo_name: repo_name,
-    github_pr_token: ENV["GITHUB_PULL_REQUEST_API_TOKEN"],
-    files_to_update: files_with_version_number,
-    files_to_update_without_prerelease_modifiers: {}
-  )
-end
-
 desc "Builds and analyzes the api_tester project to make sure APIs are expected"
 lane :run_api_tests do |options|
   check_api_tester_imports_up_to_date


### PR DESCRIPTION
As discussed, these provide little value in the hybrids and instead create unnecessary busy work.