### PR TITLE
Update iOS deployment target in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 To use this plugin, add `purchases_flutter` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/).
 
 ### Requirements
-*purchases_flutter* requires Xcode 14.0+ and minimum targets iOS 11.0+.
+*purchases_flutter* requires Xcode 14.0+ and minimum targets iOS 13.0+.
 
 ## SDK Reference
  Our full SDK reference [can be found here](https://pub.dev/documentation/purchases_flutter/latest/).

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 To use this plugin, add `purchases_flutter` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/).
 
 ### Requirements
-*purchases_flutter* requires Xcode 14.0+ and minimum targets iOS 13.0+/Android SDK 21 (Android 5.0).
+*purchases_flutter* requires Xcode 14.0+ and minimum targets iOS 13.0+/Android SDK 21+ (Android 5.0+).
 
 ## SDK Reference
  Our full SDK reference [can be found here](https://pub.dev/documentation/purchases_flutter/latest/).

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 To use this plugin, add `purchases_flutter` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/).
 
 ### Requirements
-*purchases_flutter* requires Xcode 14.0+ and minimum targets iOS 13.0+.
+*purchases_flutter* requires Xcode 14.0+ and minimum targets iOS 13.0+/Android SDK 21 (Android 5.0).
 
 ## SDK Reference
  Our full SDK reference [can be found here](https://pub.dev/documentation/purchases_flutter/latest/).


### PR DESCRIPTION
This PR updates the iOS deployment target note in the README to reflect the fact that the minimum iOS deployment target is iOS13 as of version 7.0.0.