### PR TITLE
[PurchaseTester] Refactor upsell screen to display all offerings

### DIFF
--- a/revenuecat_examples/purchase_tester/lib/src/upsell.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/upsell.dart
@@ -1,10 +1,8 @@
 import 'dart:async';
 import 'dart:developer';
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/widgets.dart';
 import 'package:purchases_flutter/purchases_flutter.dart';
 import 'package:purchases_flutter_example/src/paywall_footer_screen.dart';
 import 'package:purchases_ui_flutter/purchases_ui_flutter.dart';


### PR DESCRIPTION
I did this change to test some things and I think it's more useful. Basically moved the current UI under a collapsible section, so we can display all offerings, instead of only the `current` offering as we're doing now.

| Before | After |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/8e5a1170-c9f9-4392-833e-f099123da4c1) | ![image](https://github.com/user-attachments/assets/aa9892f0-3073-4366-a183-1885235dfd6a) |