### PR TITLE
Remove result from presentPaywall methods

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -751,9 +751,9 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
         if (fragment != null) {
             presentPaywallFromFragment(
                     fragment,
-                    requiredEntitlementIdentifier,
-                    paywallResult -> result.success(paywallResult instanceof PaywallResult.Purchased)
+                    requiredEntitlementIdentifier
             );
+            result.success(null);
         } else {
             result.error(
                 String.valueOf(PurchasesErrorCode.UnknownError.getCode()),

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -514,7 +514,7 @@ class _PurchasesFlutterApiTest {
   }
 
   void _checkPaywalls() async {
-    Future<bool> future1 = Purchases.presentPaywall();
-    Future<bool> future2 = Purchases.presentPaywallIfNeeded("test");
+    Future<void> future1 = Purchases.presentPaywall();
+    Future<void> future2 = Purchases.presentPaywallIfNeeded("test");
   }
 }

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -935,10 +935,15 @@ class Purchases {
     _logHandler?.call(logLevel, msg);
   }
 
-  static Future<bool> presentPaywall() async =>
+  /// Presents the paywall as an activity on android or a modal in iOS.
+  static Future<void> presentPaywall() async =>
       await _channel.invokeMethod('presentPaywall');
 
-  static Future<bool> presentPaywallIfNeeded(
+  /// Presents the paywall as an activity on android or a modal in iOS as long
+  /// as the user does not have the given entitlement identifier active.
+  ///
+  /// @param [requiredEntitlementIdentifier] Entitlement identifier to check if the user has access to before presenting the paywall.
+  static Future<void> presentPaywallIfNeeded(
     String requiredEntitlementIdentifier,
   ) async =>
       await _channel.invokeMethod(

--- a/revenuecat_examples/purchase_tester/lib/src/app.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/app.dart
@@ -146,13 +146,7 @@ class _UpsellScreenState extends State<UpsellScreen> {
 
         buttonThings.add(ElevatedButton(
           onPressed: () async {
-            bool result = await Purchases.presentPaywall();
-
-            if (result) {
-              print("Purchase completed");
-            } else {
-              print("Purchase failed");
-            }
+            await Purchases.presentPaywall();
           },
           child: const Text('Present paywall'),
         ));


### PR DESCRIPTION
Currently the `presentPaywall` and `presentPaywallIfNeeded` methods return a boolean indicating whether a purchase happened in the paywall. This API is confusing and not extensible and it wasn't properly working in iOS, see: #886. This first PR removes the return value from the method. In a future PR we will add proper result handling for the paywalls. Until then, the clients won't know what happened when the paywall was presented and will need to rely on the `Purchases.getCustomerInfo()` method to respond appropriately.

This is a breaking change from the previous beta.