### PR TITLE
`PaywallFooterView` support

### DIFF
--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/PurchasesUiFlutterPlugin.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/PurchasesUiFlutterPlugin.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.hybridcommon.ui.PaywallResultListener
 import com.revenuecat.purchases.hybridcommon.ui.PaywallSource
 import com.revenuecat.purchases.hybridcommon.ui.PresentPaywallOptions
 import com.revenuecat.purchases.hybridcommon.ui.presentPaywallFromFragment
+import com.revenuecat.purchases_ui_flutter.views.PaywallFooterViewFactory
 import com.revenuecat.purchases_ui_flutter.views.PaywallViewFactory
 import io.flutter.embedding.android.FlutterFragmentActivity
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -28,6 +29,10 @@ class PurchasesUiFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware 
         flutterPluginBinding.platformViewRegistry.registerViewFactory(
             "com.revenuecat.purchasesui/PaywallView",
             PaywallViewFactory()
+        )
+        flutterPluginBinding.platformViewRegistry.registerViewFactory(
+            "com.revenuecat.purchasesui/PaywallFooterView",
+            PaywallFooterViewFactory(flutterPluginBinding.binaryMessenger)
         )
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "purchases_ui_flutter")
         channel.setMethodCallHandler(this)

--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallFooterView.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallFooterView.kt
@@ -35,30 +35,6 @@ internal class PaywallFooterView(
         methodChannel = MethodChannel(messenger, "purchases_ui_flutter/PaywallFooterView/${id}")
         val offeringIdentifier = creationParams["offeringIdentifier"] as String?
         nativePaywallFooterView = object : NativePaywallFooterView(context) {
-//
-//            var shouldRemeasure = true
-//
-//            override fun requestLayout() {
-//                super.requestLayout()
-//                if (shouldRemeasure) {
-////                    post(measureAndLayout)
-//                }
-//            }
-//
-//            private val measureAndLayout = Runnable {
-//                Log.e("TEST", "MEASURE AND LAYOUT")
-//                measure(
-//                    MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
-//                    MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
-//                )
-//                layout(left, top, right, bottom)
-//            }
-//
-//            override fun onDetachedFromWindow() {
-//                super.onDetachedFromWindow()
-//                shouldRemeasure = false
-//            }
-
             public override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
                 super.onMeasure(widthMeasureSpec, heightMeasureSpec)
                 var maxWidth = 0

--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallFooterView.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallFooterView.kt
@@ -1,0 +1,90 @@
+package com.revenuecat.purchases_ui_flutter.views
+
+import android.content.Context
+import android.util.AttributeSet
+import android.util.Log
+import android.view.Gravity
+import android.view.View
+import android.widget.FrameLayout
+import androidx.core.view.children
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
+import com.revenuecat.purchases.ui.revenuecatui.views.PaywallFooterView as NativePaywallFooterView
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.platform.PlatformView
+
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
+internal class PaywallFooterView(
+    context: Context,
+    id: Int,
+    messenger: BinaryMessenger,
+    creationParams: Map<String?, Any?>
+) : PlatformView {
+
+    private val methodChannel: MethodChannel
+
+    private val nativePaywallFooterView: NativePaywallFooterView
+
+    override fun getView(): View {
+        return nativePaywallFooterView
+    }
+
+    override fun dispose() {}
+
+    init {
+        methodChannel = MethodChannel(messenger, "purchases_ui_flutter/PaywallFooterView/${id}")
+        val offeringIdentifier = creationParams["offeringIdentifier"] as String?
+        nativePaywallFooterView = object : NativePaywallFooterView(context) {
+//
+//            var shouldRemeasure = true
+//
+//            override fun requestLayout() {
+//                super.requestLayout()
+//                if (shouldRemeasure) {
+////                    post(measureAndLayout)
+//                }
+//            }
+//
+//            private val measureAndLayout = Runnable {
+//                Log.e("TEST", "MEASURE AND LAYOUT")
+//                measure(
+//                    MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+//                    MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
+//                )
+//                layout(left, top, right, bottom)
+//            }
+//
+//            override fun onDetachedFromWindow() {
+//                super.onDetachedFromWindow()
+//                shouldRemeasure = false
+//            }
+
+            public override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+                super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+                var maxWidth = 0
+                var maxHeight = 0
+                children.forEach {
+                    it.measure(widthMeasureSpec, MeasureSpec.UNSPECIFIED)
+
+                    maxWidth = maxWidth.coerceAtLeast(it.measuredWidth)
+                    maxHeight = maxHeight.coerceAtLeast(it.measuredHeight)
+                }
+                val finalWidth = maxWidth.coerceAtLeast(suggestedMinimumWidth)
+                val finalHeight = maxHeight.coerceAtLeast(suggestedMinimumHeight)
+                setMeasuredDimension(finalWidth, finalHeight)
+                updateHeight(finalHeight.toDouble())
+            }
+        }
+        nativePaywallFooterView.layoutParams = FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT,
+            FrameLayout.LayoutParams.MATCH_PARENT,
+            Gravity.BOTTOM
+        )
+        // TODO add to constructor
+        nativePaywallFooterView.setOfferingId(offeringIdentifier)
+    }
+
+    private fun updateHeight(newHeight: Double) {
+        methodChannel.invokeMethod("onHeightChanged", newHeight)
+    }
+}

