### PR TITLE
Add `PaywallView` listeners

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -26,7 +26,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    compileSdk 34
 
     // Conditional for compatibility with AGP <4.2.
     if (project.android.hasProperty("namespace")) {

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed May 24 15:08:05 PDT 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/api_tester/lib/api_tests/purchases_ui_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_ui_flutter_api_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:purchases_ui_flutter/purchases_ui_flutter.dart';
 import 'package:purchases_flutter/models/offering_wrapper.dart';
 
@@ -40,8 +41,8 @@ class _PurchasesFlutterApiTest {
     );
   }
 
-  Widget _checkPaywallView(Offering offering) {
-    return const Scaffold(
+  Widget _checkPaywallViewWithOffering(Offering offering) {
+    return Scaffold(
       body: Center(
         child: PaywallView(
           offering: offering,

--- a/api_tester/lib/api_tests/purchases_ui_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_ui_flutter_api_test.dart
@@ -31,4 +31,23 @@ class _PurchasesFlutterApiTest {
         break;
     }
   }
+
+  Widget _checkPaywallView() {
+    return const Scaffold(
+      body: Center(
+        child: PaywallView(),
+      ),
+    );
+  }
+
+  Widget _checkPaywallView(Offering offering) {
+    return const Scaffold(
+      body: Center(
+        child: PaywallView(
+          offering: offering,
+        ),
+      ),
+    );
+  }
+
 }

--- a/purchases_ui_flutter/android/build.gradle
+++ b/purchases_ui_flutter/android/build.gradle
@@ -45,10 +45,11 @@ android {
 
     defaultConfig {
         minSdkVersion 24
-        compileSdk 33
+        compileSdk 34
     }
 
     dependencies {
         implementation "com.revenuecat.purchases:purchases-hybrid-common-ui:$common_version"
+        implementation 'androidx.compose.ui:ui-android:1.5.4'
     }
 }

--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/PurchasesUiFlutterPlugin.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/PurchasesUiFlutterPlugin.kt
@@ -7,7 +7,7 @@ import com.revenuecat.purchases.hybridcommon.ui.PaywallResultListener
 import com.revenuecat.purchases.hybridcommon.ui.PaywallSource
 import com.revenuecat.purchases.hybridcommon.ui.PresentPaywallOptions
 import com.revenuecat.purchases.hybridcommon.ui.presentPaywallFromFragment
-import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResult
+import com.revenuecat.purchases_ui_flutter.views.PaywallViewFactory
 import io.flutter.embedding.android.FlutterFragmentActivity
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
@@ -25,6 +25,10 @@ class PurchasesUiFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware 
     private lateinit var channel : MethodChannel
 
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+        flutterPluginBinding.platformViewRegistry.registerViewFactory(
+            "com.revenuecat.purchasesui/PaywallView",
+            PaywallViewFactory()
+        )
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "purchases_ui_flutter")
         channel.setMethodCallHandler(this)
     }

--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/PurchasesUiFlutterPlugin.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/PurchasesUiFlutterPlugin.kt
@@ -27,7 +27,7 @@ class PurchasesUiFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware 
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         flutterPluginBinding.platformViewRegistry.registerViewFactory(
             "com.revenuecat.purchasesui/PaywallView",
-            PaywallViewFactory()
+            PaywallViewFactory(flutterPluginBinding.binaryMessenger)
         )
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "purchases_ui_flutter")
         channel.setMethodCallHandler(this)

--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallView.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallView.kt
@@ -1,19 +1,28 @@
 package com.revenuecat.purchases_ui_flutter.views
 
+import android.util.Log
 import android.content.Context
-import android.util.AttributeSet
 import android.view.View
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.platform.PlatformView
+import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.hybridcommon.ui.PaywallListenerWrapper
+import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.views.PaywallView as NativePaywallView
 
 @OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 internal class PaywallView(
     context: Context,
     id: Int,
+    messenger: BinaryMessenger,
     creationParams: Map<String?, Any?>
-) : PlatformView {
+) : PlatformView, MethodCallHandler {
 
+    private val methodChannel: MethodChannel
     private val nativePaywallView: NativePaywallView
 
     override fun getView(): View {
@@ -23,9 +32,38 @@ internal class PaywallView(
     override fun dispose() {}
 
     init {
+        methodChannel = MethodChannel(messenger, "com.revenuecat.purchasesui/PaywallView/$id")
+        methodChannel.setMethodCallHandler(this)
         val offeringIdentifier = creationParams["offeringIdentifier"] as String?
         nativePaywallView = NativePaywallView(context,)
+        nativePaywallView.setPaywallListener(object : PaywallListenerWrapper() {
+            override fun onPurchaseStarted(rcPackage: Map<String, Any?>) {
+                methodChannel.invokeMethod("onPurchaseStarted", rcPackage)
+            }
+
+            override fun onPurchaseCompleted(customerInfo: Map<String, Any?>, storeTransaction: Map<String, Any?>) {
+                // TODO
+            }
+
+            override fun onPurchaseError(error: Map<String, Any?>) {
+                // TODO
+            }
+
+            override fun onRestoreCompleted(customerInfo: Map<String, Any?>) {
+                // TODO
+            }
+
+            override fun onRestoreError(error: Map<String, Any?>) {
+                // TODO
+            }
+        })
         // TODO add to constructor
         nativePaywallView.setOfferingId(offeringIdentifier)
+    }
+
+    override fun onMethodCall(methodCall: MethodCall, result: MethodChannel.Result) {
+        when (methodCall.method) {
+            else -> result.notImplemented()
+        }
     }
 }

--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallView.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallView.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases_ui_flutter.views
 
 import android.content.Context
+import android.util.AttributeSet
 import android.view.View
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import io.flutter.plugin.platform.PlatformView
@@ -8,8 +9,9 @@ import com.revenuecat.purchases.ui.revenuecatui.views.PaywallView as NativePaywa
 
 @OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 internal class PaywallView(
-    context: Context, id: Int,
-    creationParams: Map<String?, Any?>?
+    context: Context,
+    id: Int,
+    creationParams: Map<String?, Any?>
 ) : PlatformView {
 
     private val nativePaywallView: NativePaywallView
@@ -21,6 +23,9 @@ internal class PaywallView(
     override fun dispose() {}
 
     init {
-        nativePaywallView = NativePaywallView(context)
+        val offeringIdentifier = creationParams["offeringIdentifier"] as String?
+        nativePaywallView = NativePaywallView(context,)
+        // TODO add to constructor
+        nativePaywallView.setOfferingId(offeringIdentifier)
     }
 }

--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallView.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallView.kt
@@ -1,0 +1,26 @@
+package com.revenuecat.purchases_ui_flutter.views
+
+import android.content.Context
+import android.view.View
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
+import io.flutter.plugin.platform.PlatformView
+import com.revenuecat.purchases.ui.revenuecatui.views.PaywallView as NativePaywallView
+
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
+internal class PaywallView(
+    context: Context, id: Int,
+    creationParams: Map<String?, Any?>?
+) : PlatformView {
+
+    private val nativePaywallView: NativePaywallView
+
+    override fun getView(): View {
+        return nativePaywallView
+    }
+
+    override fun dispose() {}
+
+    init {
+        nativePaywallView = NativePaywallView(context)
+    }
+}

--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallViewFactory.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallViewFactory.kt
@@ -1,0 +1,13 @@
+package com.revenuecat.purchases_ui_flutter.views
+
+import android.content.Context
+import io.flutter.plugin.common.StandardMessageCodec
+import io.flutter.plugin.platform.PlatformView
+import io.flutter.plugin.platform.PlatformViewFactory
+
+class PaywallViewFactory : PlatformViewFactory(StandardMessageCodec.INSTANCE) {
+    override fun create(context: Context, viewId: Int, args: Any?): PlatformView {
+        val creationParams = args as Map<String?, Any?>?
+        return PaywallView(context, viewId, creationParams)
+    }
+}

--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallViewFactory.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallViewFactory.kt
@@ -1,14 +1,17 @@
 package com.revenuecat.purchases_ui_flutter.views
 
 import android.content.Context
+import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.StandardMessageCodec
 import io.flutter.plugin.platform.PlatformView
 import io.flutter.plugin.platform.PlatformViewFactory
 
-class PaywallViewFactory : PlatformViewFactory(StandardMessageCodec.INSTANCE) {
+class PaywallViewFactory(
+    private val messenger: BinaryMessenger,
+) : PlatformViewFactory(StandardMessageCodec.INSTANCE) {
     override fun create(context: Context, viewId: Int, args: Any?): PlatformView {
         @Suppress("UNCHECKED_CAST")
         val creationParams = args as? Map<String?, Any?>? ?: emptyMap()
-        return PaywallView(context, viewId, creationParams)
+        return PaywallView(context, viewId, messenger, creationParams)
     }
 }

--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallViewFactory.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallViewFactory.kt
@@ -7,7 +7,8 @@ import io.flutter.plugin.platform.PlatformViewFactory
 
 class PaywallViewFactory : PlatformViewFactory(StandardMessageCodec.INSTANCE) {
     override fun create(context: Context, viewId: Int, args: Any?): PlatformView {
-        val creationParams = args as Map<String?, Any?>?
+        @Suppress("UNCHECKED_CAST")
+        val creationParams = args as? Map<String?, Any?>? ?: emptyMap()
         return PaywallView(context, viewId, creationParams)
     }
 }

--- a/purchases_ui_flutter/ios/Classes/PurchasesUiFlutterPlugin.swift
+++ b/purchases_ui_flutter/ios/Classes/PurchasesUiFlutterPlugin.swift
@@ -21,6 +21,8 @@ public class PurchasesUiFlutterPlugin: NSObject, FlutterPlugin {
         let channel = FlutterMethodChannel(name: "purchases_ui_flutter", binaryMessenger: messenger)
         let instance = PurchasesUiFlutterPlugin()
         registrar.addMethodCallDelegate(instance, channel: channel)
+        let factory = PurchasesUiPaywallViewFactory(messenger: registrar.messenger())
+        registrar.register(factory, withId: "com.revenuecat.purchasesui/PaywallView")
     }
 
     private var _paywallProxy: Any?

--- a/purchases_ui_flutter/ios/Classes/PurchasesUiPaywallView.swift
+++ b/purchases_ui_flutter/ios/Classes/PurchasesUiPaywallView.swift
@@ -1,0 +1,61 @@
+import Flutter
+import UIKit
+import PurchasesHybridCommonUI
+import RevenueCatUI
+
+class PurchasesUiPaywallViewFactory: NSObject, FlutterPlatformViewFactory {
+    private var messenger: FlutterBinaryMessenger
+
+    init(messenger: FlutterBinaryMessenger) {
+        self.messenger = messenger
+        super.init()
+    }
+
+    func create(
+        withFrame frame: CGRect,
+        viewIdentifier viewId: Int64,
+        arguments args: Any?
+    ) -> FlutterPlatformView {
+        return PurchasesUiPaywallView(
+            frame: frame,
+            viewIdentifier: viewId,
+            arguments: args,
+            binaryMessenger: messenger)
+    }
+
+    /// Implementing this method is only necessary when the `arguments` in `createWithFrame` is not `nil`.
+    public func createArgsCodec() -> FlutterMessageCodec & NSObjectProtocol {
+          return FlutterStandardMessageCodec.sharedInstance()
+    }
+}
+
+class PurchasesUiPaywallView: NSObject, FlutterPlatformView {
+    private var _view: UIView
+
+    init(
+        frame: CGRect,
+        viewIdentifier viewId: Int64,
+        arguments args: Any?,
+        binaryMessenger messenger: FlutterBinaryMessenger?
+    ) {
+        if #available(iOS 15.0, *) {
+            let paywallProxy = PaywallProxy()
+            guard let paywallView = paywallProxy.createPaywallView().view else {
+                print("Error: error getting PaywallView.")
+                _view = UIView()
+                super.init()
+                return
+            }
+            _view = paywallView
+        } else {
+            print("Error: attempted to present paywalls on unsupported iOS version.")
+            _view = UIView()
+        }
+        super.init()
+    }
+
+    func view() -> UIView {
+        return _view
+    }
+
+}

--- a/purchases_ui_flutter/lib/purchases_ui_flutter.dart
+++ b/purchases_ui_flutter/lib/purchases_ui_flutter.dart
@@ -5,6 +5,8 @@ import 'paywall_result.dart';
 
 export 'paywall_result.dart';
 
+export 'views/paywall_view.dart';
+
 class RevenueCatUI {
   static const _methodChannel = MethodChannel('purchases_ui_flutter');
 

--- a/purchases_ui_flutter/lib/views/paywall_view.dart
+++ b/purchases_ui_flutter/lib/views/paywall_view.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+
+class PaywallView extends StatelessWidget {
+  const PaywallView({Key? key}) : super(key: key);
+
+  static const String viewType = 'com.revenuecat.purchasesui/PaywallView';
+
+  @override
+  Widget build(BuildContext context) {
+    const creationParams = <String, dynamic>{};
+
+    return Platform.isAndroid
+        ? PlatformViewLink(
+            viewType: viewType,
+            surfaceFactory: (context, controller) => AndroidViewSurface(
+              controller: controller as AndroidViewController,
+              gestureRecognizers: const <Factory<
+                  OneSequenceGestureRecognizer>>{},
+              hitTestBehavior: PlatformViewHitTestBehavior.opaque,
+            ),
+            onCreatePlatformView: (params) =>
+                PlatformViewsService.initSurfaceAndroidView(
+              id: params.id,
+              viewType: viewType,
+              layoutDirection: TextDirection.ltr,
+              creationParams: creationParams,
+              creationParamsCodec: const StandardMessageCodec(),
+              onFocus: () {
+                params.onFocusChanged(true);
+              },
+            )
+                  ..addOnPlatformViewCreatedListener(
+                      params.onPlatformViewCreated)
+                  ..create(),
+          )
+        : const Text('TODO iOS PaywallView');
+  }
+}

--- a/purchases_ui_flutter/lib/views/paywall_view.dart
+++ b/purchases_ui_flutter/lib/views/paywall_view.dart
@@ -6,13 +6,27 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:purchases_flutter/models/offering_wrapper.dart';
+import 'package:purchases_flutter/models/package_wrapper.dart';
 
+/// View that displays the paywall in full screen mode.
+///
+/// [offering] (Optional) The offering object to be displayed in the paywall.
+/// Obtained from [Purchases.getOfferings].
+///
+/// [onPurchaseStarted] (Optional) Callback that gets called when a purchase
+/// is started.
 class PaywallView extends StatelessWidget {
   final Offering? offering;
+  final Function(Package rcPackage)? onPurchaseStarted;
+  MethodChannel? _listenerChannel;
 
-  const PaywallView({Key? key, this.offering}) : super(key: key);
+  PaywallView({
+    Key? key,
+    this.offering,
+    this.onPurchaseStarted,
+  }) : super(key: key);
 
-  static const String viewType = 'com.revenuecat.purchasesui/PaywallView';
+  static const String _viewType = 'com.revenuecat.purchasesui/PaywallView';
 
   @override
   Widget build(BuildContext context) {
@@ -21,22 +35,22 @@ class PaywallView extends StatelessWidget {
     };
 
     return Platform.isAndroid
-        ? buildAndroidPlatformViewLink(creationParams)
-        : buildUiKitView(creationParams);
+        ? _buildAndroidPlatformViewLink(creationParams)
+        : _buildUiKitView(creationParams);
   }
 
-  UiKitView buildUiKitView(Map<String, dynamic> creationParams) => UiKitView(
-      viewType: viewType,
+  UiKitView _buildUiKitView(Map<String, dynamic> creationParams) => UiKitView(
+      viewType: _viewType,
       layoutDirection: TextDirection.ltr,
       creationParams: creationParams,
       creationParamsCodec: const StandardMessageCodec(),
   );
 
-  PlatformViewLink buildAndroidPlatformViewLink(
+  PlatformViewLink _buildAndroidPlatformViewLink(
       Map<String, dynamic> creationParams,
   ) =>
       PlatformViewLink(
-        viewType: viewType,
+        viewType: _viewType,
         surfaceFactory: (context, controller) => AndroidViewSurface(
           controller: controller as AndroidViewController,
           gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
@@ -44,18 +58,36 @@ class PaywallView extends StatelessWidget {
         ),
         onCreatePlatformView: (params) =>
             PlatformViewsService.initSurfaceAndroidView(
-          id: params.id,
-          viewType: viewType,
-          layoutDirection: TextDirection.ltr,
-          creationParams: creationParams,
-          creationParamsCodec: const StandardMessageCodec(),
-          onFocus: () {
-            params.onFocusChanged(true);
-          },
-        )
+              id: params.id,
+              viewType: _viewType,
+              layoutDirection: TextDirection.ltr,
+              creationParams: creationParams,
+              creationParamsCodec: const StandardMessageCodec(),
+              onFocus: () {
+                params.onFocusChanged(true);
+              },
+            )
               ..addOnPlatformViewCreatedListener(
                 params.onPlatformViewCreated,
               )
+              ..addOnPlatformViewCreatedListener(
+                _buildListenerChannel,
+              )
               ..create(),
       );
+
+  void _buildListenerChannel(int id) {
+    _listenerChannel = MethodChannel(
+        'com.revenuecat.purchasesui/PaywallView/$id'
+    )
+      ..setMethodCallHandler((call) async {
+        if (call.method == 'onPurchaseStarted') {
+          final rcPackage = Package.fromJson(
+              Map<String, dynamic>.from(call.arguments)
+          );
+          onPurchaseStarted?.call(rcPackage);
+        }
+        return null;
+      });
+  }
 }

--- a/purchases_ui_flutter/lib/views/paywall_view.dart
+++ b/purchases_ui_flutter/lib/views/paywall_view.dart
@@ -43,7 +43,8 @@ class PaywallView extends StatelessWidget {
               },
             )
                   ..addOnPlatformViewCreatedListener(
-                      params.onPlatformViewCreated)
+                      params.onPlatformViewCreated,
+                  )
                   ..create(),
           )
         : const Text('TODO iOS PaywallView');

--- a/purchases_ui_flutter/lib/views/paywall_view.dart
+++ b/purchases_ui_flutter/lib/views/paywall_view.dart
@@ -10,43 +10,51 @@ import 'package:purchases_flutter/models/offering_wrapper.dart';
 class PaywallView extends StatelessWidget {
   final Offering? offering;
 
-  const PaywallView({Key? key, this.offering})
-      : super(key: key);
+  const PaywallView({Key? key, this.offering}) : super(key: key);
 
   static const String viewType = 'com.revenuecat.purchasesui/PaywallView';
 
   @override
   Widget build(BuildContext context) {
-
     final creationParams = <String, dynamic>{
       'offeringIdentifier': offering?.identifier,
     };
 
     return Platform.isAndroid
-        ? PlatformViewLink(
-            viewType: viewType,
-            surfaceFactory: (context, controller) => AndroidViewSurface(
-              controller: controller as AndroidViewController,
-              gestureRecognizers: const <Factory<
-                  OneSequenceGestureRecognizer>>{},
-              hitTestBehavior: PlatformViewHitTestBehavior.opaque,
-            ),
-            onCreatePlatformView: (params) =>
-                PlatformViewsService.initSurfaceAndroidView(
-              id: params.id,
-              viewType: viewType,
-              layoutDirection: TextDirection.ltr,
-              creationParams: creationParams,
-              creationParamsCodec: const StandardMessageCodec(),
-              onFocus: () {
-                params.onFocusChanged(true);
-              },
-            )
-                  ..addOnPlatformViewCreatedListener(
-                      params.onPlatformViewCreated,
-                  )
-                  ..create(),
-          )
-        : const Text('TODO iOS PaywallView');
+        ? buildAndroidPlatformViewLink(creationParams)
+        : buildUiKitView(creationParams);
   }
+
+  UiKitView buildUiKitView(Map<String, dynamic> creationParams) => UiKitView(
+      viewType: viewType,
+      layoutDirection: TextDirection.ltr,
+      creationParams: creationParams,
+      creationParamsCodec: const StandardMessageCodec(),
+  );
+
+  PlatformViewLink buildAndroidPlatformViewLink(
+          Map<String, dynamic> creationParams) =>
+      PlatformViewLink(
+        viewType: viewType,
+        surfaceFactory: (context, controller) => AndroidViewSurface(
+          controller: controller as AndroidViewController,
+          gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
+          hitTestBehavior: PlatformViewHitTestBehavior.opaque,
+        ),
+        onCreatePlatformView: (params) =>
+            PlatformViewsService.initSurfaceAndroidView(
+          id: params.id,
+          viewType: viewType,
+          layoutDirection: TextDirection.ltr,
+          creationParams: creationParams,
+          creationParamsCodec: const StandardMessageCodec(),
+          onFocus: () {
+            params.onFocusChanged(true);
+          },
+        )
+              ..addOnPlatformViewCreatedListener(
+                params.onPlatformViewCreated,
+              )
+              ..create(),
+      );
 }

--- a/purchases_ui_flutter/lib/views/paywall_view.dart
+++ b/purchases_ui_flutter/lib/views/paywall_view.dart
@@ -5,15 +5,22 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
+import 'package:purchases_flutter/models/offering_wrapper.dart';
 
 class PaywallView extends StatelessWidget {
-  const PaywallView({Key? key}) : super(key: key);
+  final Offering? offering;
+
+  const PaywallView({Key? key, this.offering})
+      : super(key: key);
 
   static const String viewType = 'com.revenuecat.purchasesui/PaywallView';
 
   @override
   Widget build(BuildContext context) {
-    const creationParams = <String, dynamic>{};
+
+    final creationParams = <String, dynamic>{
+      'offeringIdentifier': offering?.identifier,
+    };
 
     return Platform.isAndroid
         ? PlatformViewLink(

--- a/purchases_ui_flutter/lib/views/paywall_view.dart
+++ b/purchases_ui_flutter/lib/views/paywall_view.dart
@@ -33,7 +33,8 @@ class PaywallView extends StatelessWidget {
   );
 
   PlatformViewLink buildAndroidPlatformViewLink(
-          Map<String, dynamic> creationParams) =>
+      Map<String, dynamic> creationParams,
+  ) =>
       PlatformViewLink(
         viewType: viewType,
         surfaceFactory: (context, controller) => AndroidViewSurface(

--- a/revenuecat_examples/purchase_tester/android/app/build.gradle
+++ b/revenuecat_examples/purchase_tester/android/app/build.gradle
@@ -25,8 +25,8 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion flutter.compileSdkVersion
-    ndkVersion flutter.ndkVersion
+    compileSdk 34
+    ndkVersion "25.1.8937393"
 
     lint {
         disable 'InvalidPackage'
@@ -37,7 +37,7 @@ android {
     defaultConfig {
         applicationId "com.revenuecat.purchases_sample"
         minSdkVersion 24
-        targetSdkVersion flutter.targetSdkVersion
+        targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/revenuecat_examples/purchase_tester/android/build.gradle
+++ b/revenuecat_examples/purchase_tester/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.2.0'
     }
 }
 

--- a/revenuecat_examples/purchase_tester/android/gradle/wrapper/gradle-wrapper.properties
+++ b/revenuecat_examples/purchase_tester/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
 #Mon Feb 06 12:56:20 CST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip

--- a/revenuecat_examples/purchase_tester/lib/src/paywall.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/paywall.dart
@@ -1,0 +1,34 @@
+import 'dart:async';
+
+import 'package:purchases_ui_flutter/views/paywall_view.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'constant.dart';
+import 'cats.dart';
+import 'upsell.dart';
+
+// ignore: public_member_api_docs
+class PaywallScreen extends StatefulWidget {
+  const PaywallScreen({Key? key}) : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() => _PaywallScreenState();
+}
+
+class _PaywallScreenState extends State<PaywallScreen> {
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: PaywallView(),
+      ),
+    );
+  }
+}

--- a/revenuecat_examples/purchase_tester/lib/src/paywall.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/paywall.dart
@@ -1,10 +1,7 @@
-import 'dart:async';
-
 import 'package:purchases_ui_flutter/purchases_ui_flutter.dart';
 import 'package:purchases_flutter/purchases_flutter.dart';
 import 'package:flutter/material.dart';
 
-// ignore: public_member_api_docs
 class PaywallScreen extends StatefulWidget {
   final Offering? offering;
 

--- a/revenuecat_examples/purchase_tester/lib/src/paywall.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/paywall.dart
@@ -1,16 +1,14 @@
 import 'dart:async';
 
-import 'package:purchases_ui_flutter/views/paywall_view.dart';
+import 'package:purchases_ui_flutter/purchases_ui_flutter.dart';
+import 'package:purchases_flutter/purchases_flutter.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-
-import 'constant.dart';
-import 'cats.dart';
-import 'upsell.dart';
 
 // ignore: public_member_api_docs
 class PaywallScreen extends StatefulWidget {
-  const PaywallScreen({Key? key}) : super(key: key);
+  final Offering? offering;
+
+  const PaywallScreen({Key? key, this.offering}) : super(key: key);
 
   @override
   State<StatefulWidget> createState() => _PaywallScreenState();
@@ -25,9 +23,11 @@ class _PaywallScreenState extends State<PaywallScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(
-        child: PaywallView(),
+    return Scaffold(
+      body: SafeArea( // Wrap your body content with SafeArea
+        child: Center(
+          child: PaywallView(offering: widget.offering,),
+        ),
       ),
     );
   }

--- a/revenuecat_examples/purchase_tester/lib/src/paywall.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/paywall.dart
@@ -23,9 +23,14 @@ class _PaywallScreenState extends State<PaywallScreen> {
     return Scaffold(
       body: SafeArea( // Wrap your body content with SafeArea
         child: Center(
-          child: PaywallView(offering: widget.offering,),
+          child: PaywallView(
+            offering: widget.offering,
+            onPurchaseStarted: (Package rcPackage) {
+              print('Purchase started for package: ${rcPackage.identifier}');
+            },
+          ),
         ),
-      ),
+      )
     );
   }
 }

--- a/revenuecat_examples/purchase_tester/lib/src/upsell.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/upsell.dart
@@ -4,6 +4,7 @@ import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:purchases_flutter/purchases_flutter.dart';
+import 'package:purchases_flutter_example/src/paywall.dart';
 import 'package:purchases_ui_flutter/purchases_ui_flutter.dart';
 
 import 'constant.dart';
@@ -103,6 +104,15 @@ class _UpsellScreenState extends State<UpsellScreen> {
                       log('Paywall result: $paywallResult');
                     },
                     child: const Text('Present paywall if needed ("$entitlementKey")'),
+                  ),
+                  ElevatedButton(
+                    onPressed: () async {
+                      Navigator.pushReplacement(
+                        context,
+                        MaterialPageRoute(builder: (context) => const PaywallScreen()),
+                      );
+                    },
+                    child: const Text('Show paywall view'),
                   )
                 ]))),
       ),

--- a/revenuecat_examples/purchase_tester/lib/src/upsell.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/upsell.dart
@@ -4,12 +4,12 @@ import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:purchases_flutter/purchases_flutter.dart';
-import 'package:purchases_flutter_example/src/paywall.dart';
 import 'package:purchases_ui_flutter/purchases_ui_flutter.dart';
 
 import 'constant.dart';
 import 'cats.dart';
 import 'initial.dart';
+import 'paywall.dart';
 
 class UpsellScreen extends StatefulWidget {
   const UpsellScreen({Key? key}) : super(key: key);
@@ -107,9 +107,12 @@ class _UpsellScreenState extends State<UpsellScreen> {
                   ),
                   ElevatedButton(
                     onPressed: () async {
-                      Navigator.pushReplacement(
+                      Navigator.push(
                         context,
-                        MaterialPageRoute(builder: (context) => const PaywallScreen()),
+                        MaterialPageRoute(
+                            builder: (context) => PaywallScreen(
+                                  offering: offering,
+                                )),
                       );
                     },
                     child: const Text('Show paywall view'),


### PR DESCRIPTION
This PR adds listeners to the `PaywallView` so developers can access when certain events happen. Current listeners:
- `onPurchaseStarted`