### PR TITLE
 Adds`Purchases.getCurrentOfferingForPlacement(placementID)` and `Purchases.syncAttributesAndOfferingsIfNeeded()`

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -457,12 +457,12 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
     }
 
     private void purchaseProduct(final String productIdentifier,
-            final String type,
-            final String googleOldProductId,
-            @Nullable final Integer googleProrationMode,
-            @Nullable final Boolean googleIsPersonalizedPrice,
-            @Nullable final Map<String, Object> presentedOfferingContext,
-            final Result result) {
+                                 final String type,
+                                 final String googleOldProductId,
+                                 @Nullable final Integer googleProrationMode,
+                                 @Nullable final Boolean googleIsPersonalizedPrice,
+                                 @Nullable final Map<String, Object> presentedOfferingContext,
+                                 final Result result) {
         CommonKt.purchaseProduct(
                 getActivity(),
                 productIdentifier,

--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -17,6 +17,7 @@ import com.revenuecat.purchases.Store;
 import com.revenuecat.purchases.common.PlatformInfo;
 import com.revenuecat.purchases.hybridcommon.CommonKt;
 import com.revenuecat.purchases.hybridcommon.ErrorContainer;
+import com.revenuecat.purchases.hybridcommon.OnNullableResult;
 import com.revenuecat.purchases.hybridcommon.OnResult;
 import com.revenuecat.purchases.hybridcommon.OnResultAny;
 import com.revenuecat.purchases.hybridcommon.OnResultList;
@@ -54,10 +55,14 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
     // Only set registrar for v1 embedder.
     @SuppressWarnings("deprecation")
     private io.flutter.plugin.common.PluginRegistry.Registrar registrar;
-    // Only set activity for v2 embedder. Always access activity from getActivity() method.
-    @Nullable private Context applicationContext;
-    @Nullable private MethodChannel channel;
-    @Nullable private Activity activity;
+    // Only set activity for v2 embedder. Always access activity from getActivity()
+    // method.
+    @Nullable
+    private Context applicationContext;
+    @Nullable
+    private MethodChannel channel;
+    @Nullable
+    private Activity activity;
 
     private final Handler handler = new Handler(Looper.getMainLooper());
 
@@ -137,9 +142,9 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 String appUserId = call.argument("appUserId");
                 Boolean observerMode = call.argument("observerMode");
                 Boolean useAmazon = call.argument("useAmazon");
-                //noinspection unused
+                // noinspection unused
                 String userDefaultsSuiteName = call.argument("userDefaultsSuiteName"); // iOS-only, unused.
-                //noinspection unused
+                // noinspection unused
                 Boolean usesStoreKit2IfAvailable = call.argument("usesStoreKit2IfAvailable"); // iOS-only, unused.
                 Boolean shouldShowInAppMessagesAutomatically = call.argument("shouldShowInAppMessagesAutomatically");
                 String verificationMode = call.argument("entitlementVerificationMode");
@@ -157,6 +162,13 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
             case "getOfferings":
                 getOfferings(result);
                 break;
+            case "getCurrentOfferingForPlacement":
+                String placementIdentifier = call.argument("placementIdentifier");
+                getCurrentOfferingForPlacement(placementIdentifier, result);
+                break;
+            case "syncAttributesAndOfferingsIfNeeded":
+                syncAttributesAndOfferingsIfNeeded(result);
+                break;
             case "getProductInfo":
                 ArrayList<String> productIdentifiers = call.argument("productIdentifiers");
                 String type = call.argument("type");
@@ -169,7 +181,8 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 Boolean googleIsPersonalizedPrice = call.argument("googleIsPersonalizedPrice");
                 type = call.argument("type");
                 Map<String, Object> presentedOfferingContext = call.argument("presentedOfferingContext");
-                purchaseProduct(productIdentifier, type, googleOldProductIdentifer, googleProrationMode, googleIsPersonalizedPrice, presentedOfferingContext, result);
+                purchaseProduct(productIdentifier, type, googleOldProductIdentifer, googleProrationMode,
+                        googleIsPersonalizedPrice, presentedOfferingContext, result);
                 break;
             case "purchasePackage":
                 String packageIdentifier = call.argument("packageIdentifier");
@@ -177,7 +190,8 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 googleOldProductIdentifer = call.argument("googleOldProductIdentifier");
                 googleProrationMode = call.argument("googleProrationMode");
                 googleIsPersonalizedPrice = call.argument("googleIsPersonalizedPrice");
-                purchasePackage(packageIdentifier, presentedOfferingContext, googleOldProductIdentifer, googleProrationMode, googleIsPersonalizedPrice, result);
+                purchasePackage(packageIdentifier, presentedOfferingContext, googleOldProductIdentifer,
+                        googleProrationMode, googleIsPersonalizedPrice, result);
                 break;
             case "purchaseSubscriptionOption":
                 productIdentifier = call.argument("productIdentifier");
@@ -186,7 +200,8 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 googleProrationMode = call.argument("googleProrationMode");
                 googleIsPersonalizedPrice = call.argument("googleIsPersonalizedPrice");
                 presentedOfferingContext = call.argument("presentedOfferingContext");
-                purchaseSubscriptionOption(productIdentifier, optionIdentifier, googleOldProductIdentifer, googleProrationMode, googleIsPersonalizedPrice, presentedOfferingContext, result);
+                purchaseSubscriptionOption(productIdentifier, optionIdentifier, googleOldProductIdentifer,
+                        googleProrationMode, googleIsPersonalizedPrice, presentedOfferingContext, result);
                 break;
             case "getAppUserID":
                 getAppUserID(result);
@@ -362,8 +377,8 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
     }
 
     private void setupPurchases(String apiKey, String appUserID, @Nullable Boolean observerMode,
-                                @Nullable Boolean useAmazon, @Nullable Boolean shouldShowInAppMessagesAutomatically,
-                                @Nullable String verificationMode, final Result result) {
+            @Nullable Boolean useAmazon, @Nullable Boolean shouldShowInAppMessagesAutomatically,
+            @Nullable String verificationMode, final Result result) {
         if (this.applicationContext != null) {
             PlatformInfo platformInfo = new PlatformInfo(PLATFORM_NAME, PLUGIN_VERSION);
             Store store = Store.PLAY_STORE;
@@ -419,6 +434,14 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
         CommonKt.getOfferings(getOnResult(result));
     }
 
+    private void getCurrentOfferingForPlacement(String placementIdentifier, final Result result) {
+        CommonKt.getCurrentOfferingForPlacement(placementIdentifier, getOnNullableResult(result));
+    }
+
+    private void syncAttributesAndOfferingsIfNeeded(final Result result) {
+        CommonKt.syncAttributesAndOfferingsIfNeeded(getOnResult(result));
+    }
+
     private void getProductInfo(ArrayList<String> productIDs, String type, final Result result) {
         CommonKt.getProductInfo(productIDs, type, new OnResultList() {
             @Override
@@ -434,12 +457,12 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
     }
 
     private void purchaseProduct(final String productIdentifier,
-                                 final String type,
-                                 final String googleOldProductId,
-                                 @Nullable final Integer googleProrationMode,
-                                 @Nullable final Boolean googleIsPersonalizedPrice,
-                                 @Nullable final Map<String, Object> presentedOfferingContext,
-                                 final Result result) {
+            final String type,
+            final String googleOldProductId,
+            @Nullable final Integer googleProrationMode,
+            @Nullable final Boolean googleIsPersonalizedPrice,
+            @Nullable final Map<String, Object> presentedOfferingContext,
+            final Result result) {
         CommonKt.purchaseProduct(
                 getActivity(),
                 productIdentifier,
@@ -449,16 +472,15 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 googleProrationMode,
                 googleIsPersonalizedPrice,
                 presentedOfferingContext,
-                getOnResult(result)
-        );
+                getOnResult(result));
     }
 
     private void purchasePackage(final String packageIdentifier,
-                                 final Map<String, Object> presentedOfferingContext,
-                                 final String googleOldProductId,
-                                 @Nullable final Integer googleProrationMode,
-                                 @Nullable final Boolean googleIsPersonalizedPrice,
-                                 final Result result) {
+            final Map<String, Object> presentedOfferingContext,
+            final String googleOldProductId,
+            @Nullable final Integer googleProrationMode,
+            @Nullable final Boolean googleIsPersonalizedPrice,
+            final Result result) {
         CommonKt.purchasePackage(
                 getActivity(),
                 packageIdentifier,
@@ -466,17 +488,16 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 googleOldProductId,
                 googleProrationMode,
                 googleIsPersonalizedPrice,
-                getOnResult(result)
-        );
+                getOnResult(result));
     }
 
     private void purchaseSubscriptionOption(final String productIdentifier,
-                                            final String optionIdentifier,
-                                            final String googleOldProductId,
-                                            @Nullable final Integer googleProrationMode,
-                                            @Nullable final Boolean googleIsPersonalizedPrice,
-                                            @Nullable final Map<String, Object> presentedOfferingContext,
-                                            final Result result) {
+            final String optionIdentifier,
+            final String googleOldProductId,
+            @Nullable final Integer googleProrationMode,
+            @Nullable final Boolean googleIsPersonalizedPrice,
+            @Nullable final Map<String, Object> presentedOfferingContext,
+            final Result result) {
         CommonKt.purchaseSubscriptionOption(
                 getActivity(),
                 productIdentifier,
@@ -485,8 +506,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 googleProrationMode,
                 googleIsPersonalizedPrice,
                 presentedOfferingContext,
-                getOnResult(result)
-        );
+                getOnResult(result));
     }
 
     private void getAppUserID(final Result result) {
@@ -512,11 +532,11 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
     }
 
     private void syncObserverModeAmazonPurchase(String productID,
-                                                String receiptID,
-                                                String amazonUserID,
-                                                String isoCurrencyCode,
-                                                Double price,
-                                                final Result result) {
+            String receiptID,
+            String amazonUserID,
+            String isoCurrencyCode,
+            Double price,
+            final Result result) {
         Purchases.getSharedInstance().syncObserverModeAmazonPurchase(productID, receiptID,
                 amazonUserID, isoCurrencyCode, price);
         result.success(null);
@@ -558,9 +578,9 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
         result.success(null);
     }
 
-    //================================================================================
+    // ================================================================================
     // Subscriber Attributes
-    //================================================================================
+    // ================================================================================
 
     private void setAttributes(Map<String, String> map, final Result result) {
         SubscriberAttributesKt.setAttributes(map);
@@ -732,6 +752,21 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
         return new OnResult() {
             @Override
             public void onReceived(Map<String, ?> map) {
+                result.success(map);
+            }
+
+            @Override
+            public void onError(ErrorContainer errorContainer) {
+                reject(errorContainer, result);
+            }
+        };
+    }
+
+    @NotNull
+    private OnNullableResult getOnNullableResult(final Result result) {
+        return new OnNullableResult() {
+            @Override
+            public void onReceived(@Nullable Map<String, ?> map) {
                 result.success(map);
             }
 

--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -168,16 +168,16 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 Integer googleProrationMode = call.argument("googleProrationMode");
                 Boolean googleIsPersonalizedPrice = call.argument("googleIsPersonalizedPrice");
                 type = call.argument("type");
-                String presentedOfferingIdentifier = call.argument("presentedOfferingIdentifier");
-                purchaseProduct(productIdentifier, type, googleOldProductIdentifer, googleProrationMode, googleIsPersonalizedPrice, presentedOfferingIdentifier, result);
+                Map<String, Object> presentedOfferingContext = call.argument("presentedOfferingContext");
+                purchaseProduct(productIdentifier, type, googleOldProductIdentifer, googleProrationMode, googleIsPersonalizedPrice, presentedOfferingContext, result);
                 break;
             case "purchasePackage":
                 String packageIdentifier = call.argument("packageIdentifier");
-                String offeringIdentifier = call.argument("offeringIdentifier");
+                presentedOfferingContext = call.argument("presentedOfferingContext");
                 googleOldProductIdentifer = call.argument("googleOldProductIdentifier");
                 googleProrationMode = call.argument("googleProrationMode");
                 googleIsPersonalizedPrice = call.argument("googleIsPersonalizedPrice");
-                purchasePackage(packageIdentifier, offeringIdentifier, googleOldProductIdentifer, googleProrationMode, googleIsPersonalizedPrice, result);
+                purchasePackage(packageIdentifier, presentedOfferingContext, googleOldProductIdentifer, googleProrationMode, googleIsPersonalizedPrice, result);
                 break;
             case "purchaseSubscriptionOption":
                 productIdentifier = call.argument("productIdentifier");
@@ -185,8 +185,8 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 googleOldProductIdentifer = call.argument("googleOldProductIdentifier");
                 googleProrationMode = call.argument("googleProrationMode");
                 googleIsPersonalizedPrice = call.argument("googleIsPersonalizedPrice");
-                presentedOfferingIdentifier = call.argument("presentedOfferingIdentifier");
-                purchaseSubscriptionOption(productIdentifier, optionIdentifier, googleOldProductIdentifer, googleProrationMode, googleIsPersonalizedPrice, presentedOfferingIdentifier, result);
+                presentedOfferingContext = call.argument("presentedOfferingContext");
+                purchaseSubscriptionOption(productIdentifier, optionIdentifier, googleOldProductIdentifer, googleProrationMode, googleIsPersonalizedPrice, presentedOfferingContext, result);
                 break;
             case "getAppUserID":
                 getAppUserID(result);
@@ -438,7 +438,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                                  final String googleOldProductId,
                                  @Nullable final Integer googleProrationMode,
                                  @Nullable final Boolean googleIsPersonalizedPrice,
-                                 @Nullable final String presentedOfferingIdentifier,
+                                 @Nullable final Map<String, Object> presentedOfferingContext,
                                  final Result result) {
         CommonKt.purchaseProduct(
                 getActivity(),
@@ -448,13 +448,13 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 googleOldProductId,
                 googleProrationMode,
                 googleIsPersonalizedPrice,
-                presentedOfferingIdentifier,
+                presentedOfferingContext,
                 getOnResult(result)
         );
     }
 
     private void purchasePackage(final String packageIdentifier,
-                                 final String offeringIdentifier,
+                                 final Map<String, Object> presentedOfferingContext,
                                  final String googleOldProductId,
                                  @Nullable final Integer googleProrationMode,
                                  @Nullable final Boolean googleIsPersonalizedPrice,
@@ -462,7 +462,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
         CommonKt.purchasePackage(
                 getActivity(),
                 packageIdentifier,
-                offeringIdentifier,
+                presentedOfferingContext,
                 googleOldProductId,
                 googleProrationMode,
                 googleIsPersonalizedPrice,
@@ -475,7 +475,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                                             final String googleOldProductId,
                                             @Nullable final Integer googleProrationMode,
                                             @Nullable final Boolean googleIsPersonalizedPrice,
-                                            @Nullable final String presentedOfferingIdentifier,
+                                            @Nullable final Map<String, Object> presentedOfferingContext,
                                             final Result result) {
         CommonKt.purchaseSubscriptionOption(
                 getActivity(),
@@ -484,7 +484,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 googleOldProductId,
                 googleProrationMode,
                 googleIsPersonalizedPrice,
-                presentedOfferingIdentifier,
+                presentedOfferingContext,
                 getOnResult(result)
         );
     }

--- a/api_tester/lib/api_tests/models/package_wrapper_api_test.dart
+++ b/api_tester/lib/api_tests/models/package_wrapper_api_test.dart
@@ -30,10 +30,9 @@ class _PackageApiTest {
       String identifier,
       PackageType packageType,
       StoreProduct storeProduct,
-      String offeringIdentifier,
       PresentedOfferingContext presentedOfferingContext) {
-    Package package = Package(identifier, packageType, storeProduct,
-        offeringIdentifier, presentedOfferingContext);
+    Package package = Package(
+        identifier, packageType, storeProduct, presentedOfferingContext);
   }
 
   void _checkProperties(Package package) {

--- a/api_tester/lib/api_tests/models/package_wrapper_api_test.dart
+++ b/api_tester/lib/api_tests/models/package_wrapper_api_test.dart
@@ -26,10 +26,14 @@ class _PackageApiTest {
     Map<String, dynamic> json = package.toJson();
   }
 
-  void _checkConstructor(String identifier, PackageType packageType,
-      StoreProduct storeProduct, String offeringIdentifier) {
-    Package package =
-        Package(identifier, packageType, storeProduct, offeringIdentifier);
+  void _checkConstructor(
+      String identifier,
+      PackageType packageType,
+      StoreProduct storeProduct,
+      String offeringIdentifier,
+      PresentedOfferingContext presentedOfferingContext) {
+    Package package = Package(identifier, packageType, storeProduct,
+        offeringIdentifier, presentedOfferingContext);
   }
 
   void _checkProperties(Package package) {
@@ -37,5 +41,7 @@ class _PackageApiTest {
     PackageType packageType = package.packageType;
     StoreProduct storeProduct = package.storeProduct;
     String offeringIdentifier = package.offeringIdentifier;
+    PresentedOfferingContext presentedOfferingContext =
+        package.presentedOfferingContext;
   }
 }

--- a/api_tester/lib/api_tests/models/package_wrapper_api_test.dart
+++ b/api_tester/lib/api_tests/models/package_wrapper_api_test.dart
@@ -2,6 +2,7 @@ import 'package:purchases_flutter/object_wrappers.dart';
 
 // ignore_for_file: unused_element
 // ignore_for_file: unused_local_variable
+// ignore_for_file: deprecated_member_use
 class _PackageApiTest {
   void _checkPackageType(PackageType type) {
     switch (type) {

--- a/api_tester/lib/api_tests/models/store_product_wrapper_api_test.dart
+++ b/api_tester/lib/api_tests/models/store_product_wrapper_api_test.dart
@@ -22,7 +22,8 @@ class _StoreProductApiTest {
       List<StoreProductDiscount>? discounts,
       ProductCategory? productCategory,
       String? subscriptionPeriod,
-      String? presentedOfferingIdentifier) {
+      String? presentedOfferingIdentifier,
+      PresentedOfferingContext? presentedOfferingContext) {
     StoreProduct product = StoreProduct(
         identifier, description, title, price, priceString, currencyCode);
     product = StoreProduct(
@@ -31,7 +32,8 @@ class _StoreProductApiTest {
         discounts: discounts,
         productCategory: productCategory,
         subscriptionPeriod: subscriptionPeriod,
-        presentedOfferingIdentifier: presentedOfferingIdentifier);
+        presentedOfferingIdentifier: presentedOfferingIdentifier,
+        presentedOfferingContext: presentedOfferingContext);
   }
 
   void _checkProperties(StoreProduct product) {
@@ -48,5 +50,7 @@ class _StoreProductApiTest {
     List<SubscriptionOption>? subscriptionOptions = product.subscriptionOptions;
     String? subscriptionPeriod = product.subscriptionPeriod;
     String? presentedOfferingIdentifier = product.presentedOfferingIdentifier;
+    PresentedOfferingContext? presentedOfferingContext =
+        product.presentedOfferingContext;
   }
 }

--- a/api_tester/lib/api_tests/models/store_product_wrapper_api_test.dart
+++ b/api_tester/lib/api_tests/models/store_product_wrapper_api_test.dart
@@ -22,7 +22,6 @@ class _StoreProductApiTest {
       List<StoreProductDiscount>? discounts,
       ProductCategory? productCategory,
       String? subscriptionPeriod,
-      String? presentedOfferingIdentifier,
       PresentedOfferingContext? presentedOfferingContext) {
     StoreProduct product = StoreProduct(
         identifier, description, title, price, priceString, currencyCode);
@@ -32,7 +31,6 @@ class _StoreProductApiTest {
         discounts: discounts,
         productCategory: productCategory,
         subscriptionPeriod: subscriptionPeriod,
-        presentedOfferingIdentifier: presentedOfferingIdentifier,
         presentedOfferingContext: presentedOfferingContext);
   }
 

--- a/api_tester/lib/api_tests/models/store_product_wrapper_api_test.dart
+++ b/api_tester/lib/api_tests/models/store_product_wrapper_api_test.dart
@@ -2,6 +2,7 @@ import 'package:purchases_flutter/object_wrappers.dart';
 
 // ignore_for_file: unused_element
 // ignore_for_file: unused_local_variable
+// ignore_for_file: deprecated_member_use
 class _StoreProductApiTest {
   void _checkFromJsonFactory(Map<String, dynamic> json) {
     StoreProduct product = StoreProduct.fromJson(json);

--- a/api_tester/lib/api_tests/models/subscription_option_wrapper_api_test.dart
+++ b/api_tester/lib/api_tests/models/subscription_option_wrapper_api_test.dart
@@ -55,7 +55,7 @@ class _SubscriptionOptionApiTest {
     PricingPhase? introPhase = subscriptionOption.introPhase;
     String? presentedOfferingIdentifier =
         subscriptionOption.presentedOfferingIdentifier;
-    PresentedOfferingContext? presentedOfferingIdentifier =
+    PresentedOfferingContext? presentedOfferingContext =
         subscriptionOption.presentedOfferingContext;
   }
 }

--- a/api_tester/lib/api_tests/models/subscription_option_wrapper_api_test.dart
+++ b/api_tester/lib/api_tests/models/subscription_option_wrapper_api_test.dart
@@ -23,7 +23,8 @@ class _SubscriptionOptionApiTest {
       PricingPhase? fullPricePhase,
       PricingPhase? freePhase,
       PricingPhase? introPhase,
-      String? presentedOfferingIdentifier) {
+      String? presentedOfferingIdentifier,
+      PresentedOfferingContext? presentedOfferingContext) {
     SubscriptionOption subscriptionOption = SubscriptionOption(
         id,
         storeProductId,
@@ -36,7 +37,8 @@ class _SubscriptionOptionApiTest {
         fullPricePhase,
         freePhase,
         introPhase,
-        presentedOfferingIdentifier);
+        presentedOfferingIdentifier,
+        presentedOfferingContext);
   }
 
   void _checkProperties(SubscriptionOption subscriptionOption) {
@@ -53,5 +55,7 @@ class _SubscriptionOptionApiTest {
     PricingPhase? introPhase = subscriptionOption.introPhase;
     String? presentedOfferingIdentifier =
         subscriptionOption.presentedOfferingIdentifier;
+    PresentedOfferingContext? presentedOfferingIdentifier =
+        subscriptionOption.presentedOfferingContext;
   }
 }

--- a/api_tester/lib/api_tests/models/subscription_option_wrapper_api_test.dart
+++ b/api_tester/lib/api_tests/models/subscription_option_wrapper_api_test.dart
@@ -2,6 +2,7 @@ import 'package:purchases_flutter/object_wrappers.dart';
 
 // ignore_for_file: unused_element
 // ignore_for_file: unused_local_variable
+// ignore_for_file: deprecated_member_use
 class _SubscriptionOptionApiTest {
   void _checkFromJsonFactory(Map<String, dynamic> json) {
     SubscriptionOption product = SubscriptionOption.fromJson(json);

--- a/api_tester/lib/api_tests/models/subscription_option_wrapper_api_test.dart
+++ b/api_tester/lib/api_tests/models/subscription_option_wrapper_api_test.dart
@@ -23,7 +23,6 @@ class _SubscriptionOptionApiTest {
       PricingPhase? fullPricePhase,
       PricingPhase? freePhase,
       PricingPhase? introPhase,
-      String? presentedOfferingIdentifier,
       PresentedOfferingContext? presentedOfferingContext) {
     SubscriptionOption subscriptionOption = SubscriptionOption(
         id,
@@ -37,7 +36,6 @@ class _SubscriptionOptionApiTest {
         fullPricePhase,
         freePhase,
         introPhase,
-        presentedOfferingIdentifier,
         presentedOfferingContext);
   }
 

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -67,7 +67,7 @@ class _PurchasesFlutterApiTest {
   }
 
   void _checkGetCurrentOfferingForPlacement() async {
-    Offering offering = await Purchases.getCurrentOfferingForPlacement('');
+    Offering? offering = await Purchases.getCurrentOfferingForPlacement('');
   }
 
   void _checkSyncAttributesAndOfferingsIfNeeded() async {

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -66,6 +66,14 @@ class _PurchasesFlutterApiTest {
     Offerings offerings = await Purchases.getOfferings();
   }
 
+  void _checkGetCurrentOfferingForPlacement() async {
+    Offering offering = await Purchases.getCurrentOfferingForPlacement('');
+  }
+
+  void _checkSyncAttributesAndOfferingsIfNeeded() async {
+    Offerings offerings = await Purchases.syncAttributesAndOfferingsIfNeeded();
+  }
+
   void _checkGetProducts() async {
     List<String> productIdentifiers = List.empty();
     PurchaseType purchaseType = PurchaseType.subs;
@@ -509,7 +517,10 @@ class _PurchasesFlutterApiTest {
   }
 
   void _showInAppMessages() async {
-    Future<void> future = Purchases.showInAppMessages(types: {InAppMessageType.billingIssue,
-      InAppMessageType.priceIncreaseConsent, InAppMessageType.generic});
+    Future<void> future = Purchases.showInAppMessages(types: {
+      InAppMessageType.billingIssue,
+      InAppMessageType.priceIncreaseConsent,
+      InAppMessageType.generic
+    });
   }
 }

--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -78,7 +78,7 @@ NSString *PurchasesLogHandlerEvent = @"Purchases-LogHandlerEvent";
                        result:result];
     } else if ([@"purchasePackage" isEqualToString:call.method]) {
         [self purchasePackage:arguments[@"packageIdentifier"]
-                     offering:arguments[@"offeringIdentifier"]
+     presentedOfferingContext:arguments[@"presentedOfferingContext"]
       signedDiscountTimestamp:arguments[@"signedDiscountTimestamp"]
                        result:result];
     } else if ([@"getAppUserID" isEqualToString:call.method]) {
@@ -290,11 +290,11 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
 }
 
 - (void)purchasePackage:(NSString *)packageIdentifier
-               offering:(NSString *)offeringIdentifier
+presentedOfferingContext:(NSDictionary *)presentedOfferingContext
 signedDiscountTimestamp:(nullable NSString *)discountTimestamp
                  result:(FlutterResult)result {
     [RCCommonFunctionality purchasePackage:packageIdentifier
-                                  offering:offeringIdentifier
+                  presentedOfferingContext: presentedOfferingContext
                    signedDiscountTimestamp:discountTimestamp
                            completionBlock:[self getResponseCompletionBlock:result]];
 }

--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -70,6 +70,11 @@ NSString *PurchasesLogHandlerEvent = @"Purchases-LogHandlerEvent";
         [self setFinishTransactions:[arguments[@"finishTransactions"] boolValue] result:result];
     } else if ([@"getOfferings" isEqualToString:call.method]) {
         [self getOfferingsWithResult:result];
+    } else if ([@"getCurrentOfferingForPlacement" isEqualToString:call.method]) {
+        [self getCurrentOfferingForPlacement:arguments[@"placementIdentifier"]
+                                       result:result];
+    } else if ([@"syncAttributesAndOfferingsIfNeeded" isEqualToString:call.method]) {
+        [self syncAttributesAndOfferingsIfNeededWithResult:result];
     } else if ([@"getProductInfo" isEqualToString:call.method]) {
         [self getProductInfo:arguments[@"productIdentifiers"] result:result];
     } else if ([@"purchaseProduct" isEqualToString:call.method]) {
@@ -272,6 +277,16 @@ shouldShowInAppMessagesAutomatically:(BOOL)shouldShowInAppMessagesAutomatically
 
 - (void)getOfferingsWithResult:(FlutterResult)result {
     [RCCommonFunctionality getOfferingsWithCompletionBlock:[self getResponseCompletionBlock:result]];
+}
+
+- (void)getCurrentOfferingForPlacement:(NSString *)placement
+                             result:(FlutterResult)result {
+    [RCCommonFunctionality getCurrentOfferingForPlacement:placement 
+                                          completionBlock:[self getResponseCompletionBlock:result]];
+}
+
+- (void)syncAttributesAndOfferingsIfNeededWithResult:(FlutterResult)result {
+    [RCCommonFunctionality syncAttributesAndOfferingsIfNeededWithCompletionBlock:[self getResponseCompletionBlock:result]];
 }
 
 - (void)getProductInfo:(NSArray *)products

--- a/lib/models/package_wrapper.dart
+++ b/lib/models/package_wrapper.dart
@@ -67,13 +67,16 @@ class Package with _$Package {
     // ignore: invalid_annotation_target
     @JsonKey(name: 'product') StoreProduct storeProduct,
 
-    /// Offering this package belongs to.
-    @Deprecated('use presentedOfferingContext') String offeringIdentifier,
-
     /// Offering context this package belongs to.
     PresentedOfferingContext presentedOfferingContext,
   ) = _Package;
 
   factory Package.fromJson(Map<String, dynamic> json) =>
       _$PackageFromJson(json);
+}
+
+extension ExtendedPackage on Package {
+  /// Offering this package belongs to.
+  @Deprecated('use presentedOfferingContext')
+  String get offeringIdentifier => presentedOfferingContext.offeringIdentifier;
 }

--- a/lib/models/package_wrapper.dart
+++ b/lib/models/package_wrapper.dart
@@ -61,15 +61,17 @@ class Package with _$Package {
       name: 'packageType',
       unknownEnumValue: PackageType.unknown,
     )
-        PackageType packageType,
+    PackageType packageType,
 
     /// StoreProduct assigned to this package.
     // ignore: invalid_annotation_target
-    @JsonKey(name: 'product')
-        StoreProduct storeProduct,
+    @JsonKey(name: 'product') StoreProduct storeProduct,
 
     /// Offering this package belongs to.
-    String offeringIdentifier,
+    @Deprecated('use presentedOfferingContext') String offeringIdentifier,
+
+    /// Offering context this package belongs to.
+    PresentedOfferingContext presentedOfferingContext,
   ) = _Package;
 
   factory Package.fromJson(Map<String, dynamic> json) =>

--- a/lib/models/package_wrapper.freezed.dart
+++ b/lib/models/package_wrapper.freezed.dart
@@ -34,10 +34,6 @@ mixin _$Package {
   @JsonKey(name: 'product')
   StoreProduct get storeProduct => throw _privateConstructorUsedError;
 
-  /// Offering this package belongs to.
-  @Deprecated('use presentedOfferingContext')
-  String get offeringIdentifier => throw _privateConstructorUsedError;
-
   /// Offering context this package belongs to.
   PresentedOfferingContext get presentedOfferingContext =>
       throw _privateConstructorUsedError;
@@ -57,7 +53,6 @@ abstract class $PackageCopyWith<$Res> {
       @JsonKey(name: 'packageType', unknownEnumValue: PackageType.unknown)
       PackageType packageType,
       @JsonKey(name: 'product') StoreProduct storeProduct,
-      @Deprecated('use presentedOfferingContext') String offeringIdentifier,
       PresentedOfferingContext presentedOfferingContext});
 
   $StoreProductCopyWith<$Res> get storeProduct;
@@ -80,7 +75,6 @@ class _$PackageCopyWithImpl<$Res, $Val extends Package>
     Object? identifier = null,
     Object? packageType = null,
     Object? storeProduct = null,
-    Object? offeringIdentifier = null,
     Object? presentedOfferingContext = null,
   }) {
     return _then(_value.copyWith(
@@ -96,10 +90,6 @@ class _$PackageCopyWithImpl<$Res, $Val extends Package>
           ? _value.storeProduct
           : storeProduct // ignore: cast_nullable_to_non_nullable
               as StoreProduct,
-      offeringIdentifier: null == offeringIdentifier
-          ? _value.offeringIdentifier
-          : offeringIdentifier // ignore: cast_nullable_to_non_nullable
-              as String,
       presentedOfferingContext: null == presentedOfferingContext
           ? _value.presentedOfferingContext
           : presentedOfferingContext // ignore: cast_nullable_to_non_nullable
@@ -137,7 +127,6 @@ abstract class _$$PackageImplCopyWith<$Res> implements $PackageCopyWith<$Res> {
       @JsonKey(name: 'packageType', unknownEnumValue: PackageType.unknown)
       PackageType packageType,
       @JsonKey(name: 'product') StoreProduct storeProduct,
-      @Deprecated('use presentedOfferingContext') String offeringIdentifier,
       PresentedOfferingContext presentedOfferingContext});
 
   @override
@@ -160,7 +149,6 @@ class __$$PackageImplCopyWithImpl<$Res>
     Object? identifier = null,
     Object? packageType = null,
     Object? storeProduct = null,
-    Object? offeringIdentifier = null,
     Object? presentedOfferingContext = null,
   }) {
     return _then(_$PackageImpl(
@@ -176,10 +164,6 @@ class __$$PackageImplCopyWithImpl<$Res>
           ? _value.storeProduct
           : storeProduct // ignore: cast_nullable_to_non_nullable
               as StoreProduct,
-      null == offeringIdentifier
-          ? _value.offeringIdentifier
-          : offeringIdentifier // ignore: cast_nullable_to_non_nullable
-              as String,
       null == presentedOfferingContext
           ? _value.presentedOfferingContext
           : presentedOfferingContext // ignore: cast_nullable_to_non_nullable
@@ -196,7 +180,6 @@ class _$PackageImpl implements _Package {
       @JsonKey(name: 'packageType', unknownEnumValue: PackageType.unknown)
       this.packageType,
       @JsonKey(name: 'product') this.storeProduct,
-      @Deprecated('use presentedOfferingContext') this.offeringIdentifier,
       this.presentedOfferingContext);
 
   factory _$PackageImpl.fromJson(Map<String, dynamic> json) =>
@@ -219,18 +202,13 @@ class _$PackageImpl implements _Package {
   @JsonKey(name: 'product')
   final StoreProduct storeProduct;
 
-  /// Offering this package belongs to.
-  @override
-  @Deprecated('use presentedOfferingContext')
-  final String offeringIdentifier;
-
   /// Offering context this package belongs to.
   @override
   final PresentedOfferingContext presentedOfferingContext;
 
   @override
   String toString() {
-    return 'Package(identifier: $identifier, packageType: $packageType, storeProduct: $storeProduct, offeringIdentifier: $offeringIdentifier, presentedOfferingContext: $presentedOfferingContext)';
+    return 'Package(identifier: $identifier, packageType: $packageType, storeProduct: $storeProduct, presentedOfferingContext: $presentedOfferingContext)';
   }
 
   @override
@@ -244,8 +222,6 @@ class _$PackageImpl implements _Package {
                 other.packageType == packageType) &&
             (identical(other.storeProduct, storeProduct) ||
                 other.storeProduct == storeProduct) &&
-            (identical(other.offeringIdentifier, offeringIdentifier) ||
-                other.offeringIdentifier == offeringIdentifier) &&
             (identical(
                     other.presentedOfferingContext, presentedOfferingContext) ||
                 other.presentedOfferingContext == presentedOfferingContext));
@@ -254,7 +230,7 @@ class _$PackageImpl implements _Package {
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, identifier, packageType,
-      storeProduct, offeringIdentifier, presentedOfferingContext);
+      storeProduct, presentedOfferingContext);
 
   @JsonKey(ignore: true)
   @override
@@ -276,8 +252,6 @@ abstract class _Package implements Package {
       @JsonKey(name: 'packageType', unknownEnumValue: PackageType.unknown)
       final PackageType packageType,
       @JsonKey(name: 'product') final StoreProduct storeProduct,
-      @Deprecated('use presentedOfferingContext')
-      final String offeringIdentifier,
       final PresentedOfferingContext presentedOfferingContext) = _$PackageImpl;
 
   factory _Package.fromJson(Map<String, dynamic> json) = _$PackageImpl.fromJson;
@@ -299,11 +273,6 @@ abstract class _Package implements Package {
 // ignore: invalid_annotation_target
   @JsonKey(name: 'product')
   StoreProduct get storeProduct;
-  @override
-
-  /// Offering this package belongs to.
-  @Deprecated('use presentedOfferingContext')
-  String get offeringIdentifier;
   @override
 
   /// Offering context this package belongs to.

--- a/lib/models/package_wrapper.freezed.dart
+++ b/lib/models/package_wrapper.freezed.dart
@@ -35,7 +35,12 @@ mixin _$Package {
   StoreProduct get storeProduct => throw _privateConstructorUsedError;
 
   /// Offering this package belongs to.
+  @Deprecated('use presentedOfferingContext')
   String get offeringIdentifier => throw _privateConstructorUsedError;
+
+  /// Offering context this package belongs to.
+  PresentedOfferingContext get presentedOfferingContext =>
+      throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -52,9 +57,11 @@ abstract class $PackageCopyWith<$Res> {
       @JsonKey(name: 'packageType', unknownEnumValue: PackageType.unknown)
       PackageType packageType,
       @JsonKey(name: 'product') StoreProduct storeProduct,
-      String offeringIdentifier});
+      @Deprecated('use presentedOfferingContext') String offeringIdentifier,
+      PresentedOfferingContext presentedOfferingContext});
 
   $StoreProductCopyWith<$Res> get storeProduct;
+  $PresentedOfferingContextCopyWith<$Res> get presentedOfferingContext;
 }
 
 /// @nodoc
@@ -74,6 +81,7 @@ class _$PackageCopyWithImpl<$Res, $Val extends Package>
     Object? packageType = null,
     Object? storeProduct = null,
     Object? offeringIdentifier = null,
+    Object? presentedOfferingContext = null,
   }) {
     return _then(_value.copyWith(
       identifier: null == identifier
@@ -92,6 +100,10 @@ class _$PackageCopyWithImpl<$Res, $Val extends Package>
           ? _value.offeringIdentifier
           : offeringIdentifier // ignore: cast_nullable_to_non_nullable
               as String,
+      presentedOfferingContext: null == presentedOfferingContext
+          ? _value.presentedOfferingContext
+          : presentedOfferingContext // ignore: cast_nullable_to_non_nullable
+              as PresentedOfferingContext,
     ) as $Val);
   }
 
@@ -100,6 +112,15 @@ class _$PackageCopyWithImpl<$Res, $Val extends Package>
   $StoreProductCopyWith<$Res> get storeProduct {
     return $StoreProductCopyWith<$Res>(_value.storeProduct, (value) {
       return _then(_value.copyWith(storeProduct: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $PresentedOfferingContextCopyWith<$Res> get presentedOfferingContext {
+    return $PresentedOfferingContextCopyWith<$Res>(
+        _value.presentedOfferingContext, (value) {
+      return _then(_value.copyWith(presentedOfferingContext: value) as $Val);
     });
   }
 }
@@ -116,10 +137,13 @@ abstract class _$$PackageImplCopyWith<$Res> implements $PackageCopyWith<$Res> {
       @JsonKey(name: 'packageType', unknownEnumValue: PackageType.unknown)
       PackageType packageType,
       @JsonKey(name: 'product') StoreProduct storeProduct,
-      String offeringIdentifier});
+      @Deprecated('use presentedOfferingContext') String offeringIdentifier,
+      PresentedOfferingContext presentedOfferingContext});
 
   @override
   $StoreProductCopyWith<$Res> get storeProduct;
+  @override
+  $PresentedOfferingContextCopyWith<$Res> get presentedOfferingContext;
 }
 
 /// @nodoc
@@ -137,6 +161,7 @@ class __$$PackageImplCopyWithImpl<$Res>
     Object? packageType = null,
     Object? storeProduct = null,
     Object? offeringIdentifier = null,
+    Object? presentedOfferingContext = null,
   }) {
     return _then(_$PackageImpl(
       null == identifier
@@ -155,6 +180,10 @@ class __$$PackageImplCopyWithImpl<$Res>
           ? _value.offeringIdentifier
           : offeringIdentifier // ignore: cast_nullable_to_non_nullable
               as String,
+      null == presentedOfferingContext
+          ? _value.presentedOfferingContext
+          : presentedOfferingContext // ignore: cast_nullable_to_non_nullable
+              as PresentedOfferingContext,
     ));
   }
 }
@@ -167,7 +196,8 @@ class _$PackageImpl implements _Package {
       @JsonKey(name: 'packageType', unknownEnumValue: PackageType.unknown)
       this.packageType,
       @JsonKey(name: 'product') this.storeProduct,
-      this.offeringIdentifier);
+      @Deprecated('use presentedOfferingContext') this.offeringIdentifier,
+      this.presentedOfferingContext);
 
   factory _$PackageImpl.fromJson(Map<String, dynamic> json) =>
       _$$PackageImplFromJson(json);
@@ -191,11 +221,16 @@ class _$PackageImpl implements _Package {
 
   /// Offering this package belongs to.
   @override
+  @Deprecated('use presentedOfferingContext')
   final String offeringIdentifier;
+
+  /// Offering context this package belongs to.
+  @override
+  final PresentedOfferingContext presentedOfferingContext;
 
   @override
   String toString() {
-    return 'Package(identifier: $identifier, packageType: $packageType, storeProduct: $storeProduct, offeringIdentifier: $offeringIdentifier)';
+    return 'Package(identifier: $identifier, packageType: $packageType, storeProduct: $storeProduct, offeringIdentifier: $offeringIdentifier, presentedOfferingContext: $presentedOfferingContext)';
   }
 
   @override
@@ -210,13 +245,16 @@ class _$PackageImpl implements _Package {
             (identical(other.storeProduct, storeProduct) ||
                 other.storeProduct == storeProduct) &&
             (identical(other.offeringIdentifier, offeringIdentifier) ||
-                other.offeringIdentifier == offeringIdentifier));
+                other.offeringIdentifier == offeringIdentifier) &&
+            (identical(
+                    other.presentedOfferingContext, presentedOfferingContext) ||
+                other.presentedOfferingContext == presentedOfferingContext));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(
-      runtimeType, identifier, packageType, storeProduct, offeringIdentifier);
+  int get hashCode => Object.hash(runtimeType, identifier, packageType,
+      storeProduct, offeringIdentifier, presentedOfferingContext);
 
   @JsonKey(ignore: true)
   @override