--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallFooterView.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallFooterView.kt
@@ -56,7 +56,6 @@ internal class PaywallFooterView(
             FrameLayout.LayoutParams.MATCH_PARENT,
             Gravity.BOTTOM
         )
-        // TODO add to constructor
         nativePaywallFooterView.setOfferingId(offeringIdentifier)
     }
 

--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallFooterViewFactory.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallFooterViewFactory.kt
@@ -1,0 +1,17 @@
+package com.revenuecat.purchases_ui_flutter.views
+
+import android.content.Context
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.StandardMessageCodec
+import io.flutter.plugin.platform.PlatformView
+import io.flutter.plugin.platform.PlatformViewFactory
+
+internal class PaywallFooterViewFactory(
+    private val messenger: BinaryMessenger,
+) : PlatformViewFactory(StandardMessageCodec.INSTANCE) {
+    override fun create(context: Context, viewId: Int, args: Any?): PlatformView {
+        @Suppress("UNCHECKED_CAST")
+        val creationParams = args as? Map<String?, Any?>? ?: emptyMap()
+        return PaywallFooterView(context, viewId, messenger, creationParams)
+    }
+}

--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallView.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallView.kt
@@ -25,7 +25,6 @@ internal class PaywallView(
     init {
         val offeringIdentifier = creationParams["offeringIdentifier"] as String?
         nativePaywallView = NativePaywallView(context,)
-        // TODO add to constructor
         nativePaywallView.setOfferingId(offeringIdentifier)
     }
 }

