### PR TITLE
Fix purchases-ui-flutter main SDK version substitution

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,7 +25,7 @@ files_with_version_number = {
     './ios/Classes/PurchasesFlutterPlugin.m' => ['return @"{x}"'],
     './android/build.gradle' => ['version \'{x}\''],
     './android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java' => ['PLUGIN_VERSION = "{x}"'],
-    './purchases_ui_flutter/pubspec.yaml' => ['version: {x}', 'purchases_flutter: \^{x}'],
+    './purchases_ui_flutter/pubspec.yaml' => ['version: {x}', 'purchases_flutter: ^{x}'],
     './purchases_ui_flutter/ios/purchases_ui_flutter.podspec' => ['s.version          = \'{x}\''],
     './purchases_ui_flutter/macos/purchases_ui_flutter.podspec' => ['s.version          = \'{x}\''],
     './purchases_ui_flutter/android/build.gradle' => ['version \'{x}\''],


### PR DESCRIPTION
The version of the core SDK in the purchases_ui_flutter pubspec.yaml file wasn't working correctly. This is because we were adding an extra character, probably to escape the `^`, however, that was messing with the automation which is performing a basic substitution.