@@ -238,7 +276,9 @@ abstract class _Package implements Package {
       @JsonKey(name: 'packageType', unknownEnumValue: PackageType.unknown)
       final PackageType packageType,
       @JsonKey(name: 'product') final StoreProduct storeProduct,
-      final String offeringIdentifier) = _$PackageImpl;
+      @Deprecated('use presentedOfferingContext')
+      final String offeringIdentifier,
+      final PresentedOfferingContext presentedOfferingContext) = _$PackageImpl;
 
   factory _Package.fromJson(Map<String, dynamic> json) = _$PackageImpl.fromJson;
 
@@ -262,7 +302,12 @@ abstract class _Package implements Package {
   @override
 
   /// Offering this package belongs to.
+  @Deprecated('use presentedOfferingContext')
   String get offeringIdentifier;
+  @override
+
+  /// Offering context this package belongs to.
+  PresentedOfferingContext get presentedOfferingContext;
   @override
   @JsonKey(ignore: true)
   _$$PackageImplCopyWith<_$PackageImpl> get copyWith =>

--- a/lib/models/package_wrapper.g.dart
+++ b/lib/models/package_wrapper.g.dart
@@ -12,6 +12,8 @@ _$PackageImpl _$$PackageImplFromJson(Map json) => _$PackageImpl(
           unknownValue: PackageType.unknown),
       StoreProduct.fromJson(Map<String, dynamic>.from(json['product'] as Map)),
       json['offeringIdentifier'] as String,
+      PresentedOfferingContext.fromJson(
+          Map<String, dynamic>.from(json['presentedOfferingContext'] as Map)),
     );
 
 Map<String, dynamic> _$$PackageImplToJson(_$PackageImpl instance) =>