--- a/purchases_ui_flutter/ios/Classes/PurchasesUiFlutterPlugin.swift
+++ b/purchases_ui_flutter/ios/Classes/PurchasesUiFlutterPlugin.swift
@@ -18,7 +18,9 @@ public class PurchasesUiFlutterPlugin: NSObject, FlutterPlugin {
         #else
         let messenger = registrar.messenger()
         let factory = PurchasesUiPaywallViewFactory(messenger: messenger)
+        let footerFactory = PurchasesUiPaywallFooterViewFactory(messenger: messenger)
         registrar.register(factory, withId: "com.revenuecat.purchasesui/PaywallView")
+        registrar.register(footerFactory, withId: "com.revenuecat.purchasesui/PaywallFooterView")
         #endif
         let channel = FlutterMethodChannel(name: "purchases_ui_flutter", binaryMessenger: messenger)
         let instance = PurchasesUiFlutterPlugin()

--- a/purchases_ui_flutter/ios/Classes/PurchasesUiPaywallFooterView.swift
+++ b/purchases_ui_flutter/ios/Classes/PurchasesUiPaywallFooterView.swift
@@ -1,0 +1,79 @@
+import Flutter
+import UIKit
+import PurchasesHybridCommonUI
+import RevenueCatUI
+
+class PurchasesUiPaywallFooterViewFactory: NSObject, FlutterPlatformViewFactory {
+    private var messenger: FlutterBinaryMessenger
+
+    init(messenger: FlutterBinaryMessenger) {
+        self.messenger = messenger
+        super.init()
+    }
+
+    func create(
+        withFrame frame: CGRect,
+        viewIdentifier viewId: Int64,
+        arguments args: Any?
+    ) -> FlutterPlatformView {
+        return PurchasesUiPaywallFooterView(
+            frame: frame,
+            viewIdentifier: viewId,
+            arguments: args,
+            binaryMessenger: messenger)
+    }
+
+    /// Implementing this method is only necessary when the `arguments` in `createWithFrame` is not `nil`.
+    public func createArgsCodec() -> FlutterMessageCodec & NSObjectProtocol {
+          return FlutterStandardMessageCodec.sharedInstance()
+    }
+}
+
+class PurchasesUiPaywallFooterView: NSObject, FlutterPlatformView, PaywallViewControllerDelegateWrapper {
+    private var _view: UIView
+    private let channel: FlutterMethodChannel?
+
+    init(
+        frame: CGRect,
+        viewIdentifier viewId: Int64,
+        arguments args: Any?,
+        binaryMessenger messenger: FlutterBinaryMessenger
+    ) {
+        if #available(iOS 15.0, *) {
+            channel = FlutterMethodChannel(name: "purchases_ui_flutter/PaywallFooterView/\(viewId)",
+                                           binaryMessenger: messenger)
+            let paywallProxy = PaywallProxy()
+            let paywallFooterViewController = paywallProxy.createFooterPaywallView()
+            if let args = args as? [String: Any?] {
+                if let offeringId = args["offeringIdentifier"] as? String {
+                    paywallFooterViewController.update(with: offeringId)
+                }
+            }
+            guard let paywallFooterView = paywallFooterViewController.view else {
+                print("Error: error getting PaywallFooterView.")
+                _view = UIView()
+                super.init()
+                return
+            }
+            let newHeight = paywallFooterView.bounds.height
+            _view = paywallFooterView
+            channel?.invokeMethod("onHeightChanged", arguments: newHeight)
+        } else {
+            print("Error: attempted to present footer paywalls on unsupported iOS version.")
+            _view = UIView()
+            channel = nil
+        }
+        super.init()
+    }
+
+    func view() -> UIView {
+        return _view
+    }
+
+    @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+    func paywallViewController(_ controller: PaywallViewController, didChangeSizeTo size: CGSize) {
+        let newHeight = _view.bounds.height
+        channel?.invokeMethod("onHeightChanged", arguments: newHeight)
+    }
+
+}

--- a/purchases_ui_flutter/lib/purchases_ui_flutter.dart
+++ b/purchases_ui_flutter/lib/purchases_ui_flutter.dart
@@ -4,7 +4,7 @@ import 'package:purchases_flutter/models/offering_wrapper.dart';
 import 'paywall_result.dart';
 
 export 'paywall_result.dart';
