### PR TITLE
Fix freezed tests after latest update

### DIFF
--- a/lib/models/customer_info_wrapper.freezed.dart
+++ b/lib/models/customer_info_wrapper.freezed.dart
@@ -440,7 +440,7 @@ class _$CustomerInfoImpl implements _CustomerInfo {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$CustomerInfoImpl &&

--- a/lib/models/entitlement_info_wrapper.freezed.dart
+++ b/lib/models/entitlement_info_wrapper.freezed.dart
@@ -416,7 +416,7 @@ class _$EntitlementInfoImpl implements _EntitlementInfo {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$EntitlementInfoImpl &&

--- a/lib/models/entitlement_infos_wrapper.freezed.dart
+++ b/lib/models/entitlement_infos_wrapper.freezed.dart
@@ -180,7 +180,7 @@ class _$EntitlementInfosImpl implements _EntitlementInfos {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$EntitlementInfosImpl &&

--- a/lib/models/introductory_price.freezed.dart
+++ b/lib/models/introductory_price.freezed.dart
@@ -231,7 +231,7 @@ class _$IntroductoryPriceImpl implements _IntroductoryPrice {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$IntroductoryPriceImpl &&

--- a/lib/models/offering_wrapper.freezed.dart
+++ b/lib/models/offering_wrapper.freezed.dart
@@ -437,7 +437,7 @@ class _$OfferingImpl extends _Offering {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$OfferingImpl &&

--- a/lib/models/offerings_wrapper.freezed.dart
+++ b/lib/models/offerings_wrapper.freezed.dart
@@ -155,7 +155,7 @@ class _$OfferingsImpl extends _Offerings {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$OfferingsImpl &&

--- a/lib/models/package_wrapper.freezed.dart
+++ b/lib/models/package_wrapper.freezed.dart
@@ -199,7 +199,7 @@ class _$PackageImpl implements _Package {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$PackageImpl &&

--- a/lib/models/period_wrapper.freezed.dart
+++ b/lib/models/period_wrapper.freezed.dart
@@ -148,7 +148,7 @@ class _$PeriodImpl implements _Period {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$PeriodImpl &&

--- a/lib/models/price_wrapper.freezed.dart
+++ b/lib/models/price_wrapper.freezed.dart
@@ -158,7 +158,7 @@ class _$PriceImpl implements _Price {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$PriceImpl &&

--- a/lib/models/pricing_phase_wrapper.freezed.dart
+++ b/lib/models/pricing_phase_wrapper.freezed.dart
@@ -222,7 +222,7 @@ class _$PricingPhaseImpl implements _PricingPhase {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$PricingPhaseImpl &&

--- a/lib/models/promotional_offer.freezed.dart
+++ b/lib/models/promotional_offer.freezed.dart
@@ -194,7 +194,7 @@ class _$PromotionalOfferImpl implements _PromotionalOffer {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$PromotionalOfferImpl &&

--- a/lib/models/store_product_discount.freezed.dart
+++ b/lib/models/store_product_discount.freezed.dart
@@ -237,7 +237,7 @@ class _$StoreProductDiscountImpl implements _StoreProductDiscount {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$StoreProductDiscountImpl &&

--- a/lib/models/store_product_wrapper.freezed.dart
+++ b/lib/models/store_product_wrapper.freezed.dart
@@ -421,7 +421,7 @@ class _$StoreProductImpl implements _StoreProduct {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$StoreProductImpl &&

--- a/lib/models/store_transaction.freezed.dart
+++ b/lib/models/store_transaction.freezed.dart
@@ -238,7 +238,7 @@ class _$StoreTransactionImpl implements _StoreTransaction {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$StoreTransactionImpl &&

--- a/lib/models/subscription_option_wrapper.freezed.dart
+++ b/lib/models/subscription_option_wrapper.freezed.dart
@@ -430,7 +430,7 @@ class _$SubscriptionOptionImpl implements _SubscriptionOption {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$SubscriptionOptionImpl &&


### PR DESCRIPTION
There was a new update from `freezed` that changed the generated files, making our tests fail. This updates those files.