@@ -20,6 +22,7 @@ Map<String, dynamic> _$$PackageImplToJson(_$PackageImpl instance) =>
       'packageType': _$PackageTypeEnumMap[instance.packageType]!,
       'product': instance.storeProduct.toJson(),
       'offeringIdentifier': instance.offeringIdentifier,
+      'presentedOfferingContext': instance.presentedOfferingContext.toJson(),
     };
 
 const _$PackageTypeEnumMap = {

--- a/lib/models/package_wrapper.g.dart
+++ b/lib/models/package_wrapper.g.dart
@@ -11,7 +11,6 @@ _$PackageImpl _$$PackageImplFromJson(Map json) => _$PackageImpl(
       $enumDecode(_$PackageTypeEnumMap, json['packageType'],
           unknownValue: PackageType.unknown),
       StoreProduct.fromJson(Map<String, dynamic>.from(json['product'] as Map)),
-      json['offeringIdentifier'] as String,
       PresentedOfferingContext.fromJson(
           Map<String, dynamic>.from(json['presentedOfferingContext'] as Map)),
     );
@@ -21,7 +20,6 @@ Map<String, dynamic> _$$PackageImplToJson(_$PackageImpl instance) =>
       'identifier': instance.identifier,
       'packageType': _$PackageTypeEnumMap[instance.packageType]!,
       'product': instance.storeProduct.toJson(),
-      'offeringIdentifier': instance.offeringIdentifier,
       'presentedOfferingContext': instance.presentedOfferingContext.toJson(),
     };
 

--- a/lib/models/presented_offering_context_wrapper.dart
+++ b/lib/models/presented_offering_context_wrapper.dart
@@ -1,0 +1,25 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'presented_offering_targeting_context_wrapper.dart';
+
+part 'presented_offering_context_wrapper.freezed.dart';
+part 'presented_offering_context_wrapper.g.dart';
+
+@freezed
+
+/// Contains all the details associated with a PresentedOfferingContext
+class PresentedOfferingContext with _$PresentedOfferingContext {
+  const factory PresentedOfferingContext(
+    /// The identifier of the offering used to obtain this object
+    String offeringIdentifier,
+
+    /// The identifier of the placement used to obtain this object
+    String? placementIdentifier,
+
+    /// The revision of the targeting used to obtain this object
+    PresentedOfferingTargetingContext? targetingContext,
+  ) = _PresentedOfferingContext;
+
+  factory PresentedOfferingContext.fromJson(Map<String, dynamic> json) =>
+      _$PresentedOfferingContextFromJson(json);
+}

