### PR TITLE
Add dependency_overrides to purchases_flutter_ui

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,7 +25,7 @@ files_with_version_number = {
     './ios/Classes/PurchasesFlutterPlugin.m' => ['return @"{x}"'],
     './android/build.gradle' => ['version \'{x}\''],
     './android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java' => ['PLUGIN_VERSION = "{x}"'],
-    './purchases_ui_flutter/pubspec.yaml' => ['version: {x}', 'purchases_flutter: ^{x}'],
+    './purchases_ui_flutter/pubspec.yaml' => ['version: {x}', 'purchases_flutter: {x}'],
     './purchases_ui_flutter/ios/purchases_ui_flutter.podspec' => ['s.version          = \'{x}\''],
     './purchases_ui_flutter/macos/purchases_ui_flutter.podspec' => ['s.version          = \'{x}\''],
     './purchases_ui_flutter/android/build.gradle' => ['version \'{x}\''],

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,7 +25,7 @@ files_with_version_number = {
     './ios/Classes/PurchasesFlutterPlugin.m' => ['return @"{x}"'],
     './android/build.gradle' => ['version \'{x}\''],
     './android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java' => ['PLUGIN_VERSION = "{x}"'],
-    './purchases_ui_flutter/pubspec.yaml' => ['version: {x}'],
+    './purchases_ui_flutter/pubspec.yaml' => ['version: {x}', 'purchases_flutter: ^{x}'],
     './purchases_ui_flutter/ios/purchases_ui_flutter.podspec' => ['s.version          = \'{x}\''],
     './purchases_ui_flutter/macos/purchases_ui_flutter.podspec' => ['s.version          = \'{x}\''],
     './purchases_ui_flutter/android/build.gradle' => ['version \'{x}\''],

--- a/purchases_ui_flutter/pubspec.yaml
+++ b/purchases_ui_flutter/pubspec.yaml
@@ -11,13 +11,14 @@ environment:
   flutter: '>=3.3.0'
 
 dependencies:
-  # We can't depend on exactly the same version
-  # because it won't be available when bumping the version
-  # until it's released.
-  purchases_flutter: ^6.0.0
+  purchases_flutter: ^6.22.0
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.0.2
+
+dependency_overrides:
+  purchases_flutter:
+    path: ../
 
 dev_dependencies:
   flutter_test:

--- a/purchases_ui_flutter/pubspec.yaml
+++ b/purchases_ui_flutter/pubspec.yaml
@@ -16,6 +16,9 @@ dependencies:
     sdk: flutter
   plugin_platform_interface: ^2.0.2
 
+# It's safe to publish like this. According to the docs (https://dart.dev/tools/pub/dependencies):
+# As a result, if you publish a package to pub.dev, keep in mind that your package's dependency
+# overrides are ignored by all users of your package."
 dependency_overrides:
   purchases_flutter:
     path: ../

--- a/purchases_ui_flutter/pubspec.yaml
+++ b/purchases_ui_flutter/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
   flutter: '>=3.3.0'
 
 dependencies:
-  purchases_flutter: ^6.22.0
+  purchases_flutter: 6.22.0
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.0.2


### PR DESCRIPTION
I wasn't sure what was going on in #995 but there was some issues importing a newly added model. The problem is that we were depending on version ^6.0.0 of purchases_flutter. 

I made some changes to the pubspec.yaml, so now we use the local plugin. 

According to [the docs](https://dart.dev/tools/pub/dependencies), "As a result, if you publish a package to pub.dev, keep in mind that your package's dependency overrides are ignored by all users of your package.". So we should be fine to publish it like this.