### PR TITLE
Migration to applying Gradle plugins with the declarative plugins block in sample

### DIFF
--- a/revenuecat_examples/purchase_tester/android/app/build.gradle
+++ b/revenuecat_examples/purchase_tester/android/app/build.gradle
@@ -1,14 +1,15 @@
+plugins {
+    id "com.android.application"
+    id "kotlin-android"
+    id "dev.flutter.flutter-gradle-plugin"
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
     localPropertiesFile.withReader('UTF-8') { reader ->
         localProperties.load(reader)
     }
-}
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
@@ -21,18 +22,27 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
-apply plugin: 'com.android.application'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
-
 android {
+    namespace 'com.revenuecat.purchases_sample'
     compileSdk 34
     ndkVersion "25.1.8937393"
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
+    sourceSets {
+        main.java.srcDirs += 'src/main/kotlin'
+    }
 
     lint {
         disable 'InvalidPackage'
     }
-
-    namespace 'com.revenuecat.purchases_sample'
 
     defaultConfig {
         applicationId "com.revenuecat.purchases_sample"

--- a/revenuecat_examples/purchase_tester/android/app/src/main/java/com/revenuecat/purchases_sample/MainActivity.java
+++ b/revenuecat_examples/purchase_tester/android/app/src/main/java/com/revenuecat/purchases_sample/MainActivity.java
@@ -1,6 +1,0 @@
-package com.revenuecat.purchases_sample;
-
-import io.flutter.embedding.android.FlutterFragmentActivity;
-
-public class MainActivity extends FlutterFragmentActivity {
-}

--- a/revenuecat_examples/purchase_tester/android/app/src/main/java/com/revenuecat/purchases_sample/MainActivity.kt
+++ b/revenuecat_examples/purchase_tester/android/app/src/main/java/com/revenuecat/purchases_sample/MainActivity.kt
@@ -1,0 +1,5 @@
+package com.revenuecat.purchases_sample
+
+import io.flutter.embedding.android.FlutterFragmentActivity
+
+class MainActivity: FlutterFragmentActivity()

--- a/revenuecat_examples/purchase_tester/android/app/src/main/res/values-night/styles.xml
+++ b/revenuecat_examples/purchase_tester/android/app/src/main/res/values-night/styles.xml
@@ -3,14 +3,14 @@
     <!-- Theme applied to the Android Window while the process is starting when the OS's Dark Mode setting is on -->
     <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
         <!-- Show a splash screen on the activity. Automatically removed when
-             Flutter draws its first frame -->
+             the Flutter engine draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
     </style>
     <!-- Theme applied to the Android Window as soon as the process has started.
          This theme determines the color of the Android Window while your
          Flutter UI initializes, as well as behind your Flutter UI while its
          running.
-         
+
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
     <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
         <item name="android:windowBackground">?android:colorBackground</item>

--- a/revenuecat_examples/purchase_tester/android/app/src/main/res/values/styles.xml
+++ b/revenuecat_examples/purchase_tester/android/app/src/main/res/values/styles.xml
@@ -1,8 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
+    <!-- Theme applied to the Android Window while the process is starting when the OS's Dark Mode setting is off -->
+    <style name="LaunchTheme" parent="@android:style/Theme.Light.NoTitleBar">
         <!-- Show a splash screen on the activity. Automatically removed when
-             Flutter draws its first frame -->
+             the Flutter engine draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
+    </style>
+    <!-- Theme applied to the Android Window as soon as the process has started.
+         This theme determines the color of the Android Window while your
+         Flutter UI initializes, as well as behind your Flutter UI while its
+         running.
+
+         This Theme is only used starting with V2 of Flutter's Android embedding. -->
+    <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
+        <item name="android:windowBackground">?android:colorBackground</item>
     </style>
 </resources>

--- a/revenuecat_examples/purchase_tester/android/build.gradle
+++ b/revenuecat_examples/purchase_tester/android/build.gradle
@@ -1,14 +1,3 @@
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.0'
-    }
-}
-
 allprojects {
     repositories {
         google()

--- a/revenuecat_examples/purchase_tester/android/settings.gradle
+++ b/revenuecat_examples/purchase_tester/android/settings.gradle
@@ -1,22 +1,26 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }
+    settings.ext.flutterSdkPath = flutterSdkPath()
 
-def flutterProjectRoot = rootProject.projectDir.parentFile.toPath()
+    includeBuild("${settings.ext.flutterSdkPath}/packages/flutter_tools/gradle")
 
-def plugins = new Properties()
-def pluginsFile = new File(flutterProjectRoot.toFile(), '.flutter-plugins')
-if (pluginsFile.exists()) {
-    pluginsFile.withReader('UTF-8') { reader -> plugins.load(reader) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
 }
 
-plugins.each { name, path ->
-    def pluginDirectory = flutterProjectRoot.resolve(path).resolve('android').toFile()
-    include ":$name"
-    project(":$name").projectDir = pluginDirectory
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.2.0" apply false
+    id "org.jetbrains.kotlin.android" version "1.7.10" apply false
 }
 
-// Run enableLocalBuild task to enable building purchases-hybrid-common from your local copy
-if (file(".composite-enable").exists()) {
-    String path = new File(".composite-enable").text
-    includeBuild (path)
-}
-
+include ":app"


### PR DESCRIPTION
I kept getting 

```
You are applying Flutter's main Gradle plugin imperatively using the apply script method, which is deprecated and will be removed in a future release. Migrate to applying Gradle plugins with the declarative plugins block: https://flutter.dev/go/flutter-gradle-plugin-apply
```

when running the sample. I created a new plugin project and made some changes over to our purchase tester app