### PR TITLE
Remove macos platform support in purchases_ui_flutter

### DIFF
--- a/purchases_ui_flutter/pubspec.yaml
+++ b/purchases_ui_flutter/pubspec.yaml
@@ -50,8 +50,6 @@ flutter:
         pluginClass: PurchasesUiFlutterPlugin
       ios:
         pluginClass: PurchasesUiFlutterPlugin
-      macos:
-        pluginClass: PurchasesUiFlutterPlugin
 
   # To add assets to your plugin package, add an assets section, like this:
   # assets:


### PR DESCRIPTION
#1038 reports that MacOS is not working properly. The PaywallView and PaywallFooterView are being wrapped with UIKit, but they need to use AppKit, which is what's available in MacOS.

This PR removes support for now until we figure out what we need to do