### PR TITLE
Fix flutter analyze deprecation warnings

### DIFF
--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -259,9 +259,9 @@ class Purchases {
     String typeString;
     // ignore: deprecated_member_use_from_same_package
     if (type != PurchaseType.subs) {
-      typeString = describeEnum(type);
+      typeString = type.name;
     } else {
-      typeString = describeEnum(productCategory);
+      typeString = productCategory.name;
     }
 
     final List<dynamic> result = await _channel.invokeMethod('getProductInfo', {
@@ -304,7 +304,7 @@ class Purchases {
     final prorationMode = upgradeInfo?.prorationMode;
     final customerInfo = await _invokeReturningCustomerInfo('purchaseProduct', {
       'productIdentifier': productIdentifier,
-      'type': describeEnum(type),
+      'type': type.name,
       'googleOldProductIdentifier': upgradeInfo?.oldSKU,
       'googleProrationMode': prorationMode?.index,
       'googleIsPersonalizedPrice': null,
@@ -339,9 +339,7 @@ class Purchases {
     final prorationMode = googleProductChangeInfo?.prorationMode?.value;
     final customerInfo = await _invokeReturningCustomerInfo('purchaseProduct', {
       'productIdentifier': storeProduct.identifier,
-      'type': storeProduct.productCategory != null
-          ? describeEnum(storeProduct.productCategory!)
-          : null,
+      'type': storeProduct.productCategory?.name,
       'googleOldProductIdentifier':
           googleProductChangeInfo?.oldProductIdentifier,
       'googleProrationMode': prorationMode,
@@ -540,7 +538,7 @@ class Purchases {
   /// The default is {LOG_LEVEL.INFO} in release builds and {LOG_LEVEL.DEBUG} in debug builds.
   static Future<void> setLogLevel(LogLevel level) => _channel.invokeMethod(
         'setLogLevel',
-        {'level': describeEnum(level).toUpperCase()},
+        {'level': level.name.toUpperCase()},
       );
 
   ///
@@ -929,7 +927,7 @@ class Purchases {
     final args = Map<String, dynamic>.from(call.arguments);
     final logLevelName = args['logLevel'];
     final logLevel = LogLevel.values.firstWhere(
-      (e) => describeEnum(e).toUpperCase() == logLevelName,
+      (e) => e.name.toUpperCase() == logLevelName,
       orElse: () => LogLevel.info,
     );
     final msg = args['message'];


### PR DESCRIPTION
Looks like `describeEnum` was deprecated in the latest Flutter version and substituted with `name`. This PR changes current usages of that to fix the linter.

From what I've been able to figure out, this `name` property is available since Dart 2.15, which is our minimum version so we should be good