### PR TITLE
Crash on Amazon paywalls after purchasing

### DIFF
--- a/lib/models/introductory_price.g.dart
+++ b/lib/models/introductory_price.g.dart
@@ -11,10 +11,10 @@ _$IntroductoryPriceImpl _$$IntroductoryPriceImplFromJson(Map json) =>
       (json['price'] as num).toDouble(),
       json['priceString'] as String,
       json['period'] as String,
-      json['cycles'] as int,
+      (json['cycles'] as num).toInt(),
       $enumDecode(_$PeriodUnitEnumMap, json['periodUnit'],
           unknownValue: PeriodUnit.unknown),
-      json['periodNumberOfUnits'] as int,
+      (json['periodNumberOfUnits'] as num).toInt(),
     );
 
 Map<String, dynamic> _$$IntroductoryPriceImplToJson(

--- a/lib/models/period_wrapper.g.dart
+++ b/lib/models/period_wrapper.g.dart
@@ -8,7 +8,7 @@ part of 'period_wrapper.dart';
 
 _$PeriodImpl _$$PeriodImplFromJson(Map json) => _$PeriodImpl(
       $enumDecode(_$PeriodUnitEnumMap, json['unit']),
-      json['value'] as int,
+      (json['value'] as num).toInt(),
       json['iso8601'] as String,
     );
 

--- a/lib/models/presented_offering_targeting_context_wrapper.g.dart
+++ b/lib/models/presented_offering_targeting_context_wrapper.g.dart
@@ -9,7 +9,7 @@ part of 'presented_offering_targeting_context_wrapper.dart';
 _$PresentedOfferingTargetingContextImpl
     _$$PresentedOfferingTargetingContextImplFromJson(Map json) =>
         _$PresentedOfferingTargetingContextImpl(
-          json['revision'] as int,
+          (json['revision'] as num).toInt(),
           json['ruleId'] as String,
         );
 

--- a/lib/models/price_wrapper.g.dart
+++ b/lib/models/price_wrapper.g.dart
@@ -8,7 +8,7 @@ part of 'price_wrapper.dart';
 
 _$PriceImpl _$$PriceImplFromJson(Map json) => _$PriceImpl(
       json['formatted'] as String,
-      json['amountMicros'] as int,
+      (json['amountMicros'] as num).toInt(),
       json['currencyCode'] as String,
     );
 

--- a/lib/models/pricing_phase_wrapper.g.dart
+++ b/lib/models/pricing_phase_wrapper.g.dart
@@ -12,7 +12,7 @@ _$PricingPhaseImpl _$$PricingPhaseImplFromJson(Map json) => _$PricingPhaseImpl(
           : Period.fromJson(
               Map<String, dynamic>.from(json['billingPeriod'] as Map)),
       $enumDecodeNullable(_$RecurrenceModeEnumMap, json['recurrenceMode']),
-      json['billingCycleCount'] as int?,
+      (json['billingCycleCount'] as num?)?.toInt(),
       Price.fromJson(Map<String, dynamic>.from(json['price'] as Map)),
       $enumDecodeNullable(_$OfferPaymentModeEnumMap, json['offerPaymentMode']),
     );

--- a/lib/models/promotional_offer.g.dart
+++ b/lib/models/promotional_offer.g.dart
@@ -12,7 +12,7 @@ _$PromotionalOfferImpl _$$PromotionalOfferImplFromJson(Map json) =>
       json['keyIdentifier'] as String,
       json['nonce'] as String,
       json['signature'] as String,
-      json['timestamp'] as int,
+      (json['timestamp'] as num).toInt(),
     );
 
 Map<String, dynamic> _$$PromotionalOfferImplToJson(

--- a/lib/models/purchases_error.g.dart
+++ b/lib/models/purchases_error.g.dart
@@ -8,7 +8,8 @@ part of 'purchases_error.dart';
 
 _$PurchasesErrorImpl _$$PurchasesErrorImplFromJson(Map json) =>
     _$PurchasesErrorImpl(
-      const PurchasesErrorCodeConverter().fromJson(json['code'] as int),
+      const PurchasesErrorCodeConverter()
+          .fromJson((json['code'] as num).toInt()),
       json['message'] as String,
       json['underlyingErrorMessage'] as String,
       json['readableErrorCode'] as String? ?? '',

--- a/lib/models/store_product_discount.g.dart
+++ b/lib/models/store_product_discount.g.dart
@@ -11,10 +11,10 @@ _$StoreProductDiscountImpl _$$StoreProductDiscountImplFromJson(Map json) =>
       json['identifier'] as String,
       (json['price'] as num).toDouble(),
       json['priceString'] as String,
-      json['cycles'] as int,
+      (json['cycles'] as num).toInt(),
       json['period'] as String,
       json['periodUnit'] as String,
-      json['periodNumberOfUnits'] as int,
+      (json['periodNumberOfUnits'] as num).toInt(),
     );
 
 Map<String, dynamic> _$$StoreProductDiscountImplToJson(

--- a/lib/models/store_transaction.dart
+++ b/lib/models/store_transaction.dart
@@ -11,12 +11,12 @@ class StoreTransaction with _$StoreTransaction {
   /// Experimental. This factory method is subject to changes without
   /// a major release.
   const factory StoreTransaction.create(
-    /// RevenueCat Id associated to the transaction.
+    /// RevenueCat Id associated to the transaction. Empty for Amazon.
     // ignore: invalid_annotation_target
     @JsonKey(readValue: _readTransactionIdentifier)
     String transactionIdentifier,
 
-    /// Deprecated: Use transactionIdentifier instead.
+    /// Deprecated: Use transactionIdentifier instead. Empty for Amazon.
     @Deprecated('Use transactionIdentifier instead.')
     // ignore: invalid_annotation_target
     @JsonKey(readValue: _readTransactionIdentifier)

--- a/lib/models/store_transaction.dart
+++ b/lib/models/store_transaction.dart
@@ -12,12 +12,14 @@ class StoreTransaction with _$StoreTransaction {
   /// a major release.
   const factory StoreTransaction.create(
     /// RevenueCat Id associated to the transaction.
+    // ignore: invalid_annotation_target
+    @JsonKey(readValue: _readTransactionIdentifier)
     String transactionIdentifier,
 
     /// Deprecated: Use transactionIdentifier instead.
     @Deprecated('Use transactionIdentifier instead.')
     // ignore: invalid_annotation_target
-    @JsonKey(readValue: _readRevenueCatIdentifier)
+    @JsonKey(readValue: _readTransactionIdentifier)
         String revenueCatIdentifier,
 
     /// Product Id associated with the transaction.
@@ -51,5 +53,6 @@ class StoreTransaction with _$StoreTransaction {
       _$StoreTransactionFromJson(json);
 }
 
-Object? _readRevenueCatIdentifier(Map json, String key) =>
-    json['transactionIdentifier'];
+// reads json or defaults to '' if not there (Amazon)
+Object _readTransactionIdentifier(Map json, String key) =>
+    json['transactionIdentifier'] ?? '';

--- a/lib/models/store_transaction.freezed.dart
+++ b/lib/models/store_transaction.freezed.dart
@@ -21,11 +21,13 @@ StoreTransaction _$StoreTransactionFromJson(Map<String, dynamic> json) {
 /// @nodoc
 mixin _$StoreTransaction {
   /// RevenueCat Id associated to the transaction.
+// ignore: invalid_annotation_target
+  @JsonKey(readValue: _readTransactionIdentifier)
   String get transactionIdentifier => throw _privateConstructorUsedError;
 
   /// Deprecated: Use transactionIdentifier instead.
   @Deprecated('Use transactionIdentifier instead.')
-  @JsonKey(readValue: _readRevenueCatIdentifier)
+  @JsonKey(readValue: _readTransactionIdentifier)
   String get revenueCatIdentifier => throw _privateConstructorUsedError;
 
   /// Product Id associated with the transaction.
@@ -36,9 +38,10 @@ mixin _$StoreTransaction {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(
+            @JsonKey(readValue: _readTransactionIdentifier)
             String transactionIdentifier,
             @Deprecated('Use transactionIdentifier instead.')
-            @JsonKey(readValue: _readRevenueCatIdentifier)
+            @JsonKey(readValue: _readTransactionIdentifier)
             String revenueCatIdentifier,
             String productIdentifier,
             String purchaseDate)
@@ -48,9 +51,10 @@ mixin _$StoreTransaction {
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(
+            @JsonKey(readValue: _readTransactionIdentifier)
             String transactionIdentifier,
             @Deprecated('Use transactionIdentifier instead.')
-            @JsonKey(readValue: _readRevenueCatIdentifier)
+            @JsonKey(readValue: _readTransactionIdentifier)
             String revenueCatIdentifier,
             String productIdentifier,
             String purchaseDate)?
@@ -60,9 +64,10 @@ mixin _$StoreTransaction {
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(
+            @JsonKey(readValue: _readTransactionIdentifier)
             String transactionIdentifier,
             @Deprecated('Use transactionIdentifier instead.')
-            @JsonKey(readValue: _readRevenueCatIdentifier)
+            @JsonKey(readValue: _readTransactionIdentifier)
             String revenueCatIdentifier,
             String productIdentifier,
             String purchaseDate)?
@@ -99,9 +104,10 @@ abstract class $StoreTransactionCopyWith<$Res> {
       _$StoreTransactionCopyWithImpl<$Res, StoreTransaction>;
   @useResult
   $Res call(
-      {String transactionIdentifier,
+      {@JsonKey(readValue: _readTransactionIdentifier)
+      String transactionIdentifier,
       @Deprecated('Use transactionIdentifier instead.')
-      @JsonKey(readValue: _readRevenueCatIdentifier)
+      @JsonKey(readValue: _readTransactionIdentifier)
       String revenueCatIdentifier,
       String productIdentifier,
       String purchaseDate});
@@ -155,9 +161,10 @@ abstract class _$$StoreTransactionImplCopyWith<$Res>
   @override
   @useResult
   $Res call(
-      {String transactionIdentifier,
+      {@JsonKey(readValue: _readTransactionIdentifier)
+      String transactionIdentifier,
       @Deprecated('Use transactionIdentifier instead.')
-      @JsonKey(readValue: _readRevenueCatIdentifier)
+      @JsonKey(readValue: _readTransactionIdentifier)
       String revenueCatIdentifier,
       String productIdentifier,
       String purchaseDate});
@@ -204,9 +211,10 @@ class __$$StoreTransactionImplCopyWithImpl<$Res>
 @JsonSerializable()
 class _$StoreTransactionImpl implements _StoreTransaction {
   const _$StoreTransactionImpl(
+      @JsonKey(readValue: _readTransactionIdentifier)
       this.transactionIdentifier,
       @Deprecated('Use transactionIdentifier instead.')
-      @JsonKey(readValue: _readRevenueCatIdentifier)
+      @JsonKey(readValue: _readTransactionIdentifier)
       this.revenueCatIdentifier,
       this.productIdentifier,
       this.purchaseDate);
@@ -215,13 +223,15 @@ class _$StoreTransactionImpl implements _StoreTransaction {
       _$$StoreTransactionImplFromJson(json);
 
   /// RevenueCat Id associated to the transaction.
+// ignore: invalid_annotation_target
   @override
+  @JsonKey(readValue: _readTransactionIdentifier)
   final String transactionIdentifier;
 
   /// Deprecated: Use transactionIdentifier instead.
   @override
   @Deprecated('Use transactionIdentifier instead.')
-  @JsonKey(readValue: _readRevenueCatIdentifier)
+  @JsonKey(readValue: _readTransactionIdentifier)
   final String revenueCatIdentifier;
 
   /// Product Id associated with the transaction.
@@ -268,9 +278,10 @@ class _$StoreTransactionImpl implements _StoreTransaction {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(
+            @JsonKey(readValue: _readTransactionIdentifier)
             String transactionIdentifier,
             @Deprecated('Use transactionIdentifier instead.')
-            @JsonKey(readValue: _readRevenueCatIdentifier)
+            @JsonKey(readValue: _readTransactionIdentifier)
             String revenueCatIdentifier,
             String productIdentifier,
             String purchaseDate)
@@ -284,9 +295,10 @@ class _$StoreTransactionImpl implements _StoreTransaction {
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(
+            @JsonKey(readValue: _readTransactionIdentifier)
             String transactionIdentifier,
             @Deprecated('Use transactionIdentifier instead.')
-            @JsonKey(readValue: _readRevenueCatIdentifier)
+            @JsonKey(readValue: _readTransactionIdentifier)
             String revenueCatIdentifier,
             String productIdentifier,
             String purchaseDate)?
@@ -300,9 +312,10 @@ class _$StoreTransactionImpl implements _StoreTransaction {
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(
+            @JsonKey(readValue: _readTransactionIdentifier)
             String transactionIdentifier,
             @Deprecated('Use transactionIdentifier instead.')
-            @JsonKey(readValue: _readRevenueCatIdentifier)
+            @JsonKey(readValue: _readTransactionIdentifier)
             String revenueCatIdentifier,
             String productIdentifier,
             String purchaseDate)?
@@ -354,9 +367,10 @@ class _$StoreTransactionImpl implements _StoreTransaction {
 
 abstract class _StoreTransaction implements StoreTransaction {
   const factory _StoreTransaction(
+      @JsonKey(readValue: _readTransactionIdentifier)
       final String transactionIdentifier,
       @Deprecated('Use transactionIdentifier instead.')
-      @JsonKey(readValue: _readRevenueCatIdentifier)
+      @JsonKey(readValue: _readTransactionIdentifier)
       final String revenueCatIdentifier,
       final String productIdentifier,
       final String purchaseDate) = _$StoreTransactionImpl;
@@ -367,12 +381,14 @@ abstract class _StoreTransaction implements StoreTransaction {
   @override
 
   /// RevenueCat Id associated to the transaction.
+// ignore: invalid_annotation_target
+  @JsonKey(readValue: _readTransactionIdentifier)
   String get transactionIdentifier;
   @override
 
   /// Deprecated: Use transactionIdentifier instead.
   @Deprecated('Use transactionIdentifier instead.')
-  @JsonKey(readValue: _readRevenueCatIdentifier)
+  @JsonKey(readValue: _readTransactionIdentifier)
   String get revenueCatIdentifier;
   @override
 

--- a/lib/models/store_transaction.freezed.dart
+++ b/lib/models/store_transaction.freezed.dart
@@ -20,12 +20,12 @@ StoreTransaction _$StoreTransactionFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$StoreTransaction {
-  /// RevenueCat Id associated to the transaction.
+  /// RevenueCat Id associated to the transaction. Empty for Amazon.
 // ignore: invalid_annotation_target
   @JsonKey(readValue: _readTransactionIdentifier)
   String get transactionIdentifier => throw _privateConstructorUsedError;
 
-  /// Deprecated: Use transactionIdentifier instead.
+  /// Deprecated: Use transactionIdentifier instead. Empty for Amazon.
   @Deprecated('Use transactionIdentifier instead.')
   @JsonKey(readValue: _readTransactionIdentifier)
   String get revenueCatIdentifier => throw _privateConstructorUsedError;
@@ -222,13 +222,13 @@ class _$StoreTransactionImpl implements _StoreTransaction {
   factory _$StoreTransactionImpl.fromJson(Map<String, dynamic> json) =>
       _$$StoreTransactionImplFromJson(json);
 
-  /// RevenueCat Id associated to the transaction.
+  /// RevenueCat Id associated to the transaction. Empty for Amazon.
 // ignore: invalid_annotation_target
   @override
   @JsonKey(readValue: _readTransactionIdentifier)
   final String transactionIdentifier;
 
-  /// Deprecated: Use transactionIdentifier instead.
+  /// Deprecated: Use transactionIdentifier instead. Empty for Amazon.
   @override
   @Deprecated('Use transactionIdentifier instead.')
   @JsonKey(readValue: _readTransactionIdentifier)
@@ -380,13 +380,13 @@ abstract class _StoreTransaction implements StoreTransaction {
 
   @override
 
-  /// RevenueCat Id associated to the transaction.
+  /// RevenueCat Id associated to the transaction. Empty for Amazon.
 // ignore: invalid_annotation_target
   @JsonKey(readValue: _readTransactionIdentifier)
   String get transactionIdentifier;
   @override
 
-  /// Deprecated: Use transactionIdentifier instead.
+  /// Deprecated: Use transactionIdentifier instead. Empty for Amazon.
   @Deprecated('Use transactionIdentifier instead.')
   @JsonKey(readValue: _readTransactionIdentifier)
   String get revenueCatIdentifier;

--- a/lib/models/store_transaction.g.dart
+++ b/lib/models/store_transaction.g.dart
@@ -8,8 +8,8 @@ part of 'store_transaction.dart';
 
 _$StoreTransactionImpl _$$StoreTransactionImplFromJson(Map json) =>
     _$StoreTransactionImpl(
-      json['transactionIdentifier'] as String,
-      _readRevenueCatIdentifier(json, 'revenueCatIdentifier') as String,
+      _readTransactionIdentifier(json, 'transactionIdentifier') as String,
+      _readTransactionIdentifier(json, 'revenueCatIdentifier') as String,
       json['productIdentifier'] as String,
       json['purchaseDate'] as String,
     );


### PR DESCRIPTION
In `PurchaseCompleted` we are passing a Flutter's `StoreTransaction` in the callback. This is very confusing but:

- In Android `StoreTransaction` is what's returned after a successful purchase. This class has a nullable `orderId`
- In Android `Transaction` is the transactions in the CustomerInfo. This class has a non-nullable `transactionIdentifier`

The issue we are having is that in Flutter we only have one `StoreTransaction` with a non-nullable `transactionId`, and we are using it in both places, the `PurchaseCompleted` and `CustomerInfo`.

I see several ways of fixing this:

- Making transactionIdentifier nullable. I don’t like this. It’s breaking
- Making transactionIdentifier an empty string. Fixing it in next major
- Making transactionIdentifier an empty string, deprecating it and creating orderId which is nullable and the same as transactionIdentifier. We’ll have nullable orderIds in the customer info transactions where this object is also used. In Android we have two classes, one for CustomerInfo transactions (Transaction with non-nullable transactionId ) and StoreTransaction which is used for completed purchases
- Making a copy of StoreTransaction and name it CompletedPurchase , but with a nullable transactionIdentifier. Also breaking since we need to modify the PurchaseCompleted callback to receive this object. Making a new callback won’t work because the broken `PurchaseCompleted will keep crashing.

In this PR I am doing number 2, since it's the least breaking. This only affects apps using Amazon paywalls, which is not many.

Will fix #1049 