-
+export 'views/paywall_footer_view.dart';
 export 'views/paywall_view.dart';
 
 class RevenueCatUI {

--- a/purchases_ui_flutter/lib/views/internal_paywall_footer_view.dart
+++ b/purchases_ui_flutter/lib/views/internal_paywall_footer_view.dart
@@ -1,0 +1,80 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+import 'package:purchases_flutter/models/offering_wrapper.dart';
+
+class InternalPaywallFooterView extends StatefulWidget {
+  final Offering? offering;
+  final Function(double) onHeightChanged;
+
+  const InternalPaywallFooterView({
+    Key? key,
+    this.offering,
+    required this.onHeightChanged,
+  }) : super(key: key);
+
+  static const String _viewType = 'com.revenuecat.purchasesui/PaywallFooterView';
+
+  @override
+  State<InternalPaywallFooterView> createState() => _InternalPaywallFooterViewState();
+}
+
+class _InternalPaywallFooterViewState extends State<InternalPaywallFooterView> {
+  MethodChannel? _channel;
+
+  @override
+  Widget build(BuildContext context) {
+    final creationParams = <String, dynamic>{
+      'offeringIdentifier': widget.offering?.identifier,
+    };
+
+    return Platform.isAndroid
+        ? _buildAndroidPlatformViewLink(creationParams)
+        : _buildUiKitView(creationParams);
+  }
+
+  UiKitView _buildUiKitView(Map<String, dynamic> creationParams) => UiKitView(
+    viewType: InternalPaywallFooterView._viewType,
+    layoutDirection: TextDirection.ltr,
+    creationParams: creationParams,
+    creationParamsCodec: const StandardMessageCodec(),
+  );
+
+  PlatformViewLink _buildAndroidPlatformViewLink(
+      Map<String, dynamic> creationParams,
+      ) =>
+      PlatformViewLink(
+        viewType: InternalPaywallFooterView._viewType,
+        surfaceFactory: (context, controller) => AndroidViewSurface(
+          controller: controller as AndroidViewController,
+          gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
+          hitTestBehavior: PlatformViewHitTestBehavior.opaque,
+        ),
+        onCreatePlatformView: (params) {
+          _channel = MethodChannel(
+            'purchases_ui_flutter/PaywallFooterView/${params.id}',
+          );
+          _channel?.setMethodCallHandler((call) async {
+            if (call.method == 'onHeightChanged') {
+              widget.onHeightChanged(call.arguments as double);
+            }
+          });
+          return PlatformViewsService.initSurfaceAndroidView(
+            id: params.id,
+            viewType: InternalPaywallFooterView._viewType,
+            layoutDirection: TextDirection.ltr,
+            creationParams: creationParams,
+            creationParamsCodec: const StandardMessageCodec(),
+            onFocus: () {
+              params.onFocusChanged(true);
+            },
+          )
+            ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
+            ..create();
+        },
+      );
+}

--- a/purchases_ui_flutter/lib/views/internal_paywall_footer_view.dart
+++ b/purchases_ui_flutter/lib/views/internal_paywall_footer_view.dart
@@ -42,6 +42,16 @@ class _InternalPaywallFooterViewState extends State<InternalPaywallFooterView> {
     layoutDirection: TextDirection.ltr,
     creationParams: creationParams,
     creationParamsCodec: const StandardMessageCodec(),
+    onPlatformViewCreated: (id) {
+      _channel = MethodChannel(
+        'purchases_ui_flutter/PaywallFooterView/$id',
+      );
+      _channel?.setMethodCallHandler((call) async {
+        if (call.method == 'onHeightChanged') {
+          widget.onHeightChanged(call.arguments as double);
+        }
+      });
+    },
   );
 
   PlatformViewLink _buildAndroidPlatformViewLink(

--- a/purchases_ui_flutter/lib/views/paywall_footer_view.dart
+++ b/purchases_ui_flutter/lib/views/paywall_footer_view.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:purchases_flutter/models/offering_wrapper.dart';
 
@@ -47,7 +49,11 @@ class _PaywallFooterViewState extends State<PaywallFooterView> {
         top: 0,
         left: 0,
         right: 0,
-        bottom: _height - _roundedCornerRadius,
+        // iOS is passing the size without including the top margin with the
+        // rounded corners, so we need to adjust the bottom position.
+        bottom: Platform.isAndroid
+            ? _height - _roundedCornerRadius
+            : _height,
         child: widget.contentCreator(_roundedCornerRadius),
       ),
       Positioned(

--- a/purchases_ui_flutter/lib/views/paywall_footer_view.dart
+++ b/purchases_ui_flutter/lib/views/paywall_footer_view.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:purchases_flutter/models/offering_wrapper.dart';
+
+import 'internal_paywall_footer_view.dart';
+
+/// View that displays the paywall in footer mode.
+/// Not supported in macOS currently.
+///
+/// [offering] (Optional) The offering object to be displayed in the paywall.
+/// Obtained from [Purchases.getOfferings].
+///
+/// [content] The content to be displayed above the paywall. Make sure you
+/// apply a padding to the bottom of your content to avoid overlap. This padding
+/// can be obtained from [PaywallFooterView.roundedCornerRadius].
+class PaywallFooterView extends StatefulWidget {
+  /// The top corner radius of the footer view.
+  static const roundedCornerRadius = 20.0;
+
+  final Offering? offering;
+  final Widget content;
+
+  const PaywallFooterView({
+    Key? key,
+    this.offering,
+    required this.content,
+  }) : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() => _PaywallFooterViewState();
+}
+
+class _PaywallFooterViewState extends State<PaywallFooterView> {
+
+  var _height = 264.0; // Need to set it to a value > 0 so it's drawn
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) => Stack(
+    children: [
+      Positioned(
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: _height - PaywallFooterView.roundedCornerRadius,
+        child: Padding(
+          padding: EdgeInsets.only(bottom: 0),
+          child: widget.content,
+        ),
+      ),
+      Positioned(
+        bottom: 0,
+        left: 0,
+        right: 0,
+        child: SizedBox(
+          width: double.infinity,
+          height: _height,
+          child: InternalPaywallFooterView(
+            offering: widget.offering,
+            onHeightChanged: _updateHeight,
+          ),
+        ),
+      ),
+    ],
+  );
+
+  void _updateHeight(double newHeight) {
+    final pixelRatio = MediaQuery.of(context).devicePixelRatio;
+    final finalNewHeight = newHeight / pixelRatio;
+
+    if (_height != finalNewHeight) {
+      setState(() {
+        _height = finalNewHeight;
+      });
+    }
+  }
+}

--- a/purchases_ui_flutter/lib/views/paywall_footer_view.dart
+++ b/purchases_ui_flutter/lib/views/paywall_footer_view.dart
@@ -31,7 +31,10 @@ class PaywallFooterView extends StatefulWidget {
 
 class _PaywallFooterViewState extends State<PaywallFooterView> {
 
-  var _height = 264.0; // Need to set it to a value > 0 so it's drawn
+  // Need to set it to a value > 0 so it's drawn. Setting it to a value that
+  // approximately reflects what the footer view height will be, so redrawing
+  // is not so noticeable. Need to improve this.
+  var _height = 264.0;
 
   @override
   void initState() {
@@ -46,10 +49,7 @@ class _PaywallFooterViewState extends State<PaywallFooterView> {
         left: 0,
         right: 0,
         bottom: _height - PaywallFooterView.roundedCornerRadius,
-        child: Padding(
-          padding: EdgeInsets.only(bottom: 0),
-          child: widget.content,
-        ),
+        child: widget.content,
       ),
       Positioned(
         bottom: 0,

--- a/purchases_ui_flutter/lib/views/paywall_footer_view.dart
+++ b/purchases_ui_flutter/lib/views/paywall_footer_view.dart
@@ -9,20 +9,18 @@ import 'internal_paywall_footer_view.dart';
 /// [offering] (Optional) The offering object to be displayed in the paywall.
 /// Obtained from [Purchases.getOfferings].
 ///
-/// [content] The content to be displayed above the paywall. Make sure you
-/// apply a padding to the bottom of your content to avoid overlap. This padding
-/// can be obtained from [PaywallFooterView.roundedCornerRadius].
+/// [contentCreator] A function that creates the content to be displayed above
+/// the paywall. Make sure you apply the given padding to the bottom of your
+/// content to avoid overlap.
 class PaywallFooterView extends StatefulWidget {
-  /// The top corner radius of the footer view.
-  static const roundedCornerRadius = 20.0;
 
   final Offering? offering;
-  final Widget content;
+  final Widget Function(double bottomPadding) contentCreator;
 
   const PaywallFooterView({
     Key? key,
     this.offering,
-    required this.content,
+    required this.contentCreator,
   }) : super(key: key);
 
   @override
@@ -30,6 +28,7 @@ class PaywallFooterView extends StatefulWidget {
 }
 
 class _PaywallFooterViewState extends State<PaywallFooterView> {
+  static const _roundedCornerRadius = 20.0;
 
   // Need to set it to a value > 0 so it's drawn. Setting it to a value that
   // approximately reflects what the footer view height will be, so redrawing
@@ -48,8 +47,8 @@ class _PaywallFooterViewState extends State<PaywallFooterView> {
         top: 0,
         left: 0,
         right: 0,
-        bottom: _height - PaywallFooterView.roundedCornerRadius,
-        child: widget.content,
+        bottom: _height - _roundedCornerRadius,
+        child: widget.contentCreator(_roundedCornerRadius),
       ),
       Positioned(
         bottom: 0,

--- a/revenuecat_examples/purchase_tester/lib/src/paywall_footer_screen.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/paywall_footer_screen.dart
@@ -1,0 +1,44 @@
+import 'package:purchases_ui_flutter/purchases_ui_flutter.dart';
+import 'package:purchases_flutter/purchases_flutter.dart';
+import 'package:flutter/material.dart';
+
+class PaywallFooterScreen extends StatefulWidget {
+  final Offering? offering;
+
+  const PaywallFooterScreen({Key? key, this.offering}) : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() => _PaywallFooterScreenState();
+}
+
+class _PaywallFooterScreenState extends State<PaywallFooterScreen> {
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea( // Wrap your body content with SafeArea
+        child: Center(
+          child: PaywallFooterView(
+            offering: widget.offering,
+            content: Container(
+              color: Colors.blue.withAlpha(80),
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.only(bottom: PaywallFooterView.roundedCornerRadius),
+                child: Column(
+                  children: [
+                    for (var i in Iterable<int>.generate(50).toList()) Text('Testing footer view $i')
+                  ],
+                )
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/revenuecat_examples/purchase_tester/lib/src/paywall_footer_screen.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/paywall_footer_screen.dart
@@ -25,10 +25,10 @@ class _PaywallFooterScreenState extends State<PaywallFooterScreen> {
         child: Center(
           child: PaywallFooterView(
             offering: widget.offering,
-            content: Container(
+            contentCreator: (bottomPadding) => Container(
               color: Colors.blue.withAlpha(80),
               child: SingleChildScrollView(
-                padding: const EdgeInsets.only(bottom: PaywallFooterView.roundedCornerRadius),
+                padding: EdgeInsets.only(bottom: bottomPadding),
                 child: Column(
                   children: [
                     for (var i in Iterable<int>.generate(50).toList()) Text('Testing footer view $i')

--- a/revenuecat_examples/purchase_tester/lib/src/upsell.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/upsell.dart
@@ -4,6 +4,7 @@ import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:purchases_flutter/purchases_flutter.dart';
+import 'package:purchases_flutter_example/src/paywall_footer_screen.dart';
 import 'package:purchases_ui_flutter/purchases_ui_flutter.dart';
 
 import 'constant.dart';
@@ -116,6 +117,18 @@ class _UpsellScreenState extends State<UpsellScreen> {
                       );
                     },
                     child: const Text('Show paywall view'),
+                  ),
+                  ElevatedButton(
+                    onPressed: () async {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                            builder: (context) => PaywallFooterScreen(
+                              offering: offering,
+                            )),
+                      );
+                    },
+                    child: const Text('Show paywall footer view'),
                   )
                 ]))),
       ),


### PR DESCRIPTION
This adds initial support for the `PaywallFooterView`. Includes iOS support from #999 

https://github.com/RevenueCat/purchases-flutter/assets/808417/427341bc-d93e-4f87-bf9c-2207d2cff2dd



![image](https://github.com/RevenueCat/purchases-flutter/assets/808417/9feeddab-6cd7-4240-bdac-43ae5c8167e4)


- [x] Holding until iOS is ready #999 