### PR TITLE
Fix github_release job not running after release jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -432,6 +432,7 @@ workflows:
           requires:
             - make-release
             - make-release-purchases-flutter-ui
+          <<: *release-tags
   weekly-run-workflow:
     when:
       and:


### PR DESCRIPTION
After splitting the ci jobs for deploying both the flutter and paywalls sdks, we separated the github release to its own job to be executed after those 2. However, it didn't execute in the last release. This should fix that.