--- a/lib/models/presented_offering_context_wrapper.freezed.dart
+++ b/lib/models/presented_offering_context_wrapper.freezed.dart
@@ -1,0 +1,239 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'presented_offering_context_wrapper.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+PresentedOfferingContext _$PresentedOfferingContextFromJson(
+    Map<String, dynamic> json) {
+  return _PresentedOfferingContext.fromJson(json);
+}
+
+/// @nodoc
+mixin _$PresentedOfferingContext {
+  /// The identifier of the offering used to obtain this object
+  String get offeringIdentifier => throw _privateConstructorUsedError;
+
+  /// The identifier of the placement used to obtain this object
+  String? get placementIdentifier => throw _privateConstructorUsedError;
+
+  /// The revision of the targeting used to obtain this object
+  PresentedOfferingTargetingContext? get targetingContext =>
+      throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $PresentedOfferingContextCopyWith<PresentedOfferingContext> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PresentedOfferingContextCopyWith<$Res> {
+  factory $PresentedOfferingContextCopyWith(PresentedOfferingContext value,
+          $Res Function(PresentedOfferingContext) then) =
+      _$PresentedOfferingContextCopyWithImpl<$Res, PresentedOfferingContext>;
+  @useResult
+  $Res call(
+      {String offeringIdentifier,
+      String? placementIdentifier,
+      PresentedOfferingTargetingContext? targetingContext});
+
+  $PresentedOfferingTargetingContextCopyWith<$Res>? get targetingContext;
+}
+
+/// @nodoc
+class _$PresentedOfferingContextCopyWithImpl<$Res,
+        $Val extends PresentedOfferingContext>
+    implements $PresentedOfferingContextCopyWith<$Res> {
+  _$PresentedOfferingContextCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? offeringIdentifier = null,
+    Object? placementIdentifier = freezed,
+    Object? targetingContext = freezed,
+  }) {
+    return _then(_value.copyWith(
+      offeringIdentifier: null == offeringIdentifier
+          ? _value.offeringIdentifier
+          : offeringIdentifier // ignore: cast_nullable_to_non_nullable
+              as String,
+      placementIdentifier: freezed == placementIdentifier
+          ? _value.placementIdentifier
+          : placementIdentifier // ignore: cast_nullable_to_non_nullable
+              as String?,
+      targetingContext: freezed == targetingContext
+          ? _value.targetingContext
+          : targetingContext // ignore: cast_nullable_to_non_nullable
+              as PresentedOfferingTargetingContext?,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $PresentedOfferingTargetingContextCopyWith<$Res>? get targetingContext {
+    if (_value.targetingContext == null) {
+      return null;
+    }
+
+    return $PresentedOfferingTargetingContextCopyWith<$Res>(
+        _value.targetingContext!, (value) {
+      return _then(_value.copyWith(targetingContext: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$PresentedOfferingContextImplCopyWith<$Res>
+    implements $PresentedOfferingContextCopyWith<$Res> {
+  factory _$$PresentedOfferingContextImplCopyWith(
+          _$PresentedOfferingContextImpl value,
+          $Res Function(_$PresentedOfferingContextImpl) then) =
+      __$$PresentedOfferingContextImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String offeringIdentifier,
+      String? placementIdentifier,
+      PresentedOfferingTargetingContext? targetingContext});
+
+  @override
+  $PresentedOfferingTargetingContextCopyWith<$Res>? get targetingContext;
+}
+
+/// @nodoc
+class __$$PresentedOfferingContextImplCopyWithImpl<$Res>
+    extends _$PresentedOfferingContextCopyWithImpl<$Res,
+        _$PresentedOfferingContextImpl>
+    implements _$$PresentedOfferingContextImplCopyWith<$Res> {
+  __$$PresentedOfferingContextImplCopyWithImpl(
+      _$PresentedOfferingContextImpl _value,
+      $Res Function(_$PresentedOfferingContextImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? offeringIdentifier = null,
+    Object? placementIdentifier = freezed,
+    Object? targetingContext = freezed,
+  }) {
+    return _then(_$PresentedOfferingContextImpl(
+      null == offeringIdentifier
+          ? _value.offeringIdentifier
+          : offeringIdentifier // ignore: cast_nullable_to_non_nullable
+              as String,
+      freezed == placementIdentifier
+          ? _value.placementIdentifier
+          : placementIdentifier // ignore: cast_nullable_to_non_nullable
+              as String?,
+      freezed == targetingContext
+          ? _value.targetingContext
+          : targetingContext // ignore: cast_nullable_to_non_nullable
+              as PresentedOfferingTargetingContext?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$PresentedOfferingContextImpl implements _PresentedOfferingContext {
+  const _$PresentedOfferingContextImpl(
+      this.offeringIdentifier, this.placementIdentifier, this.targetingContext);
+
+  factory _$PresentedOfferingContextImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PresentedOfferingContextImplFromJson(json);
+
+  /// The identifier of the offering used to obtain this object
+  @override
+  final String offeringIdentifier;
+
+  /// The identifier of the placement used to obtain this object
+  @override
+  final String? placementIdentifier;
+
+  /// The revision of the targeting used to obtain this object
+  @override
+  final PresentedOfferingTargetingContext? targetingContext;
+
+  @override
+  String toString() {
+    return 'PresentedOfferingContext(offeringIdentifier: $offeringIdentifier, placementIdentifier: $placementIdentifier, targetingContext: $targetingContext)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PresentedOfferingContextImpl &&
+            (identical(other.offeringIdentifier, offeringIdentifier) ||
+                other.offeringIdentifier == offeringIdentifier) &&
+            (identical(other.placementIdentifier, placementIdentifier) ||
+                other.placementIdentifier == placementIdentifier) &&
+            (identical(other.targetingContext, targetingContext) ||
+                other.targetingContext == targetingContext));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, offeringIdentifier, placementIdentifier, targetingContext);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PresentedOfferingContextImplCopyWith<_$PresentedOfferingContextImpl>
+      get copyWith => __$$PresentedOfferingContextImplCopyWithImpl<
+          _$PresentedOfferingContextImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$PresentedOfferingContextImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _PresentedOfferingContext implements PresentedOfferingContext {
+  const factory _PresentedOfferingContext(
+          final String offeringIdentifier,
+          final String? placementIdentifier,
+          final PresentedOfferingTargetingContext? targetingContext) =
+      _$PresentedOfferingContextImpl;
+
+  factory _PresentedOfferingContext.fromJson(Map<String, dynamic> json) =
+      _$PresentedOfferingContextImpl.fromJson;
+
+  @override
+
+  /// The identifier of the offering used to obtain this object
+  String get offeringIdentifier;
+  @override
+
+  /// The identifier of the placement used to obtain this object
+  String? get placementIdentifier;
+  @override
+
+  /// The revision of the targeting used to obtain this object
+  PresentedOfferingTargetingContext? get targetingContext;
+  @override
+  @JsonKey(ignore: true)
+  _$$PresentedOfferingContextImplCopyWith<_$PresentedOfferingContextImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/models/presented_offering_context_wrapper.g.dart
+++ b/lib/models/presented_offering_context_wrapper.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'presented_offering_context_wrapper.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$PresentedOfferingContextImpl _$$PresentedOfferingContextImplFromJson(
+        Map json) =>
+    _$PresentedOfferingContextImpl(
+      json['offeringIdentifier'] as String,
+      json['placementIdentifier'] as String?,
+      json['targetingContext'] == null
+          ? null
+          : PresentedOfferingTargetingContext.fromJson(
+              Map<String, dynamic>.from(json['targetingContext'] as Map)),
+    );
+
+Map<String, dynamic> _$$PresentedOfferingContextImplToJson(
+        _$PresentedOfferingContextImpl instance) =>
+    <String, dynamic>{
+      'offeringIdentifier': instance.offeringIdentifier,
+      'placementIdentifier': instance.placementIdentifier,
+      'targetingContext': instance.targetingContext?.toJson(),
+    };

--- a/lib/models/presented_offering_targeting_context_wrapper.dart
+++ b/lib/models/presented_offering_targeting_context_wrapper.dart
@@ -1,0 +1,24 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'period_unit.dart';
+
+part 'presented_offering_targeting_context_wrapper.freezed.dart';
+part 'presented_offering_targeting_context_wrapper.g.dart';
+
+@freezed
+
+/// Contains all the details associated with a PresentedOfferingContext
+class PresentedOfferingTargetingContext
+    with _$PresentedOfferingTargetingContext {
+  const factory PresentedOfferingTargetingContext(
+    /// The revision of the targeting used to obtain this object
+    int revision,
+
+    /// The rule id from the targeting used to obtain this object
+    String ruleId,
+  ) = _PresentedOfferingTargetingContext;
+
+  factory PresentedOfferingTargetingContext.fromJson(
+          Map<String, dynamic> json) =>
+      _$PresentedOfferingTargetingContextFromJson(json);
+}

--- a/lib/models/presented_offering_targeting_context_wrapper.dart
+++ b/lib/models/presented_offering_targeting_context_wrapper.dart
@@ -1,7 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
-import 'period_unit.dart';
-
 part 'presented_offering_targeting_context_wrapper.freezed.dart';
 part 'presented_offering_targeting_context_wrapper.g.dart';
 
@@ -19,6 +17,7 @@ class PresentedOfferingTargetingContext
   ) = _PresentedOfferingTargetingContext;
 
   factory PresentedOfferingTargetingContext.fromJson(
-          Map<String, dynamic> json) =>
+    Map<String, dynamic> json,
+  ) =>
       _$PresentedOfferingTargetingContextFromJson(json);
 }

--- a/lib/models/presented_offering_targeting_context_wrapper.freezed.dart
+++ b/lib/models/presented_offering_targeting_context_wrapper.freezed.dart
@@ -1,0 +1,194 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'presented_offering_targeting_context_wrapper.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+PresentedOfferingTargetingContext _$PresentedOfferingTargetingContextFromJson(
+    Map<String, dynamic> json) {
+  return _PresentedOfferingTargetingContext.fromJson(json);
+}
+
+/// @nodoc
+mixin _$PresentedOfferingTargetingContext {
+  /// The revision of the targeting used to obtain this object
+  int get revision => throw _privateConstructorUsedError;
+
+  /// The rule id from the targeting used to obtain this object
+  String get ruleId => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $PresentedOfferingTargetingContextCopyWith<PresentedOfferingTargetingContext>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PresentedOfferingTargetingContextCopyWith<$Res> {
+  factory $PresentedOfferingTargetingContextCopyWith(
+          PresentedOfferingTargetingContext value,
+          $Res Function(PresentedOfferingTargetingContext) then) =
+      _$PresentedOfferingTargetingContextCopyWithImpl<$Res,
+          PresentedOfferingTargetingContext>;
+  @useResult
+  $Res call({int revision, String ruleId});
+}
+
+/// @nodoc
+class _$PresentedOfferingTargetingContextCopyWithImpl<$Res,
+        $Val extends PresentedOfferingTargetingContext>
+    implements $PresentedOfferingTargetingContextCopyWith<$Res> {
+  _$PresentedOfferingTargetingContextCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? revision = null,
+    Object? ruleId = null,
+  }) {
+    return _then(_value.copyWith(
+      revision: null == revision
+          ? _value.revision
+          : revision // ignore: cast_nullable_to_non_nullable
+              as int,
+      ruleId: null == ruleId
+          ? _value.ruleId
+          : ruleId // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$PresentedOfferingTargetingContextImplCopyWith<$Res>
+    implements $PresentedOfferingTargetingContextCopyWith<$Res> {
+  factory _$$PresentedOfferingTargetingContextImplCopyWith(
+          _$PresentedOfferingTargetingContextImpl value,
+          $Res Function(_$PresentedOfferingTargetingContextImpl) then) =
+      __$$PresentedOfferingTargetingContextImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({int revision, String ruleId});
+}
+
+/// @nodoc
+class __$$PresentedOfferingTargetingContextImplCopyWithImpl<$Res>
+    extends _$PresentedOfferingTargetingContextCopyWithImpl<$Res,
+        _$PresentedOfferingTargetingContextImpl>
+    implements _$$PresentedOfferingTargetingContextImplCopyWith<$Res> {
+  __$$PresentedOfferingTargetingContextImplCopyWithImpl(
+      _$PresentedOfferingTargetingContextImpl _value,
+      $Res Function(_$PresentedOfferingTargetingContextImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? revision = null,
+    Object? ruleId = null,
+  }) {
+    return _then(_$PresentedOfferingTargetingContextImpl(
+      null == revision
+          ? _value.revision
+          : revision // ignore: cast_nullable_to_non_nullable
+              as int,
+      null == ruleId
+          ? _value.ruleId
+          : ruleId // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$PresentedOfferingTargetingContextImpl
+    implements _PresentedOfferingTargetingContext {
+  const _$PresentedOfferingTargetingContextImpl(this.revision, this.ruleId);
+
+  factory _$PresentedOfferingTargetingContextImpl.fromJson(
+          Map<String, dynamic> json) =>
+      _$$PresentedOfferingTargetingContextImplFromJson(json);
+
+  /// The revision of the targeting used to obtain this object
+  @override
+  final int revision;
+
+  /// The rule id from the targeting used to obtain this object
+  @override
+  final String ruleId;
+
+  @override
+  String toString() {
+    return 'PresentedOfferingTargetingContext(revision: $revision, ruleId: $ruleId)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PresentedOfferingTargetingContextImpl &&
+            (identical(other.revision, revision) ||
+                other.revision == revision) &&
+            (identical(other.ruleId, ruleId) || other.ruleId == ruleId));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, revision, ruleId);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PresentedOfferingTargetingContextImplCopyWith<
+          _$PresentedOfferingTargetingContextImpl>
+      get copyWith => __$$PresentedOfferingTargetingContextImplCopyWithImpl<
+          _$PresentedOfferingTargetingContextImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$PresentedOfferingTargetingContextImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _PresentedOfferingTargetingContext
+    implements PresentedOfferingTargetingContext {
+  const factory _PresentedOfferingTargetingContext(
+          final int revision, final String ruleId) =
+      _$PresentedOfferingTargetingContextImpl;
+
+  factory _PresentedOfferingTargetingContext.fromJson(
+          Map<String, dynamic> json) =
+      _$PresentedOfferingTargetingContextImpl.fromJson;
+
+  @override
+
+  /// The revision of the targeting used to obtain this object
+  int get revision;
+  @override
+
+  /// The rule id from the targeting used to obtain this object
+  String get ruleId;
+  @override
+  @JsonKey(ignore: true)
+  _$$PresentedOfferingTargetingContextImplCopyWith<
+          _$PresentedOfferingTargetingContextImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/models/presented_offering_targeting_context_wrapper.g.dart
+++ b/lib/models/presented_offering_targeting_context_wrapper.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'presented_offering_targeting_context_wrapper.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$PresentedOfferingTargetingContextImpl
+    _$$PresentedOfferingTargetingContextImplFromJson(Map json) =>
+        _$PresentedOfferingTargetingContextImpl(
+          json['revision'] as int,
+          json['ruleId'] as String,
+        );
+
+Map<String, dynamic> _$$PresentedOfferingTargetingContextImplToJson(
+        _$PresentedOfferingTargetingContextImpl instance) =>
+    <String, dynamic>{
+      'revision': instance.revision,
+      'ruleId': instance.ruleId,
+    };

--- a/lib/models/store_product_wrapper.dart
+++ b/lib/models/store_product_wrapper.dart
@@ -67,6 +67,6 @@ extension ExtendedStoreProduct on StoreProduct {
   /// Offering this package belongs to.
   /// Null if not using offerings or if fetched directly from store via getProducts
   @Deprecated('use presentedOfferingContext')
-  String? get offeringIdentifier =>
+  String? get presentedOfferingIdentifier =>
       presentedOfferingContext?.offeringIdentifier;
 }

--- a/lib/models/store_product_wrapper.dart
+++ b/lib/models/store_product_wrapper.dart
@@ -47,11 +47,6 @@ class StoreProduct with _$StoreProduct {
     /// Collection of subscription options for a product. Google Play only.
     List<SubscriptionOption>? subscriptionOptions,
 
-    /// Offering identifier the store product was presented from
-    /// Null if not using offerings or if fetched directly from store via getProducts
-    @Deprecated('use presentedOfferingContext')
-    String? presentedOfferingIdentifier,
-
     /// Offering context this package belongs to.
     /// Null if not using offerings or if fetched directly from store via getProducts
     PresentedOfferingContext? presentedOfferingContext,
@@ -66,4 +61,12 @@ class StoreProduct with _$StoreProduct {
 
   factory StoreProduct.fromJson(Map<String, dynamic> json) =>
       _$StoreProductFromJson(json);
+}
+
+extension ExtendedStoreProduct on StoreProduct {
+  /// Offering this package belongs to.
+  /// Null if not using offerings or if fetched directly from store via getProducts
+  @Deprecated('use presentedOfferingContext')
+  String? get offeringIdentifier =>
+      presentedOfferingContext?.offeringIdentifier;
 }

--- a/lib/models/store_product_wrapper.dart
+++ b/lib/models/store_product_wrapper.dart
@@ -1,6 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 import 'introductory_price.dart';
+import 'presented_offering_context_wrapper.dart';
 import 'product_category.dart';
 import 'store_product_discount.dart';
 import 'subscription_option_wrapper.dart';
@@ -30,7 +31,6 @@ class StoreProduct with _$StoreProduct {
 
     /// Currency code for price and original price.
     String currencyCode, {
-
     /// Introductory price for product. Can be null.
     // ignore: invalid_annotation_target
     @JsonKey(name: 'introPrice') IntroductoryPrice? introductoryPrice,
@@ -49,7 +49,12 @@ class StoreProduct with _$StoreProduct {
 
     /// Offering identifier the store product was presented from
     /// Null if not using offerings or if fetched directly from store via getProducts
+    @Deprecated('use presentedOfferingContext')
     String? presentedOfferingIdentifier,
+
+    /// Offering context this package belongs to.
+    /// Null if not using offerings or if fetched directly from store via getProducts
+    PresentedOfferingContext? presentedOfferingContext,
 
     /// Subscription period, specified in ISO 8601 format. For example,
     /// P1W equates to one week, P1M equates to one month,

--- a/lib/models/store_product_wrapper.freezed.dart
+++ b/lib/models/store_product_wrapper.freezed.dart
@@ -60,7 +60,13 @@ mixin _$StoreProduct {
 
   /// Offering identifier the store product was presented from
   /// Null if not using offerings or if fetched directly from store via getProducts
+  @Deprecated('use presentedOfferingContext')
   String? get presentedOfferingIdentifier => throw _privateConstructorUsedError;
+
+  /// Offering context this package belongs to.
+  /// Null if not using offerings or if fetched directly from store via getProducts
+  PresentedOfferingContext? get presentedOfferingContext =>
+      throw _privateConstructorUsedError;
 
   /// Subscription period, specified in ISO 8601 format. For example,
   /// P1W equates to one week, P1M equates to one month,
@@ -93,11 +99,14 @@ abstract class $StoreProductCopyWith<$Res> {
       ProductCategory? productCategory,
       SubscriptionOption? defaultOption,
       List<SubscriptionOption>? subscriptionOptions,
+      @Deprecated('use presentedOfferingContext')
       String? presentedOfferingIdentifier,
+      PresentedOfferingContext? presentedOfferingContext,
       String? subscriptionPeriod});
 
   $IntroductoryPriceCopyWith<$Res>? get introductoryPrice;
   $SubscriptionOptionCopyWith<$Res>? get defaultOption;
+  $PresentedOfferingContextCopyWith<$Res>? get presentedOfferingContext;
 }
 
 /// @nodoc
@@ -125,6 +134,7 @@ class _$StoreProductCopyWithImpl<$Res, $Val extends StoreProduct>
     Object? defaultOption = freezed,
     Object? subscriptionOptions = freezed,
     Object? presentedOfferingIdentifier = freezed,
+    Object? presentedOfferingContext = freezed,
     Object? subscriptionPeriod = freezed,
   }) {
     return _then(_value.copyWith(
@@ -176,6 +186,10 @@ class _$StoreProductCopyWithImpl<$Res, $Val extends StoreProduct>
           ? _value.presentedOfferingIdentifier
           : presentedOfferingIdentifier // ignore: cast_nullable_to_non_nullable
               as String?,
+      presentedOfferingContext: freezed == presentedOfferingContext
+          ? _value.presentedOfferingContext
+          : presentedOfferingContext // ignore: cast_nullable_to_non_nullable
+              as PresentedOfferingContext?,
       subscriptionPeriod: freezed == subscriptionPeriod
           ? _value.subscriptionPeriod
           : subscriptionPeriod // ignore: cast_nullable_to_non_nullable
@@ -206,6 +220,19 @@ class _$StoreProductCopyWithImpl<$Res, $Val extends StoreProduct>
       return _then(_value.copyWith(defaultOption: value) as $Val);
     });
   }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $PresentedOfferingContextCopyWith<$Res>? get presentedOfferingContext {
+    if (_value.presentedOfferingContext == null) {
+      return null;
+    }
+
+    return $PresentedOfferingContextCopyWith<$Res>(
+        _value.presentedOfferingContext!, (value) {
+      return _then(_value.copyWith(presentedOfferingContext: value) as $Val);
+    });
+  }
 }
 
 /// @nodoc
@@ -228,13 +255,17 @@ abstract class _$$StoreProductImplCopyWith<$Res>
       ProductCategory? productCategory,
       SubscriptionOption? defaultOption,
       List<SubscriptionOption>? subscriptionOptions,
+      @Deprecated('use presentedOfferingContext')
       String? presentedOfferingIdentifier,
+      PresentedOfferingContext? presentedOfferingContext,
       String? subscriptionPeriod});
 
   @override
   $IntroductoryPriceCopyWith<$Res>? get introductoryPrice;
   @override
   $SubscriptionOptionCopyWith<$Res>? get defaultOption;
+  @override
+  $PresentedOfferingContextCopyWith<$Res>? get presentedOfferingContext;
 }
 
 /// @nodoc
@@ -260,6 +291,7 @@ class __$$StoreProductImplCopyWithImpl<$Res>
     Object? defaultOption = freezed,
     Object? subscriptionOptions = freezed,
     Object? presentedOfferingIdentifier = freezed,
+    Object? presentedOfferingContext = freezed,
     Object? subscriptionPeriod = freezed,
   }) {
     return _then(_$StoreProductImpl(
@@ -311,6 +343,10 @@ class __$$StoreProductImplCopyWithImpl<$Res>
           ? _value.presentedOfferingIdentifier
           : presentedOfferingIdentifier // ignore: cast_nullable_to_non_nullable
               as String?,
+      presentedOfferingContext: freezed == presentedOfferingContext
+          ? _value.presentedOfferingContext
+          : presentedOfferingContext // ignore: cast_nullable_to_non_nullable
+              as PresentedOfferingContext?,
       subscriptionPeriod: freezed == subscriptionPeriod
           ? _value.subscriptionPeriod
           : subscriptionPeriod // ignore: cast_nullable_to_non_nullable
@@ -329,7 +365,9 @@ class _$StoreProductImpl implements _StoreProduct {
       this.productCategory,
       this.defaultOption,
       final List<SubscriptionOption>? subscriptionOptions,
+      @Deprecated('use presentedOfferingContext')
       this.presentedOfferingIdentifier,
+      this.presentedOfferingContext,
       this.subscriptionPeriod})
       : _discounts = discounts,
         _subscriptionOptions = subscriptionOptions;
@@ -405,7 +443,13 @@ class _$StoreProductImpl implements _StoreProduct {
   /// Offering identifier the store product was presented from
   /// Null if not using offerings or if fetched directly from store via getProducts
   @override
+  @Deprecated('use presentedOfferingContext')
   final String? presentedOfferingIdentifier;
+
+  /// Offering context this package belongs to.
+  /// Null if not using offerings or if fetched directly from store via getProducts
+  @override
+  final PresentedOfferingContext? presentedOfferingContext;
 
   /// Subscription period, specified in ISO 8601 format. For example,
   /// P1W equates to one week, P1M equates to one month,
@@ -417,7 +461,7 @@ class _$StoreProductImpl implements _StoreProduct {
 
   @override
   String toString() {
-    return 'StoreProduct(identifier: $identifier, description: $description, title: $title, price: $price, priceString: $priceString, currencyCode: $currencyCode, introductoryPrice: $introductoryPrice, discounts: $discounts, productCategory: $productCategory, defaultOption: $defaultOption, subscriptionOptions: $subscriptionOptions, presentedOfferingIdentifier: $presentedOfferingIdentifier, subscriptionPeriod: $subscriptionPeriod)';
+    return 'StoreProduct(identifier: $identifier, description: $description, title: $title, price: $price, priceString: $priceString, currencyCode: $currencyCode, introductoryPrice: $introductoryPrice, discounts: $discounts, productCategory: $productCategory, defaultOption: $defaultOption, subscriptionOptions: $subscriptionOptions, presentedOfferingIdentifier: $presentedOfferingIdentifier, presentedOfferingContext: $presentedOfferingContext, subscriptionPeriod: $subscriptionPeriod)';
   }
 
   @override
@@ -449,6 +493,9 @@ class _$StoreProductImpl implements _StoreProduct {
                     presentedOfferingIdentifier) ||
                 other.presentedOfferingIdentifier ==
                     presentedOfferingIdentifier) &&
+            (identical(
+                    other.presentedOfferingContext, presentedOfferingContext) ||
+                other.presentedOfferingContext == presentedOfferingContext) &&
             (identical(other.subscriptionPeriod, subscriptionPeriod) ||
                 other.subscriptionPeriod == subscriptionPeriod));
   }
@@ -469,6 +516,7 @@ class _$StoreProductImpl implements _StoreProduct {
       defaultOption,
       const DeepCollectionEquality().hash(_subscriptionOptions),
       presentedOfferingIdentifier,
+      presentedOfferingContext,
       subscriptionPeriod);
 
   @JsonKey(ignore: true)
@@ -498,7 +546,9 @@ abstract class _StoreProduct implements StoreProduct {
       final ProductCategory? productCategory,
       final SubscriptionOption? defaultOption,
       final List<SubscriptionOption>? subscriptionOptions,
+      @Deprecated('use presentedOfferingContext')
       final String? presentedOfferingIdentifier,
+      final PresentedOfferingContext? presentedOfferingContext,
       final String? subscriptionPeriod}) = _$StoreProductImpl;
 
   factory _StoreProduct.fromJson(Map<String, dynamic> json) =
@@ -554,7 +604,13 @@ abstract class _StoreProduct implements StoreProduct {
 
   /// Offering identifier the store product was presented from
   /// Null if not using offerings or if fetched directly from store via getProducts
+  @Deprecated('use presentedOfferingContext')
   String? get presentedOfferingIdentifier;
+  @override
+
+  /// Offering context this package belongs to.
+  /// Null if not using offerings or if fetched directly from store via getProducts
+  PresentedOfferingContext? get presentedOfferingContext;
   @override
 
   /// Subscription period, specified in ISO 8601 format. For example,

--- a/lib/models/store_product_wrapper.freezed.dart
+++ b/lib/models/store_product_wrapper.freezed.dart
@@ -58,11 +58,6 @@ mixin _$StoreProduct {
   List<SubscriptionOption>? get subscriptionOptions =>
       throw _privateConstructorUsedError;
 
-  /// Offering identifier the store product was presented from
-  /// Null if not using offerings or if fetched directly from store via getProducts
-  @Deprecated('use presentedOfferingContext')
-  String? get presentedOfferingIdentifier => throw _privateConstructorUsedError;
-
   /// Offering context this package belongs to.
   /// Null if not using offerings or if fetched directly from store via getProducts
   PresentedOfferingContext? get presentedOfferingContext =>
@@ -99,8 +94,6 @@ abstract class $StoreProductCopyWith<$Res> {
       ProductCategory? productCategory,
       SubscriptionOption? defaultOption,
       List<SubscriptionOption>? subscriptionOptions,
-      @Deprecated('use presentedOfferingContext')
-      String? presentedOfferingIdentifier,
       PresentedOfferingContext? presentedOfferingContext,
       String? subscriptionPeriod});
 
@@ -133,7 +126,6 @@ class _$StoreProductCopyWithImpl<$Res, $Val extends StoreProduct>
     Object? productCategory = freezed,
     Object? defaultOption = freezed,
     Object? subscriptionOptions = freezed,
-    Object? presentedOfferingIdentifier = freezed,
     Object? presentedOfferingContext = freezed,
     Object? subscriptionPeriod = freezed,
   }) {
@@ -182,10 +174,6 @@ class _$StoreProductCopyWithImpl<$Res, $Val extends StoreProduct>
           ? _value.subscriptionOptions
           : subscriptionOptions // ignore: cast_nullable_to_non_nullable
               as List<SubscriptionOption>?,
-      presentedOfferingIdentifier: freezed == presentedOfferingIdentifier
-          ? _value.presentedOfferingIdentifier
-          : presentedOfferingIdentifier // ignore: cast_nullable_to_non_nullable
-              as String?,
       presentedOfferingContext: freezed == presentedOfferingContext
           ? _value.presentedOfferingContext
           : presentedOfferingContext // ignore: cast_nullable_to_non_nullable
@@ -255,8 +243,6 @@ abstract class _$$StoreProductImplCopyWith<$Res>
       ProductCategory? productCategory,
       SubscriptionOption? defaultOption,
       List<SubscriptionOption>? subscriptionOptions,
-      @Deprecated('use presentedOfferingContext')
-      String? presentedOfferingIdentifier,
       PresentedOfferingContext? presentedOfferingContext,
       String? subscriptionPeriod});
 
@@ -290,7 +276,6 @@ class __$$StoreProductImplCopyWithImpl<$Res>
     Object? productCategory = freezed,
     Object? defaultOption = freezed,
     Object? subscriptionOptions = freezed,
-    Object? presentedOfferingIdentifier = freezed,
     Object? presentedOfferingContext = freezed,
     Object? subscriptionPeriod = freezed,
   }) {
@@ -339,10 +324,6 @@ class __$$StoreProductImplCopyWithImpl<$Res>
           ? _value._subscriptionOptions
           : subscriptionOptions // ignore: cast_nullable_to_non_nullable
               as List<SubscriptionOption>?,
-      presentedOfferingIdentifier: freezed == presentedOfferingIdentifier
-          ? _value.presentedOfferingIdentifier
-          : presentedOfferingIdentifier // ignore: cast_nullable_to_non_nullable
-              as String?,
       presentedOfferingContext: freezed == presentedOfferingContext
           ? _value.presentedOfferingContext
           : presentedOfferingContext // ignore: cast_nullable_to_non_nullable
@@ -365,8 +346,6 @@ class _$StoreProductImpl implements _StoreProduct {
       this.productCategory,
       this.defaultOption,
       final List<SubscriptionOption>? subscriptionOptions,
-      @Deprecated('use presentedOfferingContext')
-      this.presentedOfferingIdentifier,
       this.presentedOfferingContext,
       this.subscriptionPeriod})
       : _discounts = discounts,
@@ -440,12 +419,6 @@ class _$StoreProductImpl implements _StoreProduct {
     return EqualUnmodifiableListView(value);
   }
 
-  /// Offering identifier the store product was presented from
-  /// Null if not using offerings or if fetched directly from store via getProducts
-  @override
-  @Deprecated('use presentedOfferingContext')
-  final String? presentedOfferingIdentifier;
-
   /// Offering context this package belongs to.
   /// Null if not using offerings or if fetched directly from store via getProducts
   @override
@@ -461,7 +434,7 @@ class _$StoreProductImpl implements _StoreProduct {
 
   @override
   String toString() {
-    return 'StoreProduct(identifier: $identifier, description: $description, title: $title, price: $price, priceString: $priceString, currencyCode: $currencyCode, introductoryPrice: $introductoryPrice, discounts: $discounts, productCategory: $productCategory, defaultOption: $defaultOption, subscriptionOptions: $subscriptionOptions, presentedOfferingIdentifier: $presentedOfferingIdentifier, presentedOfferingContext: $presentedOfferingContext, subscriptionPeriod: $subscriptionPeriod)';
+    return 'StoreProduct(identifier: $identifier, description: $description, title: $title, price: $price, priceString: $priceString, currencyCode: $currencyCode, introductoryPrice: $introductoryPrice, discounts: $discounts, productCategory: $productCategory, defaultOption: $defaultOption, subscriptionOptions: $subscriptionOptions, presentedOfferingContext: $presentedOfferingContext, subscriptionPeriod: $subscriptionPeriod)';
   }
 
   @override
@@ -489,10 +462,6 @@ class _$StoreProductImpl implements _StoreProduct {
                 other.defaultOption == defaultOption) &&
             const DeepCollectionEquality()
                 .equals(other._subscriptionOptions, _subscriptionOptions) &&
-            (identical(other.presentedOfferingIdentifier,
-                    presentedOfferingIdentifier) ||
-                other.presentedOfferingIdentifier ==
-                    presentedOfferingIdentifier) &&
             (identical(
                     other.presentedOfferingContext, presentedOfferingContext) ||
                 other.presentedOfferingContext == presentedOfferingContext) &&
@@ -515,7 +484,6 @@ class _$StoreProductImpl implements _StoreProduct {
       productCategory,
       defaultOption,
       const DeepCollectionEquality().hash(_subscriptionOptions),
-      presentedOfferingIdentifier,
       presentedOfferingContext,
       subscriptionPeriod);
 
@@ -546,8 +514,6 @@ abstract class _StoreProduct implements StoreProduct {
       final ProductCategory? productCategory,
       final SubscriptionOption? defaultOption,
       final List<SubscriptionOption>? subscriptionOptions,
-      @Deprecated('use presentedOfferingContext')
-      final String? presentedOfferingIdentifier,
       final PresentedOfferingContext? presentedOfferingContext,
       final String? subscriptionPeriod}) = _$StoreProductImpl;
 
@@ -600,12 +566,6 @@ abstract class _StoreProduct implements StoreProduct {
 
   /// Collection of subscription options for a product. Google Play only.
   List<SubscriptionOption>? get subscriptionOptions;
-  @override
-
-  /// Offering identifier the store product was presented from
-  /// Null if not using offerings or if fetched directly from store via getProducts
-  @Deprecated('use presentedOfferingContext')
-  String? get presentedOfferingIdentifier;
   @override
 
   /// Offering context this package belongs to.

--- a/lib/models/store_product_wrapper.g.dart
+++ b/lib/models/store_product_wrapper.g.dart
@@ -33,6 +33,10 @@ _$StoreProductImpl _$$StoreProductImplFromJson(Map json) => _$StoreProductImpl(
           .toList(),
       presentedOfferingIdentifier:
           json['presentedOfferingIdentifier'] as String?,
+      presentedOfferingContext: json['presentedOfferingContext'] == null
+          ? null
+          : PresentedOfferingContext.fromJson(Map<String, dynamic>.from(
+              json['presentedOfferingContext'] as Map)),
       subscriptionPeriod: json['subscriptionPeriod'] as String?,
     );
 
@@ -51,6 +55,7 @@ Map<String, dynamic> _$$StoreProductImplToJson(_$StoreProductImpl instance) =>
       'subscriptionOptions':
           instance.subscriptionOptions?.map((e) => e.toJson()).toList(),
       'presentedOfferingIdentifier': instance.presentedOfferingIdentifier,
+      'presentedOfferingContext': instance.presentedOfferingContext?.toJson(),
       'subscriptionPeriod': instance.subscriptionPeriod,
     };
 

--- a/lib/models/store_product_wrapper.g.dart
+++ b/lib/models/store_product_wrapper.g.dart
@@ -31,8 +31,6 @@ _$StoreProductImpl _$$StoreProductImplFromJson(Map json) => _$StoreProductImpl(
           ?.map((e) =>
               SubscriptionOption.fromJson(Map<String, dynamic>.from(e as Map)))
           .toList(),
-      presentedOfferingIdentifier:
-          json['presentedOfferingIdentifier'] as String?,
       presentedOfferingContext: json['presentedOfferingContext'] == null
           ? null
           : PresentedOfferingContext.fromJson(Map<String, dynamic>.from(
@@ -54,7 +52,6 @@ Map<String, dynamic> _$$StoreProductImplToJson(_$StoreProductImpl instance) =>
       'defaultOption': instance.defaultOption?.toJson(),
       'subscriptionOptions':
           instance.subscriptionOptions?.map((e) => e.toJson()).toList(),
-      'presentedOfferingIdentifier': instance.presentedOfferingIdentifier,
       'presentedOfferingContext': instance.presentedOfferingContext?.toJson(),
       'subscriptionPeriod': instance.subscriptionPeriod,
     };

--- a/lib/models/subscription_option_wrapper.dart
+++ b/lib/models/subscription_option_wrapper.dart
@@ -68,6 +68,6 @@ extension ExtendedSubscriptionOption on SubscriptionOption {
   /// Offering this package belongs to.
   /// Null if not using offerings or if fetched directly from store via getProducts
   @Deprecated('use presentedOfferingContext')
-  String? get offeringIdentifier =>
+  String? get presentedOfferingIdentifier =>
       presentedOfferingContext?.offeringIdentifier;
 }

--- a/lib/models/subscription_option_wrapper.dart
+++ b/lib/models/subscription_option_wrapper.dart
@@ -55,10 +55,6 @@ class SubscriptionOption with _$SubscriptionOption {
     /// There can be a freeTrialPhase and an introductoryPhase in the same SubscriptionOption.
     PricingPhase? introPhase,
 
-    // Offering identifier the subscriptioni option was presented from
-    @Deprecated('use presentedOfferingContext')
-    String? presentedOfferingIdentifier,
-
     /// Offering context this package belongs to.
     /// Null if not using offerings or if fetched directly from store via getProducts
     PresentedOfferingContext? presentedOfferingContext,
@@ -66,4 +62,12 @@ class SubscriptionOption with _$SubscriptionOption {
 
   factory SubscriptionOption.fromJson(Map<String, dynamic> json) =>
       _$SubscriptionOptionFromJson(json);
+}
+
+extension ExtendedSubscriptionOption on SubscriptionOption {
+  /// Offering this package belongs to.
+  /// Null if not using offerings or if fetched directly from store via getProducts
+  @Deprecated('use presentedOfferingContext')
+  String? get offeringIdentifier =>
+      presentedOfferingContext?.offeringIdentifier;
 }

--- a/lib/models/subscription_option_wrapper.dart
+++ b/lib/models/subscription_option_wrapper.dart
@@ -1,6 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 import 'period_wrapper.dart';
+import 'presented_offering_context_wrapper.dart';
 import 'pricing_phase_wrapper.dart';
 
 part 'subscription_option_wrapper.freezed.dart';
@@ -55,7 +56,12 @@ class SubscriptionOption with _$SubscriptionOption {
     PricingPhase? introPhase,
 
     // Offering identifier the subscriptioni option was presented from
+    @Deprecated('use presentedOfferingContext')
     String? presentedOfferingIdentifier,
+
+    /// Offering context this package belongs to.
+    /// Null if not using offerings or if fetched directly from store via getProducts
+    PresentedOfferingContext? presentedOfferingContext,
   ) = _SubscriptionOption;
 
   factory SubscriptionOption.fromJson(Map<String, dynamic> json) =>

--- a/lib/models/subscription_option_wrapper.freezed.dart
+++ b/lib/models/subscription_option_wrapper.freezed.dart
@@ -60,10 +60,7 @@ mixin _$SubscriptionOption {
   /// The intro trial PricingPhase of the subscription.
   /// Looks for the first pricing phase of the SubscriptionOption where amountMicros is greater than 0.
   /// There can be a freeTrialPhase and an introductoryPhase in the same SubscriptionOption.
-  PricingPhase? get introPhase =>
-      throw _privateConstructorUsedError; // Offering identifier the subscriptioni option was presented from
-  @Deprecated('use presentedOfferingContext')
-  String? get presentedOfferingIdentifier => throw _privateConstructorUsedError;
+  PricingPhase? get introPhase => throw _privateConstructorUsedError;
 
   /// Offering context this package belongs to.
   /// Null if not using offerings or if fetched directly from store via getProducts
@@ -94,8 +91,6 @@ abstract class $SubscriptionOptionCopyWith<$Res> {
       PricingPhase? fullPricePhase,
       PricingPhase? freePhase,
       PricingPhase? introPhase,
-      @Deprecated('use presentedOfferingContext')
-      String? presentedOfferingIdentifier,
       PresentedOfferingContext? presentedOfferingContext});
 
   $PeriodCopyWith<$Res>? get billingPeriod;
@@ -129,7 +124,6 @@ class _$SubscriptionOptionCopyWithImpl<$Res, $Val extends SubscriptionOption>
     Object? fullPricePhase = freezed,
     Object? freePhase = freezed,
     Object? introPhase = freezed,
-    Object? presentedOfferingIdentifier = freezed,
     Object? presentedOfferingContext = freezed,
   }) {
     return _then(_value.copyWith(
@@ -177,10 +171,6 @@ class _$SubscriptionOptionCopyWithImpl<$Res, $Val extends SubscriptionOption>
           ? _value.introPhase
           : introPhase // ignore: cast_nullable_to_non_nullable
               as PricingPhase?,
-      presentedOfferingIdentifier: freezed == presentedOfferingIdentifier
-          ? _value.presentedOfferingIdentifier
-          : presentedOfferingIdentifier // ignore: cast_nullable_to_non_nullable
-              as String?,
       presentedOfferingContext: freezed == presentedOfferingContext
           ? _value.presentedOfferingContext
           : presentedOfferingContext // ignore: cast_nullable_to_non_nullable
@@ -270,8 +260,6 @@ abstract class _$$SubscriptionOptionImplCopyWith<$Res>
       PricingPhase? fullPricePhase,
       PricingPhase? freePhase,
       PricingPhase? introPhase,
-      @Deprecated('use presentedOfferingContext')
-      String? presentedOfferingIdentifier,
       PresentedOfferingContext? presentedOfferingContext});
 
   @override
@@ -308,7 +296,6 @@ class __$$SubscriptionOptionImplCopyWithImpl<$Res>
     Object? fullPricePhase = freezed,
     Object? freePhase = freezed,
     Object? introPhase = freezed,
-    Object? presentedOfferingIdentifier = freezed,
     Object? presentedOfferingContext = freezed,
   }) {
     return _then(_$SubscriptionOptionImpl(
@@ -356,10 +343,6 @@ class __$$SubscriptionOptionImplCopyWithImpl<$Res>
           ? _value.introPhase
           : introPhase // ignore: cast_nullable_to_non_nullable
               as PricingPhase?,
-      freezed == presentedOfferingIdentifier
-          ? _value.presentedOfferingIdentifier
-          : presentedOfferingIdentifier // ignore: cast_nullable_to_non_nullable
-              as String?,
       freezed == presentedOfferingContext
           ? _value.presentedOfferingContext
           : presentedOfferingContext // ignore: cast_nullable_to_non_nullable
@@ -383,8 +366,6 @@ class _$SubscriptionOptionImpl implements _SubscriptionOption {
       this.fullPricePhase,
       this.freePhase,
       this.introPhase,
-      @Deprecated('use presentedOfferingContext')
-      this.presentedOfferingIdentifier,
       this.presentedOfferingContext)
       : _pricingPhases = pricingPhases,
         _tags = tags;
@@ -458,10 +439,6 @@ class _$SubscriptionOptionImpl implements _SubscriptionOption {
   /// There can be a freeTrialPhase and an introductoryPhase in the same SubscriptionOption.
   @override
   final PricingPhase? introPhase;
-// Offering identifier the subscriptioni option was presented from
-  @override
-  @Deprecated('use presentedOfferingContext')
-  final String? presentedOfferingIdentifier;
 
   /// Offering context this package belongs to.
   /// Null if not using offerings or if fetched directly from store via getProducts
@@ -470,7 +447,7 @@ class _$SubscriptionOptionImpl implements _SubscriptionOption {
 
   @override
   String toString() {
-    return 'SubscriptionOption(id: $id, storeProductId: $storeProductId, productId: $productId, pricingPhases: $pricingPhases, tags: $tags, isBasePlan: $isBasePlan, billingPeriod: $billingPeriod, isPrepaid: $isPrepaid, fullPricePhase: $fullPricePhase, freePhase: $freePhase, introPhase: $introPhase, presentedOfferingIdentifier: $presentedOfferingIdentifier, presentedOfferingContext: $presentedOfferingContext)';
+    return 'SubscriptionOption(id: $id, storeProductId: $storeProductId, productId: $productId, pricingPhases: $pricingPhases, tags: $tags, isBasePlan: $isBasePlan, billingPeriod: $billingPeriod, isPrepaid: $isPrepaid, fullPricePhase: $fullPricePhase, freePhase: $freePhase, introPhase: $introPhase, presentedOfferingContext: $presentedOfferingContext)';
   }
 
   @override
@@ -498,10 +475,6 @@ class _$SubscriptionOptionImpl implements _SubscriptionOption {
                 other.freePhase == freePhase) &&
             (identical(other.introPhase, introPhase) ||
                 other.introPhase == introPhase) &&
-            (identical(other.presentedOfferingIdentifier,
-                    presentedOfferingIdentifier) ||
-                other.presentedOfferingIdentifier ==
-                    presentedOfferingIdentifier) &&
             (identical(
                     other.presentedOfferingContext, presentedOfferingContext) ||
                 other.presentedOfferingContext == presentedOfferingContext));
@@ -522,7 +495,6 @@ class _$SubscriptionOptionImpl implements _SubscriptionOption {
       fullPricePhase,
       freePhase,
       introPhase,
-      presentedOfferingIdentifier,
       presentedOfferingContext);
 
   @JsonKey(ignore: true)
@@ -553,8 +525,6 @@ abstract class _SubscriptionOption implements SubscriptionOption {
           final PricingPhase? fullPricePhase,
           final PricingPhase? freePhase,
           final PricingPhase? introPhase,
-          @Deprecated('use presentedOfferingContext')
-          final String? presentedOfferingIdentifier,
           final PresentedOfferingContext? presentedOfferingContext) =
       _$SubscriptionOptionImpl;
 
@@ -614,9 +584,6 @@ abstract class _SubscriptionOption implements SubscriptionOption {
   /// Looks for the first pricing phase of the SubscriptionOption where amountMicros is greater than 0.
   /// There can be a freeTrialPhase and an introductoryPhase in the same SubscriptionOption.
   PricingPhase? get introPhase;
-  @override // Offering identifier the subscriptioni option was presented from
-  @Deprecated('use presentedOfferingContext')
-  String? get presentedOfferingIdentifier;
   @override
 
   /// Offering context this package belongs to.

--- a/lib/models/subscription_option_wrapper.freezed.dart
+++ b/lib/models/subscription_option_wrapper.freezed.dart
@@ -62,7 +62,13 @@ mixin _$SubscriptionOption {
   /// There can be a freeTrialPhase and an introductoryPhase in the same SubscriptionOption.
   PricingPhase? get introPhase =>
       throw _privateConstructorUsedError; // Offering identifier the subscriptioni option was presented from
+  @Deprecated('use presentedOfferingContext')
   String? get presentedOfferingIdentifier => throw _privateConstructorUsedError;
+
+  /// Offering context this package belongs to.
+  /// Null if not using offerings or if fetched directly from store via getProducts
+  PresentedOfferingContext? get presentedOfferingContext =>
+      throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -88,12 +94,15 @@ abstract class $SubscriptionOptionCopyWith<$Res> {
       PricingPhase? fullPricePhase,
       PricingPhase? freePhase,
       PricingPhase? introPhase,
-      String? presentedOfferingIdentifier});
+      @Deprecated('use presentedOfferingContext')
+      String? presentedOfferingIdentifier,
+      PresentedOfferingContext? presentedOfferingContext});
 
   $PeriodCopyWith<$Res>? get billingPeriod;
   $PricingPhaseCopyWith<$Res>? get fullPricePhase;
   $PricingPhaseCopyWith<$Res>? get freePhase;
   $PricingPhaseCopyWith<$Res>? get introPhase;
+  $PresentedOfferingContextCopyWith<$Res>? get presentedOfferingContext;
 }
 
 /// @nodoc
@@ -121,6 +130,7 @@ class _$SubscriptionOptionCopyWithImpl<$Res, $Val extends SubscriptionOption>
     Object? freePhase = freezed,
     Object? introPhase = freezed,
     Object? presentedOfferingIdentifier = freezed,
+    Object? presentedOfferingContext = freezed,
   }) {
     return _then(_value.copyWith(
       id: null == id
@@ -171,6 +181,10 @@ class _$SubscriptionOptionCopyWithImpl<$Res, $Val extends SubscriptionOption>
           ? _value.presentedOfferingIdentifier
           : presentedOfferingIdentifier // ignore: cast_nullable_to_non_nullable
               as String?,
+      presentedOfferingContext: freezed == presentedOfferingContext
+          ? _value.presentedOfferingContext
+          : presentedOfferingContext // ignore: cast_nullable_to_non_nullable
+              as PresentedOfferingContext?,
     ) as $Val);
   }
 
@@ -221,6 +235,19 @@ class _$SubscriptionOptionCopyWithImpl<$Res, $Val extends SubscriptionOption>
       return _then(_value.copyWith(introPhase: value) as $Val);
     });
   }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $PresentedOfferingContextCopyWith<$Res>? get presentedOfferingContext {
+    if (_value.presentedOfferingContext == null) {
+      return null;
+    }
+
+    return $PresentedOfferingContextCopyWith<$Res>(
+        _value.presentedOfferingContext!, (value) {
+      return _then(_value.copyWith(presentedOfferingContext: value) as $Val);
+    });
+  }
 }
 
 /// @nodoc
@@ -243,7 +270,9 @@ abstract class _$$SubscriptionOptionImplCopyWith<$Res>
       PricingPhase? fullPricePhase,
       PricingPhase? freePhase,
       PricingPhase? introPhase,
-      String? presentedOfferingIdentifier});
+      @Deprecated('use presentedOfferingContext')
+      String? presentedOfferingIdentifier,
+      PresentedOfferingContext? presentedOfferingContext});
 
   @override
   $PeriodCopyWith<$Res>? get billingPeriod;
