### PR TITLE
Fix `purchaseDiscountedPackage`

### DIFF
--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -309,7 +309,7 @@ presentedOfferingContext:(NSDictionary *)presentedOfferingContext
 signedDiscountTimestamp:(nullable NSString *)discountTimestamp
                  result:(FlutterResult)result {
     [RCCommonFunctionality purchasePackage:packageIdentifier
-                  presentedOfferingContext: presentedOfferingContext
+                  presentedOfferingContext:presentedOfferingContext
                    signedDiscountTimestamp:discountTimestamp
                            completionBlock:[self getResponseCompletionBlock:result]];
 }

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -512,8 +512,8 @@ class Purchases {
   ) async {
     final customerInfo = await _invokeReturningCustomerInfo('purchasePackage', {
       'packageIdentifier': packageToPurchase.identifier,
-      'offeringContext':
-          packageToPurchase.presentedOfferingContext.offeringIdentifier,
+      'presentedOfferingContext':
+          packageToPurchase.presentedOfferingContext.toJson(),
       'signedDiscountTimestamp': promotionalOffer.timestamp.toString(),
     });
     return customerInfo;


### PR DESCRIPTION
`purchaseDiscountedPackage` is broken, we were passing the wrong parameters to the `purchasePackage` method. This should fix the issue and deal with https://github.com/RevenueCat/purchases-flutter/issues/1040