### PR TITLE
Parse recordPurchase response

### DIFF
--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -925,7 +925,7 @@ class Purchases {
       'recordPurchaseForProductID',
       {'productID': productID},
     );
-  
+    if (response == null) throw UnsupportedPlatformException();
     return StoreTransaction.fromJson(Map<String, dynamic>.from(response));
   }
 

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -925,12 +925,8 @@ class Purchases {
       'recordPurchaseForProductID',
       {'productID': productID},
     );
-
-    if (response == null) {
-      throw UnsupportedPlatformException();
-    }
-
-    return StoreTransaction.fromJson(response);
+  
+    return StoreTransaction.fromJson(Map<String, dynamic>.from(response));
   }
 
   /// iOS 15+ only. Presents a refund request sheet in the current window scene for

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -921,12 +921,16 @@ class Purchases {
   static Future<StoreTransaction> recordPurchase(
     String productID,
   ) async {
-    final statusCode = await _channel.invokeMethod(
+    final response = await _channel.invokeMethod(
       'recordPurchaseForProductID',
+      {'productID': productID},
     );
-    if (statusCode == null) throw UnsupportedPlatformException();
-    return await _channel
-        .invokeMethod('recordPurchaseForProductID', {'productID': productID});
+
+    if (response == null) {
+      throw UnsupportedPlatformException();
+    }
+
+    return StoreTransaction.fromJson(response);
   }
 
   /// iOS 15+ only. Presents a refund request sheet in the current window scene for


### PR DESCRIPTION
This change modifies the `recordPurchase` function to correctly parse the response from the PHC library from a map to a `StoreTransaction` object.