@@ -253,6 +282,8 @@ abstract class _$$SubscriptionOptionImplCopyWith<$Res>
   $PricingPhaseCopyWith<$Res>? get freePhase;
   @override
   $PricingPhaseCopyWith<$Res>? get introPhase;
+  @override
+  $PresentedOfferingContextCopyWith<$Res>? get presentedOfferingContext;
 }
 
 /// @nodoc
@@ -278,6 +309,7 @@ class __$$SubscriptionOptionImplCopyWithImpl<$Res>
     Object? freePhase = freezed,
     Object? introPhase = freezed,
     Object? presentedOfferingIdentifier = freezed,
+    Object? presentedOfferingContext = freezed,
   }) {
     return _then(_$SubscriptionOptionImpl(
       null == id
@@ -328,6 +360,10 @@ class __$$SubscriptionOptionImplCopyWithImpl<$Res>
           ? _value.presentedOfferingIdentifier
           : presentedOfferingIdentifier // ignore: cast_nullable_to_non_nullable
               as String?,
+      freezed == presentedOfferingContext
+          ? _value.presentedOfferingContext
+          : presentedOfferingContext // ignore: cast_nullable_to_non_nullable
+              as PresentedOfferingContext?,
     ));
   }
 }
@@ -347,7 +383,9 @@ class _$SubscriptionOptionImpl implements _SubscriptionOption {
       this.fullPricePhase,
       this.freePhase,
       this.introPhase,
-      this.presentedOfferingIdentifier)
+      @Deprecated('use presentedOfferingContext')
+      this.presentedOfferingIdentifier,
+      this.presentedOfferingContext)
       : _pricingPhases = pricingPhases,
         _tags = tags;
 
