### PR TITLE
use tryParse in PurchasesErrorHelper to avoid FormatException

### DIFF
--- a/lib/errors.dart
+++ b/lib/errors.dart
@@ -143,8 +143,8 @@ class PurchasesErrorHelper {
   /// }
   /// ```
   static PurchasesErrorCode getErrorCode(PlatformException e) {
-    final errorCode = int.parse(e.code);
-    if (errorCode >= PurchasesErrorCode.values.length) {
+    final errorCode = int.tryParse(e.code);
+    if (errorCode == null || errorCode >= PurchasesErrorCode.values.length) {
       return PurchasesErrorCode.unknownError;
     }
     return PurchasesErrorCode.values[errorCode];


### PR DESCRIPTION
In some cases using PurchasesErrorHelper in a catch block will result in an uncaught FormatException when `code` is not a valid Int. This causes additional boilerplate in client applications.

Example error observed in production:

``` 
Non-fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: FormatException: Invalid radix-10 number (at character 1)
error
^

       at int.parse(dart:core)
       at PurchasesErrorHelper.getErrorCode(errors.dart:146)
```