### PR TITLE
Fix area insets in PaywallView

### DIFF
--- a/purchases_ui_flutter/ios/Classes/PurchasesUiPaywallView.swift
+++ b/purchases_ui_flutter/ios/Classes/PurchasesUiPaywallView.swift
@@ -50,7 +50,11 @@ class PaywallViewWrapper: UIView {
     
     override func layoutSubviews() {
         super.layoutSubviews()
-        
+
+        // Need to wait for this view to be in the hierarchy to look for the parent UIVC.
+        // This is required to add a SwiftUI `UIHostingController` to the hierarchy in a way that allows
+        // UIKit to read properties from the environment, like traits and safe area.
+        // Not doing this leads to the view not respecting the safe area.
         if !addedToHierarchy {
             if let parentController = self.parentViewController {
                 paywallViewController.view.translatesAutoresizingMaskIntoConstraints = false

--- a/purchases_ui_flutter/ios/Classes/PurchasesUiPaywallView.swift
+++ b/purchases_ui_flutter/ios/Classes/PurchasesUiPaywallView.swift
@@ -48,8 +48,8 @@ class PaywallViewWrapper: UIView {
         NSLayoutConstraint.activate([
             paywallViewController.view.topAnchor.constraint(equalTo: topAnchor),
             paywallViewController.view.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
-            paywallViewController.view.trailingAnchor.constraint(equalTo: trailingAnchor),
-            paywallViewController.view.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor)
+            paywallViewController.view.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
+            paywallViewController.view.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
     }
     
@@ -70,9 +70,9 @@ class PaywallViewWrapper: UIView {
     private func updateAdditionalSafeAreaInsets() {
         let insets = UIEdgeInsets(
             top: 0,
-            left: safeAreaInsets.left,
-            bottom: 0,
-            right: safeAreaInsets.right
+            left: 0,
+            bottom: -safeAreaInsets.bottom/2,
+            right: 0
         )
         paywallViewController.additionalSafeAreaInsets = insets
     }


### PR DESCRIPTION
This PR basically does the same we do in React Native to handle the safe area in the PaywallView

| Before | After |
|--------|--------|
| ![simulator_screenshot_C744866E-38EE-4081-973F-FEB94C903675](https://github.com/user-attachments/assets/edf8cd42-899e-4318-9168-7016cfde516d) | ![simulator_screenshot_57C3C890-24D0-4EF9-8F7C-2866AC82A3DA](https://github.com/user-attachments/assets/61998b96-b39e-41a3-ab28-3554f95581d6) | 

