### PR TITLE
fix: call presentPaywallIfNeeded when needed

### DIFF
--- a/purchases_ui_flutter/ios/Classes/PurchasesUiFlutterPlugin.swift
+++ b/purchases_ui_flutter/ios/Classes/PurchasesUiFlutterPlugin.swift
@@ -103,9 +103,11 @@ public class PurchasesUiFlutterPlugin: NSObject, FlutterPlugin {
                 // This is needed for: https://github.com/RevenueCat/purchases-flutter/issues/1023
                 PaywallProxy.PaywallOptionsKeys.shouldBlockTouchEvents: true
             ]
-            if let requiredEntitlementIdentifier {
-                options[PaywallProxy.PaywallOptionsKeys.requiredEntitlementIdentifier] = requiredEntitlementIdentifier
+
+             if let offeringIdentifier {
+                options[PaywallProxy.PaywallOptionsKeys.offeringIdentifier] = offeringIdentifier
             }
+
             if let requiredEntitlementIdentifier {
                 options[PaywallProxy.PaywallOptionsKeys.requiredEntitlementIdentifier] = requiredEntitlementIdentifier
 

--- a/purchases_ui_flutter/ios/Classes/PurchasesUiFlutterPlugin.swift
+++ b/purchases_ui_flutter/ios/Classes/PurchasesUiFlutterPlugin.swift
@@ -106,13 +106,19 @@ public class PurchasesUiFlutterPlugin: NSObject, FlutterPlugin {
             if let requiredEntitlementIdentifier {
                 options[PaywallProxy.PaywallOptionsKeys.requiredEntitlementIdentifier] = requiredEntitlementIdentifier
             }
-            if let offeringIdentifier {
-                options[PaywallProxy.PaywallOptionsKeys.offeringIdentifier] = offeringIdentifier
+            if let requiredEntitlementIdentifier {
+                options[PaywallProxy.PaywallOptionsKeys.requiredEntitlementIdentifier] = requiredEntitlementIdentifier
+
+                self.paywallProxy.presentPaywallIfNeeded(
+                    options: options,
+                    paywallResultHandler: result
+                )
+            } else {
+                self.paywallProxy.presentPaywall(
+                    options: options,
+                    paywallResultHandler: result
+                )
             }
-            self.paywallProxy.presentPaywall(
-                options: options,
-                paywallResultHandler: result
-            )
         } else {
             NSLog("Presenting paywall requires iOS 15+")
         }


### PR DESCRIPTION
Thank you for contributing to Purchases. Before pressing the "Create Pull Request" button, please provide the following:

  - [x] A description about what and why you are contributing, even if it's trivial.
  - Call the `presentPaywallIfNeeded` method when the `requiredEntitlementIdentifier` is not empty

  - [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.
[https://github.com/RevenueCat/purchases-flutter/issues/1065](url)
  - [ ] If applicable, unit tests.