@@ -422,11 +460,17 @@ class _$SubscriptionOptionImpl implements _SubscriptionOption {
   final PricingPhase? introPhase;
 // Offering identifier the subscriptioni option was presented from
   @override
+  @Deprecated('use presentedOfferingContext')
   final String? presentedOfferingIdentifier;
+
+  /// Offering context this package belongs to.
+  /// Null if not using offerings or if fetched directly from store via getProducts
+  @override
+  final PresentedOfferingContext? presentedOfferingContext;
 
   @override
   String toString() {
-    return 'SubscriptionOption(id: $id, storeProductId: $storeProductId, productId: $productId, pricingPhases: $pricingPhases, tags: $tags, isBasePlan: $isBasePlan, billingPeriod: $billingPeriod, isPrepaid: $isPrepaid, fullPricePhase: $fullPricePhase, freePhase: $freePhase, introPhase: $introPhase, presentedOfferingIdentifier: $presentedOfferingIdentifier)';
+    return 'SubscriptionOption(id: $id, storeProductId: $storeProductId, productId: $productId, pricingPhases: $pricingPhases, tags: $tags, isBasePlan: $isBasePlan, billingPeriod: $billingPeriod, isPrepaid: $isPrepaid, fullPricePhase: $fullPricePhase, freePhase: $freePhase, introPhase: $introPhase, presentedOfferingIdentifier: $presentedOfferingIdentifier, presentedOfferingContext: $presentedOfferingContext)';
   }
 
   @override
@@ -457,7 +501,10 @@ class _$SubscriptionOptionImpl implements _SubscriptionOption {
             (identical(other.presentedOfferingIdentifier,
                     presentedOfferingIdentifier) ||
                 other.presentedOfferingIdentifier ==
-                    presentedOfferingIdentifier));
+                    presentedOfferingIdentifier) &&
+            (identical(
+                    other.presentedOfferingContext, presentedOfferingContext) ||
+                other.presentedOfferingContext == presentedOfferingContext));
   }
 
   @JsonKey(ignore: true)
