### PR TITLE
v7-MIGRATION.md typo fix

### DIFF
--- a/migrations/v7-MIGRATION.md
+++ b/migrations/v7-MIGRATION.md
@@ -9,7 +9,7 @@ This latest release updates the Android SDK dependency from v7 to [v8](https://g
 
 ### New Minimum OS Versions
 
-This release raises the minumum required OS versions to the following:
+This release raises the minimum required OS versions to the following:
 
 - iOS 13.0
 - tvOS 13.0


### PR DESCRIPTION
Fixes a typo in the v7 migration guide