### PR TITLE
Remove SafeArea in sample in paywall.dart

### DIFF
--- a/revenuecat_examples/purchase_tester/lib/src/paywall.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/paywall.dart
@@ -20,34 +20,30 @@ class _PaywallScreenState extends State<PaywallScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: SafeArea(
-        child: Center(
-          child: PaywallView(
-            offering: widget.offering,
-            displayCloseButton: true,
-            onPurchaseStarted: (Package rcPackage) {
-              print('Purchase started for package: ${rcPackage.identifier}');
-            },
-            onPurchaseCompleted:
-                (CustomerInfo customerInfo, StoreTransaction storeTransaction) {
-              print('Purchase completed for customerInfo:\n $customerInfo\n '
-                  'and storeTransaction:\n $storeTransaction');
-            },
-            onPurchaseError: (PurchasesError error) {
-              print('Purchase error: $error');
-            },
-            onRestoreCompleted: (CustomerInfo customerInfo) {
-              print('Restore completed for customerInfo:\n $customerInfo');
-            },
-            onRestoreError: (PurchasesError error) {
-              print('Restore error: $error');
-            },
-            onDismiss: () {
-              print('Paywall asked to dismiss');
-              Navigator.pop(context);
-            },
-          ),
-        ),
+      body: PaywallView(
+        offering: widget.offering,
+        displayCloseButton: true,
+        onPurchaseStarted: (Package rcPackage) {
+          print('Purchase started for package: ${rcPackage.identifier}');
+        },
+        onPurchaseCompleted:
+            (CustomerInfo customerInfo, StoreTransaction storeTransaction) {
+          print('Purchase completed for customerInfo:\n $customerInfo\n '
+              'and storeTransaction:\n $storeTransaction');
+        },
+        onPurchaseError: (PurchasesError error) {
+          print('Purchase error: $error');
+        },
+        onRestoreCompleted: (CustomerInfo customerInfo) {
+          print('Restore completed for customerInfo:\n $customerInfo');
+        },
+        onRestoreError: (PurchasesError error) {
+          print('Restore error: $error');
+        },
+        onDismiss: () {
+          print('Paywall asked to dismiss');
+          Navigator.pop(context);
+        },
       ),
     );
   }


### PR DESCRIPTION
The `SafeArea` was causing the X close button to be pushed down

<img width="246" alt="Screenshot 2024-04-26 at 11 05 55" src="https://github.com/RevenueCat/purchases-flutter/assets/664544/da8712cc-3828-420a-925e-bd000f355851">

It looks like the `SafeArea` is adding some padding causing the `StatusBarSpacer` in purchases-android to add the wrong Spacer

```
@Composable
fun StatusBarSpacer() {
    return Spacer(
        Modifier.windowInsetsTopHeight(
            WindowInsets.statusBars,
        ),
    )
}
```

It doesn't make sense we wrap the `PaywallView` in a `SafeArea` since it should fill up the Activity that contains it so I removed it from the purchase tester to represent a more realistic scenario.