### PR TITLE
Add `RC_BILLING` store

### DIFF
--- a/api_tester/lib/api_tests/models/store_api_test.dart
+++ b/api_tester/lib/api_tests/models/store_api_test.dart
@@ -12,6 +12,7 @@ class _StoreApiTest {
       case Store.promotional:
       case Store.unknownStore:
       case Store.amazon:
+      case Store.rcBilling:
         break;
     }
   }

--- a/lib/models/entitlement_info_wrapper.g.dart
+++ b/lib/models/entitlement_info_wrapper.g.dart
@@ -68,6 +68,7 @@ const _$StoreEnumMap = {
   Store.promotional: 'PROMOTIONAL',
   Store.unknownStore: 'unknownStore',
   Store.amazon: 'AMAZON',
+  Store.rcBilling: 'RC_BILLING',
 };
 
 const _$PeriodTypeEnumMap = {

--- a/lib/models/store.dart
+++ b/lib/models/store.dart
@@ -28,4 +28,7 @@ enum Store {
   /// For entitlements granted via Amazon Appstore.
   @JsonValue('AMAZON')
   amazon,
+
+  @JsonValue('RC_BILLING')
+  rcBilling,
 }


### PR DESCRIPTION
Depends on https://github.com/RevenueCat/purchases-hybrid-common/pull/773. Adds the `RC_BILLING` store to flutter.

#### TODO
- [x] Hold until PHC with changes has been deployed and updated.