### PR TITLE
Fix `presentPaywallIfNeeded`

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -371,6 +371,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
             case "presentPaywallIfNeeded":
                 final String requiredEntitlementIdentifier = call.argument("requiredEntitlementIdentifier");
                 presentPaywall(result, requiredEntitlementIdentifier);
+                break;
             default:
                 result.notImplemented();
                 break;


### PR DESCRIPTION
We forgot a `break` when calling this method, which caused it to fall to the `default` case, resulting in the result being called twice, causing a crash. This deals with #902 