### PR TITLE
Add `onDismiss` handler and `displayCloseButton` to `PaywallView` and `PaywallFooterView`

### DIFF
--- a/api_tester/lib/api_tests/purchases_ui_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_ui_flutter_api_test.dart
@@ -55,10 +55,15 @@ class _PurchasesFlutterApiTest {
     );
   }
 
-  Widget _checkPaywallViewWithListeners(Offering offering) {
+  Widget _checkPaywallViewWithListeners(
+      Offering offering,
+      bool displayCloseButton,
+  ) {
     return Scaffold(
       body: Center(
         child: PaywallView(
+          offering: offering,
+          displayCloseButton: displayCloseButton,
           onPurchaseStarted: (Package rcPackage) {
           },
           onPurchaseCompleted:
@@ -69,6 +74,8 @@ class _PurchasesFlutterApiTest {
           onRestoreCompleted: (CustomerInfo customerInfo) {
           },
           onRestoreError: (PurchasesError error) {
+          },
+          onDismiss: () {
           },
         ),
       ),
@@ -114,6 +121,8 @@ class _PurchasesFlutterApiTest {
           onRestoreCompleted: (CustomerInfo customerInfo) {
           },
           onRestoreError: (PurchasesError error) {
+          },
+          onDismiss: () {
           },
           contentCreator: (double bottomPadding) {
             return Container();

--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallFooterView.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallFooterView.kt
@@ -37,7 +37,8 @@ internal class PaywallFooterView(
         val offeringIdentifier = creationParams["offeringIdentifier"] as String?
         nativePaywallFooterView = object : NativePaywallFooterView(
             context,
-            dismissHandler = { methodChannel.invokeMethod("onDismiss", null) }) {
+            dismissHandler = { methodChannel.invokeMethod("onDismiss", null) }
+        ) {
             public override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
                 super.onMeasure(widthMeasureSpec, heightMeasureSpec)
                 var maxWidth = 0

--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallFooterView.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallFooterView.kt
@@ -35,7 +35,9 @@ internal class PaywallFooterView(
     init {
         methodChannel = MethodChannel(messenger, "com.revenuecat.purchasesui/PaywallFooterView/${id}")
         val offeringIdentifier = creationParams["offeringIdentifier"] as String?
-        nativePaywallFooterView = object : NativePaywallFooterView(context) {
+        nativePaywallFooterView = object : NativePaywallFooterView(
+            context,
+            dismissHandler = { methodChannel.invokeMethod("onDismiss", null) }) {
             public override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
                 super.onMeasure(widthMeasureSpec, heightMeasureSpec)
                 var maxWidth = 0

--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallView.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallView.kt
@@ -32,7 +32,12 @@ internal class PaywallView(
         methodChannel = MethodChannel(messenger, "com.revenuecat.purchasesui/PaywallView/$id")
         methodChannel.setMethodCallHandler(this)
         val offeringIdentifier = creationParams["offeringIdentifier"] as String?
-        nativePaywallView = NativePaywallView(context,)
+        val displayCloseButton = creationParams["displayCloseButton"] as Boolean?
+        nativePaywallView = NativePaywallView(
+            context = context,
+            shouldDisplayDismissButton = displayCloseButton,
+            dismissHandler = { methodChannel.invokeMethod("onDismiss", null) }
+        )
         nativePaywallView.setPaywallListener(object : PaywallListenerWrapper() {
             override fun onPurchaseStarted(rcPackage: Map<String, Any?>) {
                 methodChannel.invokeMethod("onPurchaseStarted", rcPackage)

--- a/purchases_ui_flutter/ios/Classes/PurchasesUiPaywallFooterView.swift
+++ b/purchases_ui_flutter/ios/Classes/PurchasesUiPaywallFooterView.swift
@@ -112,4 +112,8 @@ extension PurchasesUiPaywallFooterView: PaywallViewControllerDelegateWrapper {
                                didFailRestoringWith errorDictionary: [String : Any]) {
         channel.invokeMethod("onRestoreError", arguments: errorDictionary)
     }
+
+    func paywallViewControllerRequestedDismissal(_ controller: PaywallViewController) {
+        channel.invokeMethod("onDismiss", arguments: nil)
+    }
 }

--- a/purchases_ui_flutter/ios/Classes/PurchasesUiPaywallView.swift
+++ b/purchases_ui_flutter/ios/Classes/PurchasesUiPaywallView.swift
@@ -57,6 +57,10 @@ class PurchasesUiPaywallView: NSObject, FlutterPlatformView {
             if let offeringId = args["offeringIdentifier"] as? String {
                 _paywallViewController.update(with: offeringId)
             }
+            if let displayCloseButton = args["displayCloseButton"] as? Bool {
+                // TODO: Set displayCloseButton
+                // TODO: set onDismiss callback
+            }
         }
         guard let paywallView = _paywallViewController.view else {
             print("Error: error getting PaywallView.")

--- a/purchases_ui_flutter/ios/Classes/PurchasesUiPaywallView.swift
+++ b/purchases_ui_flutter/ios/Classes/PurchasesUiPaywallView.swift
@@ -58,8 +58,7 @@ class PurchasesUiPaywallView: NSObject, FlutterPlatformView {
                 _paywallViewController.update(with: offeringId)
             }
             if let displayCloseButton = args["displayCloseButton"] as? Bool {
-                // TODO: Set displayCloseButton
-                // TODO: set onDismiss callback
+                _paywallViewController.update(with: displayCloseButton)
             }
         }
         guard let paywallView = _paywallViewController.view else {
@@ -121,5 +120,9 @@ extension PurchasesUiPaywallView: PaywallViewControllerDelegateWrapper {
     func paywallViewController(_ controller: PaywallViewController,
                                didFailRestoringWith errorDictionary: [String : Any]) {
         _methodChannel.invokeMethod("onRestoreError", arguments: errorDictionary)
+    }
+
+    func paywallViewControllerRequestedDismissal(_ controller: PaywallViewController) {
+        _methodChannel.invokeMethod("onDismiss", arguments: nil)
     }
 }

--- a/purchases_ui_flutter/lib/views/internal_paywall_footer_view.dart
+++ b/purchases_ui_flutter/lib/views/internal_paywall_footer_view.dart
@@ -21,6 +21,7 @@ class InternalPaywallFooterView extends StatelessWidget {
   final Function(PurchasesError)? onPurchaseError;
   final Function(CustomerInfo customerInfo)? onRestoreCompleted;
   final Function(PurchasesError)? onRestoreError;
+  final Function()? onDismiss;
   final Function(double) onHeightChanged;
 
   const InternalPaywallFooterView({
@@ -31,6 +32,7 @@ class InternalPaywallFooterView extends StatelessWidget {
     this.onPurchaseError,
     this.onRestoreCompleted,
     this.onRestoreError,
+    this.onDismiss,
     required this.onHeightChanged,
   }) : super(key: key);
 
@@ -87,6 +89,7 @@ class InternalPaywallFooterView extends StatelessWidget {
       onPurchaseError,
       onRestoreCompleted,
       onRestoreError,
+      onDismiss,
     );
     MethodChannel('com.revenuecat.purchasesui/PaywallFooterView/$id')
         .setMethodCallHandler((call) async {

--- a/purchases_ui_flutter/lib/views/paywall_footer_view.dart
+++ b/purchases_ui_flutter/lib/views/paywall_footer_view.dart
@@ -43,6 +43,7 @@ class PaywallFooterView extends StatefulWidget {
   final Function(PurchasesError)? onPurchaseError;
   final Function(CustomerInfo customerInfo)? onRestoreCompleted;
   final Function(PurchasesError)? onRestoreError;
+  final Function()? onDismiss;
   final Widget Function(double bottomPadding) contentCreator;
 
   const PaywallFooterView({
@@ -53,6 +54,7 @@ class PaywallFooterView extends StatefulWidget {
     this.onPurchaseError,
     this.onRestoreCompleted,
     this.onRestoreError,
+    this.onDismiss,
     required this.contentCreator,
   }) : super(key: key);
 
@@ -97,6 +99,7 @@ class _PaywallFooterViewState extends State<PaywallFooterView> {
             onPurchaseError: widget.onPurchaseError,
             onRestoreCompleted: widget.onRestoreCompleted,
             onRestoreError: widget.onRestoreError,
+            onDismiss: widget.onDismiss,
             onHeightChanged: _updateHeight,
           ),
         ),

--- a/purchases_ui_flutter/lib/views/paywall_footer_view.dart
+++ b/purchases_ui_flutter/lib/views/paywall_footer_view.dart
@@ -31,6 +31,9 @@ import 'internal_paywall_footer_view.dart';
 /// [onRestoreError] (Optional) Callback that gets called when a restore
 /// fails.
 ///
+/// [onDismiss] (Optional) Callback that gets called when the paywall wants to
+/// dismiss. Currently, after a purchase is completed.
+///
 /// [contentCreator] A function that creates the content to be displayed above
 /// the paywall. Make sure you apply the given padding to the bottom of your
 /// content to avoid overlap.

--- a/purchases_ui_flutter/lib/views/paywall_view.dart
+++ b/purchases_ui_flutter/lib/views/paywall_view.dart
@@ -1,4 +1,3 @@
-import 'dart:ffi';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';

--- a/purchases_ui_flutter/lib/views/paywall_view.dart
+++ b/purchases_ui_flutter/lib/views/paywall_view.dart
@@ -1,3 +1,4 @@
+import 'dart:ffi';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
@@ -19,6 +20,9 @@ import 'paywall_view_method_handler.dart';
 /// [offering] (Optional) The offering object to be displayed in the paywall.
 /// Obtained from [Purchases.getOfferings].
 ///
+/// [displayCloseButton] (Optional) Whether to display a close button in the
+/// paywall. Defaults to false.
+///
 /// [onPurchaseStarted] (Optional) Callback that gets called when a purchase
 /// is started.
 ///
@@ -34,23 +38,31 @@ import 'paywall_view_method_handler.dart';
 ///
 /// [onRestoreError] (Optional) Callback that gets called when a restore
 /// fails.
+///
+/// [onDismiss] (Optional) Callback that gets called when the paywall wants to
+/// dismiss. Currently, after a purchase is completed or when the close button
+/// is tapped.
 class PaywallView extends StatelessWidget {
   final Offering? offering;
+  final bool? displayCloseButton;
   final Function(Package rcPackage)? onPurchaseStarted;
   final Function(CustomerInfo customerInfo, StoreTransaction storeTransaction)?
       onPurchaseCompleted;
   final Function(PurchasesError)? onPurchaseError;
   final Function(CustomerInfo customerInfo)? onRestoreCompleted;
   final Function(PurchasesError)? onRestoreError;
+  final Function()? onDismiss;
 
   const PaywallView({
     Key? key,
     this.offering,
+    this.displayCloseButton,
     this.onPurchaseStarted,
     this.onPurchaseCompleted,
     this.onPurchaseError,
     this.onRestoreCompleted,
     this.onRestoreError,
+    this.onDismiss,
   }) : super(key: key);
 
   static const String _viewType = 'com.revenuecat.purchasesui/PaywallView';
@@ -59,6 +71,7 @@ class PaywallView extends StatelessWidget {
   Widget build(BuildContext context) {
     final creationParams = <String, dynamic>{
       'offeringIdentifier': offering?.identifier,
+      'displayCloseButton': displayCloseButton,
     };
 
     return Platform.isAndroid
@@ -111,6 +124,7 @@ class PaywallView extends StatelessWidget {
       onPurchaseError,
       onRestoreCompleted,
       onRestoreError,
+      onDismiss,
     );
     MethodChannel('com.revenuecat.purchasesui/PaywallView/$id')
           .setMethodCallHandler(handler.handleMethodCall);

--- a/purchases_ui_flutter/lib/views/paywall_view_method_handler.dart
+++ b/purchases_ui_flutter/lib/views/paywall_view_method_handler.dart
@@ -12,6 +12,7 @@ class PaywallViewMethodHandler {
   final Function(PurchasesError)? onPurchaseError;
   final Function(CustomerInfo customerInfo)? onRestoreCompleted;
   final Function(PurchasesError)? onRestoreError;
+  final Function()? onDismiss;
 
   const PaywallViewMethodHandler(
       this.onPurchaseStarted,
@@ -19,6 +20,7 @@ class PaywallViewMethodHandler {
       this.onPurchaseError,
       this.onRestoreCompleted,
       this.onRestoreError,
+      this.onDismiss,
   );
 
   Future<void> handleMethodCall(MethodCall call) async {
@@ -37,6 +39,9 @@ class PaywallViewMethodHandler {
         break;
       case 'onRestoreError':
         _handleOnRestoreError(call);
+        break;
+      case 'onDismiss':
+        onDismiss?.call();
         break;
       default:
         break;

--- a/revenuecat_examples/purchase_tester/lib/src/paywall.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/paywall.dart
@@ -24,6 +24,7 @@ class _PaywallScreenState extends State<PaywallScreen> {
         child: Center(
           child: PaywallView(
             offering: widget.offering,
+            displayCloseButton: true,
             onPurchaseStarted: (Package rcPackage) {
               print('Purchase started for package: ${rcPackage.identifier}');
             },
@@ -40,6 +41,10 @@ class _PaywallScreenState extends State<PaywallScreen> {
             },
             onRestoreError: (PurchasesError error) {
               print('Restore error: $error');
+            },
+            onDismiss: () {
+              print('Paywall asked to dismiss');
+              Navigator.pop(context);
             },
           ),
         ),

--- a/revenuecat_examples/purchase_tester/lib/src/paywall_footer_screen.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/paywall_footer_screen.dart
@@ -42,6 +42,10 @@ class _PaywallFooterScreenState extends State<PaywallFooterScreen> {
             onRestoreError: (PurchasesError error) {
               print('Restore error: $error');
             },
+            onDismiss: () {
+              print('Paywall asked to dismiss');
+              Navigator.pop(context);
+            },
             contentCreator: (bottomPadding) => Container(
               color: Colors.blue.withAlpha(80),
               child: SingleChildScrollView(


### PR DESCRIPTION
This PR adds support for the `onDismiss` callback to `PaywallView` and `PaywallFooterView`. Additionally, it also adds the `displayCloseButton` parameter to `PaywallView` to test it more easily.