### PR TITLE
Fix ios integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,7 +272,7 @@ jobs:
     description: "Run integration tests for Flutter"
     resource_class: macos.x86.medium.gen2
     macos:
-      xcode: 14.3.1
+      xcode: 15.2
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
@@ -295,7 +295,7 @@ jobs:
     description: "Run integration tests for Flutter"
     resource_class: macos.m1.medium.gen1
     macos:
-      xcode: 15.0.0
+      xcode: 15.2
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,7 @@ jobs:
     description: "Run integration tests for Flutter"
     resource_class: macos.m1.medium.gen1
     macos:
-      xcode: 14.3.1
+      xcode: 15.0.0
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,6 +151,20 @@ commands:
             if ! sdk env install; then
               echo "Error installing Java SDK through SDKMAN, continuing with default Java" >&2
             fi
+  
+  install-correct-cocoapods:
+    description: Install correct cocoapods version
+    steps:
+      - run:
+          name: Install Cocoapods
+          command: |
+            # This is needed because Flutter doesn't use 'bundle exec'
+
+            # Uninstalling preinstalled CircleCI cocoapods
+            gem uninstall -aIx cocoapods
+
+            # Need >= 1.14.0 to prevent ActiveSupport crash
+            gem install cocoapods -v '>= 1.14.0'
 
 jobs:
   lint:
@@ -262,6 +276,7 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
+      - install-correct-cocoapods
       - macos/preboot-simulator:
           device: iPhone 14
           version: '16.4'
@@ -284,16 +299,7 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
-      - run:
-          name: Install Cocoapods
-          command: |
-            # This is needed because Flutter doesn't use 'bundle exec'
-
-            # Uninstalling preinstalled CircleCI cocoapods
-            gem uninstall -aIx cocoapods
-
-            # Need >= 1.14.0 to prevent ActiveSupport crash
-            gem install cocoapods -v '>= 1.14.0'
+      - install-correct-cocoapods
       - setup-flutter
       - replace-api-key
       - build-flutter-project:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,7 @@ jobs:
     description: "Run integration tests for Flutter"
     resource_class: macos.m1.medium.gen1
     macos:
-      xcode: 15.2
+      xcode: 14.3.1
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
@@ -280,7 +280,7 @@ jobs:
     description: "Run integration tests for Flutter"
     resource_class: macos.m1.medium.gen1
     macos:
-      xcode: 15.2
+      xcode: 15.0.0
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,20 +151,6 @@ commands:
             if ! sdk env install; then
               echo "Error installing Java SDK through SDKMAN, continuing with default Java" >&2
             fi
-  
-  install-correct-cocoapods:
-    description: Install correct cocoapods version
-    steps:
-      - run:
-          name: Install Cocoapods
-          command: |
-            # This is needed because Flutter doesn't use 'bundle exec'
-
-            # Uninstalling preinstalled CircleCI cocoapods
-            gem uninstall -aIx cocoapods
-
-            # Need >= 1.14.0 to prevent ActiveSupport crash
-            gem install cocoapods -v '>= 1.14.0'
 
 jobs:
   lint:
@@ -276,7 +262,6 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
-      - install-correct-cocoapods
       - macos/preboot-simulator:
           device: iPhone 14
           version: '16.4'
@@ -299,7 +284,16 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
-      - install-correct-cocoapods
+      - run:
+          name: Install Cocoapods
+          command: |
+            # This is needed because Flutter doesn't use 'bundle exec'
+
+            # Uninstalling preinstalled CircleCI cocoapods
+            gem uninstall -aIx cocoapods
+
+            # Need >= 1.14.0 to prevent ActiveSupport crash
+            gem install cocoapods -v '>= 1.14.0'
       - setup-flutter
       - replace-api-key
       - build-flutter-project:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,7 +270,7 @@ jobs:
 
   ios-integration-test:
     description: "Run integration tests for Flutter"
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
     macos:
       xcode: 15.2
     shell: /bin/bash --login -o pipefail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,7 +272,7 @@ jobs:
     description: "Run integration tests for Flutter"
     resource_class: macos.m1.medium.gen1
     macos:
