### PR TITLE
Refine StoreKitVersion logging in configure function

### DIFF
--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -151,7 +151,8 @@ class Purchases {
               as PurchasesAreCompletedByMyApp)
           .storeKitVersion;
 
-      if (purchasesConfiguration.storeKitVersion !=
+      if (purchasesConfiguration.storeKitVersion != null &&
+          purchasesConfiguration.storeKitVersion !=
               StoreKitVersion.defaultVersion &&
           storeKitVersionToUse != purchasesConfiguration.storeKitVersion) {
         debugPrint(

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -151,10 +151,19 @@ class Purchases {
               as PurchasesAreCompletedByMyApp)
           .storeKitVersion;
 
-      if (storeKitVersionToUse != purchasesConfiguration.storeKitVersion) {
+      if (purchasesConfiguration.storeKitVersion !=
+              StoreKitVersion.defaultVersion &&
+          storeKitVersionToUse != purchasesConfiguration.storeKitVersion) {
         debugPrint(
             'Warning: The storeKitVersion in purchasesAreCompletedBy does not match the '
             'function\'s storeKitVersion parameter. We will use the value found in purchasesAreCompletedBy.');
+      }
+
+      if (storeKitVersionToUse == StoreKitVersion.defaultVersion) {
+        debugPrint(
+            'Warning: You should provide the specific StoreKit version you\'re using in '
+            'your implementation when configuring PurchasesAreCompletedByMyApp, '
+            'and not rely on the DEFAULT.');
       }
     }
 


### PR DESCRIPTION
This PR refines the logging related to the `storeKitVersion` in the `configure()` function. Specifically, it:
- Only logs a message about the storeKitVersions being passed conflicting if the `storeKitVersion` param is not the default value. This should prevent confusion in the event that a developer passes in a `PurchasesAreCompletedByMyApp` but doesn't pass in a `storeKitVersion` param
- If the `storeKitVersion` passed into `PurchasesAreCompletedByMyApp` is the default value, it logs a warning letting the developer know that they should provide a specific `storeKitVersion` that matches what they're using in their StoreKit implementation.