### PR TITLE
Removes api key from integration test

### DIFF
--- a/revenuecat_examples/purchase_tester/integration_test/app_test.dart
+++ b/revenuecat_examples/purchase_tester/integration_test/app_test.dart
@@ -10,7 +10,7 @@ void main() {
   var userId = "integration-test-${DateTime.now().millisecondsSinceEpoch}";
 
   setUpAll(() {
-    PurchasesConfiguration configuration = PurchasesConfiguration("appl_KhXKryBEHUWEdShrggQyjyzHKHW");
+    PurchasesConfiguration configuration = PurchasesConfiguration("api_key");
     configuration.appUserID = userId;
     configuration.entitlementVerificationMode = EntitlementVerificationMode.informational;
     Purchases.configure(configuration);


### PR DESCRIPTION
As the title says. Saw this while working on something else. 

Reading [.circleci/config.yml](https://github.com/RevenueCat/purchases-flutter/blob/main/.circleci/config.yml) it seems that the `replace-api-key` command should pick this up and replace it properly, but let me know if I'm overlooking something! 

I'm also happy to close this if this is not a problem, or if the fix is not as easy as this PR. 