-      xcode: 15.0.0
+      xcode: 15.2
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
@@ -295,7 +295,7 @@ jobs:
     description: "Run integration tests for Flutter"
     resource_class: macos.m1.medium.gen1
     macos:
-      xcode: 15.0.0
+      xcode: 15.2
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout

--- a/revenuecat_examples/purchase_tester/integration_test/app_test.dart
+++ b/revenuecat_examples/purchase_tester/integration_test/app_test.dart
@@ -1,5 +1,4 @@
 // Imports the Flutter Driver API.
-import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';

--- a/revenuecat_examples/purchase_tester/integration_test/app_test.dart
+++ b/revenuecat_examples/purchase_tester/integration_test/app_test.dart
@@ -8,18 +8,18 @@ import 'package:purchases_flutter/purchases_flutter.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  var userId = "integration-test-${DateTime.now().millisecondsSinceEpoch}";
+  var uuid = UniqueKey().toString();
 
   setUpAll(() {
     PurchasesConfiguration configuration = PurchasesConfiguration("appl_KhXKryBEHUWEdShrggQyjyzHKHW");
-    configuration.appUserID = userId;
+    configuration.appUserID = uuid;
     configuration.entitlementVerificationMode = EntitlementVerificationMode.informational;
     Purchases.configure(configuration);
   });
 
   testWidgets('Configures without crashing', (WidgetTester tester) async {
     try {
-      assert(await Purchases.appUserID == userId, true);
+      assert(await Purchases.appUserID == uuid, true);
     } on PlatformException catch (e) {
       fail('there was an exception ' + e.toString());
     }
@@ -28,7 +28,7 @@ void main() {
   testWidgets('Purchaser info fetched successfully',
       (WidgetTester tester) async {
     try {
-      assert((await Purchases.getCustomerInfo()).originalAppUserId == userId, true);
+      assert((await Purchases.getCustomerInfo()).originalAppUserId == uuid, true);
     } on PlatformException catch (e) {
       fail('there was an exception ' + e.toString());
     }

--- a/revenuecat_examples/purchase_tester/integration_test/app_test.dart
+++ b/revenuecat_examples/purchase_tester/integration_test/app_test.dart
@@ -8,18 +8,18 @@ import 'package:purchases_flutter/purchases_flutter.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  var uuid = UniqueKey().toString();
+  var userId = "integration-test-${DateTime.now().millisecondsSinceEpoch}";
 
   setUpAll(() {
     PurchasesConfiguration configuration = PurchasesConfiguration("appl_KhXKryBEHUWEdShrggQyjyzHKHW");
-    configuration.appUserID = uuid;
+    configuration.appUserID = userId;
     configuration.entitlementVerificationMode = EntitlementVerificationMode.informational;
     Purchases.configure(configuration);
   });
 
   testWidgets('Configures without crashing', (WidgetTester tester) async {
     try {
-      assert(await Purchases.appUserID == uuid, true);
+      assert(await Purchases.appUserID == userId, true);
     } on PlatformException catch (e) {
       fail('there was an exception ' + e.toString());
     }
@@ -28,7 +28,7 @@ void main() {
   testWidgets('Purchaser info fetched successfully',
       (WidgetTester tester) async {
     try {
-      assert((await Purchases.getCustomerInfo()).originalAppUserId == uuid, true);
+      assert((await Purchases.getCustomerInfo()).originalAppUserId == userId, true);
     } on PlatformException catch (e) {
       fail('there was an exception ' + e.toString());
     }


### PR DESCRIPTION
ios integration tests were failing getting stuck in macos x86 machines. This updates to using M1 machines and updates to newer Xcode version, which required some small changes in the integration tests.