@@ -475,7 +522,8 @@ class _$SubscriptionOptionImpl implements _SubscriptionOption {
       fullPricePhase,
       freePhase,
       introPhase,
-      presentedOfferingIdentifier);
+      presentedOfferingIdentifier,
+      presentedOfferingContext);
 
   @JsonKey(ignore: true)
   @override
@@ -494,18 +542,21 @@ class _$SubscriptionOptionImpl implements _SubscriptionOption {
 
 abstract class _SubscriptionOption implements SubscriptionOption {
   const factory _SubscriptionOption(
-      final String id,
-      final String storeProductId,
-      final String productId,
-      final List<PricingPhase> pricingPhases,
-      final List<String> tags,
-      final bool isBasePlan,
-      final Period? billingPeriod,
-      final bool isPrepaid,
-      final PricingPhase? fullPricePhase,
-      final PricingPhase? freePhase,
-      final PricingPhase? introPhase,
-      final String? presentedOfferingIdentifier) = _$SubscriptionOptionImpl;
+          final String id,
+          final String storeProductId,
+          final String productId,
+          final List<PricingPhase> pricingPhases,
+          final List<String> tags,
+          final bool isBasePlan,
+          final Period? billingPeriod,
+          final bool isPrepaid,
+          final PricingPhase? fullPricePhase,
+          final PricingPhase? freePhase,
+          final PricingPhase? introPhase,
+          @Deprecated('use presentedOfferingContext')
+          final String? presentedOfferingIdentifier,
+          final PresentedOfferingContext? presentedOfferingContext) =
+      _$SubscriptionOptionImpl;
 
   factory _SubscriptionOption.fromJson(Map<String, dynamic> json) =
       _$SubscriptionOptionImpl.fromJson;
@@ -564,7 +615,13 @@ abstract class _SubscriptionOption implements SubscriptionOption {
   /// There can be a freeTrialPhase and an introductoryPhase in the same SubscriptionOption.
   PricingPhase? get introPhase;
   @override // Offering identifier the subscriptioni option was presented from
+  @Deprecated('use presentedOfferingContext')
   String? get presentedOfferingIdentifier;
+  @override
+
+  /// Offering context this package belongs to.
+  /// Null if not using offerings or if fetched directly from store via getProducts
+  PresentedOfferingContext? get presentedOfferingContext;
   @override
   @JsonKey(ignore: true)
   _$$SubscriptionOptionImplCopyWith<_$SubscriptionOptionImpl> get copyWith =>

--- a/lib/models/subscription_option_wrapper.g.dart
+++ b/lib/models/subscription_option_wrapper.g.dart
@@ -34,7 +34,6 @@ _$SubscriptionOptionImpl _$$SubscriptionOptionImplFromJson(Map json) =>
           ? null
           : PricingPhase.fromJson(
               Map<String, dynamic>.from(json['introPhase'] as Map)),
-      json['presentedOfferingIdentifier'] as String?,
       json['presentedOfferingContext'] == null
           ? null
           : PresentedOfferingContext.fromJson(Map<String, dynamic>.from(
@@ -55,6 +54,5 @@ Map<String, dynamic> _$$SubscriptionOptionImplToJson(
       'fullPricePhase': instance.fullPricePhase?.toJson(),
       'freePhase': instance.freePhase?.toJson(),
       'introPhase': instance.introPhase?.toJson(),
-      'presentedOfferingIdentifier': instance.presentedOfferingIdentifier,
       'presentedOfferingContext': instance.presentedOfferingContext?.toJson(),
     };

--- a/lib/models/subscription_option_wrapper.g.dart
+++ b/lib/models/subscription_option_wrapper.g.dart
@@ -35,6 +35,10 @@ _$SubscriptionOptionImpl _$$SubscriptionOptionImplFromJson(Map json) =>
           : PricingPhase.fromJson(
               Map<String, dynamic>.from(json['introPhase'] as Map)),
       json['presentedOfferingIdentifier'] as String?,
+      json['presentedOfferingContext'] == null
+          ? null
+          : PresentedOfferingContext.fromJson(Map<String, dynamic>.from(
+              json['presentedOfferingContext'] as Map)),
     );
 
 Map<String, dynamic> _$$SubscriptionOptionImplToJson(
@@ -52,4 +56,5 @@ Map<String, dynamic> _$$SubscriptionOptionImplToJson(
       'freePhase': instance.freePhase?.toJson(),
       'introPhase': instance.introPhase?.toJson(),
       'presentedOfferingIdentifier': instance.presentedOfferingIdentifier,
+      'presentedOfferingContext': instance.presentedOfferingContext?.toJson(),
     };

--- a/lib/object_wrappers.dart
+++ b/lib/object_wrappers.dart
@@ -10,6 +10,8 @@ export 'models/offerings_wrapper.dart';
 export 'models/package_wrapper.dart';
 export 'models/period_unit.dart';
 export 'models/period_wrapper.dart';
+export 'models/presented_offering_context_wrapper.dart';
+export 'models/presented_offering_targeting_context_wrapper.dart';
 export 'models/price_wrapper.dart';
 export 'models/pricing_phase_wrapper.dart';
 export 'models/product_category.dart';

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -347,7 +347,8 @@ class Purchases {
           googleProductChangeInfo?.oldProductIdentifier,
       'googleProrationMode': prorationMode,
       'googleIsPersonalizedPrice': googleIsPersonalizedPrice,
-      'presentedOfferingContext': storeProduct.presentedOfferingContext,
+      'presentedOfferingIdentifier':
+          storeProduct.presentedOfferingContext?.offeringIdentifier,
     });
 
     return customerInfo;
@@ -384,7 +385,8 @@ class Purchases {
         upgradeInfo?.prorationMode?.index;
     final customerInfo = await _invokeReturningCustomerInfo('purchasePackage', {
       'packageIdentifier': packageToPurchase.identifier,
-      'presentedOfferingContext': packageToPurchase.presentedOfferingContext,
+      'offeringIdentifier':
+          packageToPurchase.presentedOfferingContext.offeringIdentifier,
       'googleOldProductIdentifier':
           googleProductChangeInfo?.oldProductIdentifier ?? upgradeInfo?.oldSKU,
       'googleProrationMode': prorationMode,
@@ -432,7 +434,8 @@ class Purchases {
           googleProductChangeInfo?.oldProductIdentifier,
       'googleProrationMode': prorationMode,
       'googleIsPersonalizedPrice': googleIsPersonalizedPrice,
-      'presentedOfferingContext': subscriptionOption.presentedOfferingContext,
+      'presentedOfferingIdentifier':
+          subscriptionOption.presentedOfferingContext?.offeringIdentifier,
     });
     return customerInfo;
   }
@@ -456,7 +459,8 @@ class Purchases {
     final customerInfo = await _invokeReturningCustomerInfo('purchaseProduct', {
       'productIdentifier': product.identifier,
       'signedDiscountTimestamp': promotionalOffer.timestamp.toString(),
-      'presentedOfferingContext': product.presentedOfferingContext,
+      'presentedOfferingIdentifier':
+          product.presentedOfferingContext?.offeringIdentifier,
     });
     return customerInfo;
   }
@@ -479,7 +483,8 @@ class Purchases {
   ) async {
     final customerInfo = await _invokeReturningCustomerInfo('purchasePackage', {
       'packageIdentifier': packageToPurchase.identifier,
-      'presentedOfferingContext': packageToPurchase.presentedOfferingContext,
+      'offeringContext':
+          packageToPurchase.presentedOfferingContext.offeringIdentifier,
       'signedDiscountTimestamp': promotionalOffer.timestamp.toString(),
     });
     return customerInfo;

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -238,6 +238,27 @@ class Purchases {
     );
   }
 
+  static Future<Offering?> getCurrentOfferingForPlacement(
+      String placementIdentifier) async {
+    final res = await _channel.invokeMethod('getCurrentOfferingForPlacement',
+        {'placementIdentifier': placementIdentifier});
+    if (res != null) {
+      return Offering.fromJson(
+        Map<String, dynamic>.from(res),
+      );
+    } else {
+      return null;
+    }
+  }
+
+  static Future<Offerings> syncAttributesAndOfferingsIfNeeded() async {
+    final res =
+        await _channel.invokeMethod('syncAttributesAndOfferingsIfNeeded');
+    return Offerings.fromJson(
+      Map<String, dynamic>.from(res),
+    );
+  }
+
   /// Fetch the product info. Returns a list of products or throws an error if
   /// the products are not properly configured in RevenueCat or if there is
   /// another error while retrieving them.

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -385,8 +385,8 @@ class Purchases {
         upgradeInfo?.prorationMode?.index;
     final customerInfo = await _invokeReturningCustomerInfo('purchasePackage', {
       'packageIdentifier': packageToPurchase.identifier,
-      'offeringIdentifier':
-          packageToPurchase.presentedOfferingContext.offeringIdentifier,
+      'presentedOfferingContext':
+          packageToPurchase.presentedOfferingContext.toJson(),
       'googleOldProductIdentifier':
           googleProductChangeInfo?.oldProductIdentifier ?? upgradeInfo?.oldSKU,
       'googleProrationMode': prorationMode,

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -238,6 +238,8 @@ class Purchases {
     );
   }
 
+  /// Retrieves a current offering for a placement identifier, use this to access offerings defined by targeting
+  /// placements configured in the RevenueCat dashboard.
   static Future<Offering?> getCurrentOfferingForPlacement(
     String placementIdentifier,
   ) async {
@@ -254,6 +256,9 @@ class Purchases {
     }
   }
 
+  /// Syncs subscriber attributes and then fetches the configured offerings for this user. This method is intended to
+  /// be called when using Targeting Rules with Custom Attributes. Any subscriber attributes should be set before
+  /// calling this method to ensure the returned offerings are applied with the latest subscriber attributes.
   static Future<Offerings> syncAttributesAndOfferingsIfNeeded() async {
     final res =
         await _channel.invokeMethod('syncAttributesAndOfferingsIfNeeded');

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -239,9 +239,12 @@ class Purchases {
   }
 
   static Future<Offering?> getCurrentOfferingForPlacement(
-      String placementIdentifier) async {
-    final res = await _channel.invokeMethod('getCurrentOfferingForPlacement',
-        {'placementIdentifier': placementIdentifier});
+    String placementIdentifier,
+  ) async {
+    final res = await _channel.invokeMethod(
+      'getCurrentOfferingForPlacement',
+      {'placementIdentifier': placementIdentifier},
+    );
     if (res != null) {
       return Offering.fromJson(
         Map<String, dynamic>.from(res),

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -143,8 +143,10 @@ class Purchases {
           'usesStoreKit2IfAvailable':
               // ignore: deprecated_member_use_from_same_package
               purchasesConfiguration.usesStoreKit2IfAvailable,
-          'shouldShowInAppMessagesAutomatically': purchasesConfiguration.shouldShowInAppMessagesAutomatically,
-          'entitlementVerificationMode': purchasesConfiguration.entitlementVerificationMode.name,
+          'shouldShowInAppMessagesAutomatically':
+              purchasesConfiguration.shouldShowInAppMessagesAutomatically,
+          'entitlementVerificationMode':
+              purchasesConfiguration.entitlementVerificationMode.name,
         },
       );
 
@@ -345,7 +347,7 @@ class Purchases {
           googleProductChangeInfo?.oldProductIdentifier,
       'googleProrationMode': prorationMode,
       'googleIsPersonalizedPrice': googleIsPersonalizedPrice,
-      'presentedOfferingIdentifier': storeProduct.presentedOfferingIdentifier,
+      'presentedOfferingContext': storeProduct.presentedOfferingContext,
     });
 
     return customerInfo;
@@ -382,7 +384,7 @@ class Purchases {
         upgradeInfo?.prorationMode?.index;
     final customerInfo = await _invokeReturningCustomerInfo('purchasePackage', {
       'packageIdentifier': packageToPurchase.identifier,
-      'offeringIdentifier': packageToPurchase.offeringIdentifier,
+      'presentedOfferingContext': packageToPurchase.presentedOfferingContext,
       'googleOldProductIdentifier':
           googleProductChangeInfo?.oldProductIdentifier ?? upgradeInfo?.oldSKU,
       'googleProrationMode': prorationMode,
@@ -430,8 +432,7 @@ class Purchases {
           googleProductChangeInfo?.oldProductIdentifier,
       'googleProrationMode': prorationMode,
       'googleIsPersonalizedPrice': googleIsPersonalizedPrice,
-      'presentedOfferingIdentifier':
-          subscriptionOption.presentedOfferingIdentifier,
+      'presentedOfferingContext': subscriptionOption.presentedOfferingContext,
     });
     return customerInfo;
   }
@@ -455,7 +456,7 @@ class Purchases {
     final customerInfo = await _invokeReturningCustomerInfo('purchaseProduct', {
       'productIdentifier': product.identifier,
       'signedDiscountTimestamp': promotionalOffer.timestamp.toString(),
-      'presentedOfferingIdentifier': product.presentedOfferingIdentifier,
+      'presentedOfferingContext': product.presentedOfferingContext,
     });
     return customerInfo;
   }
@@ -478,7 +479,7 @@ class Purchases {
   ) async {
     final customerInfo = await _invokeReturningCustomerInfo('purchasePackage', {
       'packageIdentifier': packageToPurchase.identifier,
-      'offeringIdentifier': packageToPurchase.offeringIdentifier,
+      'presentedOfferingContext': packageToPurchase.presentedOfferingContext,
       'signedDiscountTimestamp': promotionalOffer.timestamp.toString(),
     });
     return customerInfo;

--- a/revenuecat_examples/purchase_tester/lib/src/constant.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/constant.dart
@@ -1,8 +1,8 @@
 //TO DO: add the Apple API key for your app from the RevenueCat dashboard: https://app.revenuecat.com
-const appleApiKey = 'appl_KFpRDwauDyfIGIETKyVymslMcjX';
+const appleApiKey = 'appl_api_key';
 
 //TO DO: add the Google API key for your app from the RevenueCat dashboard: https://app.revenuecat.com
-const googleApiKey = 'goog_cRtaFpfwfcQYPXkIEqFUkVszUfN';
+const googleApiKey = 'googl_api_key';
 
 //TO DO: add the Amazon API key for your app from the RevenueCat dashboard: https://app.revenuecat.com
 const amazonApiKey = 'amazon_api_key';

--- a/revenuecat_examples/purchase_tester/lib/src/constant.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/constant.dart
@@ -1,8 +1,8 @@
 //TO DO: add the Apple API key for your app from the RevenueCat dashboard: https://app.revenuecat.com
-const appleApiKey = 'appl_api_key';
+const appleApiKey = 'appl_KFpRDwauDyfIGIETKyVymslMcjX';
 
 //TO DO: add the Google API key for your app from the RevenueCat dashboard: https://app.revenuecat.com
-const googleApiKey = 'googl_api_key';
+const googleApiKey = 'goog_cRtaFpfwfcQYPXkIEqFUkVszUfN';
 
 //TO DO: add the Amazon API key for your app from the RevenueCat dashboard: https://app.revenuecat.com
 const amazonApiKey = 'amazon_api_key';

--- a/revenuecat_examples/purchase_tester/lib/src/upsell.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/upsell.dart
@@ -326,14 +326,16 @@ class ShowPromptButton extends StatefulWidget {
   final String title;
   final Function(String) onTextSubmitted;
 
-  ShowPromptButton({required this.title, required this.onTextSubmitted});
+  const ShowPromptButton(
+      {Key? key, required this.title, required this.onTextSubmitted})
+      : super(key: key);
 
   @override
   _ShowPromptButtonState createState() => _ShowPromptButtonState();
 }
 
 class _ShowPromptButtonState extends State<ShowPromptButton> {
-  TextEditingController _textFieldController = TextEditingController();
+  final TextEditingController _textFieldController = TextEditingController();
 
   void _showPrompt() {
     showDialog(
@@ -343,17 +345,17 @@ class _ShowPromptButtonState extends State<ShowPromptButton> {
           title: Text(widget.title),
           content: TextField(
             controller: _textFieldController,
-            decoration: InputDecoration(hintText: "Text here"),
+            decoration: const InputDecoration(hintText: "Text here"),
           ),
           actions: <Widget>[
             ElevatedButton(
-              child: Text('CANCEL'),
+              child: const Text('CANCEL'),
               onPressed: () {
                 Navigator.of(context).pop();
               },
             ),
             ElevatedButton(
-              child: Text('OK'),
+              child: const Text('OK'),
               onPressed: () {
                 // Call the callback function with the text value
                 widget.onTextSubmitted(_textFieldController.text);

--- a/test/offering_test.dart
+++ b/test/offering_test.dart
@@ -26,7 +26,9 @@ void main() {
               'presentedOfferingIdentifier': null,
               'subscriptionPeriod': null,
             },
-            'offeringIdentifier': 'theoffering',
+            'presentedOfferingContext': {
+              'offeringIdentifier': 'theoffering',
+            }
           }
         ],
         'lifetime': null,

--- a/test/offering_test.dart
+++ b/test/offering_test.dart
@@ -28,7 +28,7 @@ void main() {
             },
             'presentedOfferingContext': {
               'offeringIdentifier': 'theoffering',
-            }
+            },
           }
         ],
         'lifetime': null,

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -473,7 +473,6 @@ void main() {
         '\$rc_lifetime',
         PackageType.lifetime,
         mockStoreProduct,
-        'main',
         PresentedOfferingContext('main', null, null),
       );
       final purchasePackageResult =
@@ -523,7 +522,6 @@ void main() {
         '\$rc_lifetime',
         PackageType.lifetime,
         mockStoreProduct,
-        'main',
         PresentedOfferingContext('main', null, null),
       );
       final googleProductChangeInfo = GoogleProductChangeInfo(
@@ -578,7 +576,6 @@ void main() {
         '\$rc_lifetime',
         PackageType.lifetime,
         mockStoreProduct,
-        'main',
         PresentedOfferingContext('main', null, null),
       );
       const mockPaymentDiscount = PromotionalOffer(
@@ -704,7 +701,8 @@ void main() {
         '\$199.99',
         'USD',
         productCategory: ProductCategory.subscription,
-        presentedOfferingIdentifier: 'my-offer',
+        presentedOfferingContext:
+            PresentedOfferingContext('my-offer', null, null),
       );
       final purchasePackageResult =
           await Purchases.purchaseStoreProduct(mockStoreProduct);
@@ -747,7 +745,8 @@ void main() {
         199.99,
         '\$199.99',
         'USD',
-        presentedOfferingIdentifier: 'my-offer',
+        presentedOfferingContext:
+            PresentedOfferingContext('my-offer', null, null),
       );
       const mockPaymentDiscount = PromotionalOffer(
         'aIdentifier',
@@ -810,7 +809,6 @@ void main() {
         phase,
         null,
         null,
-        'my-offer',
         PresentedOfferingContext('my-offer', null, null),
       );
       final purchasePackageResult =
@@ -870,7 +868,6 @@ void main() {
         phase,
         null,
         null,
-        'my-offer',
         PresentedOfferingContext('my-offer', null, null),
       );
       final googleProductChangeInfo = GoogleProductChangeInfo(
@@ -930,7 +927,6 @@ void main() {
         Period(PeriodUnit.month, 1, 'P1M'),
         false,
         phase,
-        null,
         null,
         null,
         null,

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -474,6 +474,7 @@ void main() {
         PackageType.lifetime,
         mockStoreProduct,
         'main',
+        PresentedOfferingContext('main', null, null),
       );
       final purchasePackageResult =
           await Purchases.purchasePackage(mockPackage);
@@ -523,6 +524,7 @@ void main() {
         PackageType.lifetime,
         mockStoreProduct,
         'main',
+        PresentedOfferingContext('main', null, null),
       );
       final googleProductChangeInfo = GoogleProductChangeInfo(
         'com.revenuecat.weekly',
@@ -577,6 +579,7 @@ void main() {
         PackageType.lifetime,
         mockStoreProduct,
         'main',
+        PresentedOfferingContext('main', null, null),
       );
       const mockPaymentDiscount = PromotionalOffer(
         'aIdentifier',
@@ -808,6 +811,7 @@ void main() {
         null,
         null,
         'my-offer',
+        PresentedOfferingContext('my-offer', null, null),
       );
       final purchasePackageResult =
           await Purchases.purchaseSubscriptionOption(mockSubscriptionOption);
@@ -867,6 +871,7 @@ void main() {
         null,
         null,
         'my-offer',
+        PresentedOfferingContext('my-offer', null, null),
       );
       final googleProductChangeInfo = GoogleProductChangeInfo(
         'silver',
@@ -925,6 +930,7 @@ void main() {
         Period(PeriodUnit.month, 1, 'P1M'),
         false,
         phase,
+        null,
         null,
         null,
         null,
@@ -1245,24 +1251,25 @@ void main() {
     ]);
   });
 
-  test(
-      'showInAppMessages works correctly when passing arguments',
-      () async {
+  test('showInAppMessages works correctly when passing arguments', () async {
     await Purchases.showInAppMessages(
-      types: {InAppMessageType.billingIssue, InAppMessageType.priceIncreaseConsent, InAppMessageType.generic},
+      types: {
+        InAppMessageType.billingIssue,
+        InAppMessageType.priceIncreaseConsent,
+        InAppMessageType.generic,
+      },
     );
     expect(log, <Matcher>[
       isMethodCall(
         'showInAppMessages',
         arguments: {
-          'types': [0,1,2],
+          'types': [0, 1, 2],
         },
       ),
     ]);
   });
 
-  test(
-      'showInAppMessages works correctly when not passing arguments',
+  test('showInAppMessages works correctly when not passing arguments',
       () async {
     await Purchases.showInAppMessages();
     expect(log, <Matcher>[

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -489,7 +489,11 @@ void main() {
             'purchasePackage',
             arguments: <String, dynamic>{
               'packageIdentifier': '\$rc_lifetime',
-              'offeringIdentifier': 'main',
+              'presentedOfferingContext': <String, dynamic>{
+                'offeringIdentifier': 'main',
+                'placementIdentifier': null,
+                'targetingContext': null,
+              },
               'googleOldProductIdentifier': null,
               'googleProrationMode': null,
               'googleIsPersonalizedPrice': null,
@@ -545,7 +549,11 @@ void main() {
             'purchasePackage',
             arguments: <String, dynamic>{
               'packageIdentifier': '\$rc_lifetime',
-              'offeringIdentifier': 'main',
+              'presentedOfferingContext': <String, dynamic>{
+                'offeringIdentifier': 'main',
+                'placementIdentifier': null,
+                'targetingContext': null,
+              },
               'googleOldProductIdentifier': 'com.revenuecat.weekly',
               'googleProrationMode': 1,
               'googleIsPersonalizedPrice': true,


### PR DESCRIPTION
## Motivation

Bump to PHC `10.1.0` and add support for new Targeting methods

## Description

⚠️ This removes `offeringIdentifier`/`presentedOfferingIdentifier` from the constructor for `Package`, `StoreProduct`, and `SubscriptionOption` which is _technically_ a breaking change

However, the property for `offeringIdentifier`/`presentedOfferingIdentifier` still exists (as an extension) which is how most developer should be using it. 

### Get Current Offering for Placement

Get an offering specific to the place of your paywall (eg: onboarding, settings, feature gate, etc). This is determined by Targeting.

```dart
final offering = await Purchases.getCurrentOfferingForPlacement("your-placement-identifier")
if (offering != null) {
    // Navigate to paywall
} else {
    // Do nothing or continue to another screen
}
```

### Sync Attributes and Offerings

A blocking call to sync attributes and fetch new offerings to to be used with Targeting that uses Custom Attributes.

```dart
// Using this result is optional - offerings will be cached for next Purchases.getOfferings() call
final offerings = await Purchases.syncAttributesAndOfferingsIfNeeded()
```