### PR TITLE
Fix footer sizing issues in iOS

### DIFF
--- a/purchases_ui_flutter/ios/Classes/PurchasesUiPaywallFooterView.swift
+++ b/purchases_ui_flutter/ios/Classes/PurchasesUiPaywallFooterView.swift
@@ -64,9 +64,7 @@ class PurchasesUiPaywallFooterView: NSObject, FlutterPlatformView {
             super.init()
             return
         }
-        let newHeight = paywallFooterView.bounds.height
         _view = paywallFooterView
-        channel.invokeMethod("onHeightChanged", arguments: newHeight)
         super.init()
         paywallProxy.delegate = self
     }

--- a/purchases_ui_flutter/lib/views/paywall_footer_view.dart
+++ b/purchases_ui_flutter/lib/views/paywall_footer_view.dart
@@ -49,11 +49,7 @@ class _PaywallFooterViewState extends State<PaywallFooterView> {
         top: 0,
         left: 0,
         right: 0,
-        // iOS is passing the size without including the top margin with the
-        // rounded corners, so we need to adjust the bottom position.
-        bottom: Platform.isAndroid
-            ? _height - _roundedCornerRadius
-            : _height,
+        bottom: _height - _roundedCornerRadius,
         child: widget.contentCreator(_roundedCornerRadius),
       ),
       Positioned(
@@ -73,7 +69,10 @@ class _PaywallFooterViewState extends State<PaywallFooterView> {
   );
 
   void _updateHeight(double newHeight) {
-    final pixelRatio = MediaQuery.of(context).devicePixelRatio;
+    // In android we get pixels but in iOS we get pixel independent units.
+    final pixelRatio = Platform.isAndroid
+        ? MediaQuery.of(context).devicePixelRatio
+        : 1.0;
     final finalNewHeight = newHeight / pixelRatio;
 
     if (_height != finalNewHeight) {


### PR DESCRIPTION
The iOS footer was not sized appropriately. There were some issues:
- Delegate was not set correctly so we were not receiving the callback with the size from the native side.
- We get the size in pixel-independent units, contrary to android. But the initial time we were getting the size was in pixel units, which was confusing.

This fixes the issue so it has the correct height in all devices.