### PR TITLE
Fix `syncObserverModeAmazonPurchase` deprecation warning

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -360,13 +360,13 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 ArrayList<Integer> types = call.argument("types");
                 showInAppMessages(types, result);
                 break;
-            case "syncObserverModeAmazonPurchase":
+            case "syncAmazonPurchase":
                 String productID = call.argument("productID");
                 String receiptID = call.argument("receiptID");
                 String amazonUserID = call.argument("amazonUserID");
                 String isoCurrencyCode = call.argument("isoCurrencyCode");
                 Double price = call.argument("price");
-                syncObserverModeAmazonPurchase(productID, receiptID, amazonUserID, isoCurrencyCode,
+                syncAmazonPurchase(productID, receiptID, amazonUserID, isoCurrencyCode,
                         price, result);
                 break;
             default:
@@ -542,13 +542,13 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
         result.success(null);
     }
 
-    private void syncObserverModeAmazonPurchase(String productID,
+    private void syncAmazonPurchase(String productID,
             String receiptID,
             String amazonUserID,
             String isoCurrencyCode,
             Double price,
             final Result result) {
-        Purchases.getSharedInstance().syncObserverModeAmazonPurchase(productID, receiptID,
+        Purchases.getSharedInstance().syncAmazonPurchase(productID, receiptID,
                 amazonUserID, isoCurrencyCode, price);
         result.success(null);
     }

--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -222,7 +222,7 @@ NSString *PurchasesLogHandlerEvent = @"Purchases-LogHandlerEvent";
         [self closeWithResult:result];
     } else if ([@"setLogHandler" isEqualToString:call.method]) {
         [self setLogHandlerWithResult:result];
-    } else if ([@"syncObserverModeAmazonPurchase" isEqualToString:call.method]) {
+    } else if ([@"syncAmazonPurchase" isEqualToString:call.method]) {
         // NOOP
         result(nil);
     } else {

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -988,7 +988,7 @@ class Purchases {
     double? price,
   ) =>
       _channel.invokeMethod(
-        'syncObserverModeAmazonPurchase',
+        'syncAmazonPurchase',
         {
           'productID': productID,
           'receiptID': receiptID,

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -1219,7 +1219,7 @@ void main() {
     );
     expect(log, <Matcher>[
       isMethodCall(
-        'syncObserverModeAmazonPurchase',
+        'syncAmazonPurchase',
         arguments: {
           'productID': 'productID_test',
           'receiptID': 'receiptID_test',
@@ -1243,7 +1243,7 @@ void main() {
     );
     expect(log, <Matcher>[
       isMethodCall(
-        'syncObserverModeAmazonPurchase',
+        'syncAmazonPurchase',
         arguments: {
           'productID': 'productID_test',
           'receiptID': 'receiptID_test',


### PR DESCRIPTION
This will fix a warning introduced with the recent deprecation warning of one of the methods in purchases-android: https://github.com/RevenueCat/purchases-flutter/issues/1114.

We will modify the public API in purchases-flutter as well soon to reflect the new naming.