### PR TITLE
Support displaying deferred win-back StoreKit messages

### DIFF
--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -530,7 +530,8 @@ class _PurchasesFlutterApiTest {
     Future<void> future = Purchases.showInAppMessages(types: {
       InAppMessageType.billingIssue,
       InAppMessageType.priceIncreaseConsent,
-      InAppMessageType.generic
+      InAppMessageType.generic,
+      InAppMessageType.winBackOffer
     });
   }
 

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -459,6 +459,7 @@ class _PurchasesFlutterApiTest {
       case InAppMessageType.billingIssue:
       case InAppMessageType.priceIncreaseConsent:
       case InAppMessageType.generic:
+      case InAppMessageType.winBackOffer:
         break;
     }
   }

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -1210,7 +1210,11 @@ enum InAppMessageType {
   priceIncreaseConsent,
 
   /// iOS-only. StoreKit generic messages.
-  generic
+  generic,
+
+  /// iOS-only. This message will show if the subscriber is eligible for an iOS win-back
+  /// offer and will allow the subscriber to redeem the offer.
+  winBackOffer
 }
 
 /// Log levels.


### PR DESCRIPTION
This PR introduces the ability for a developer to display deferred StoreKit win-back offer messages to the user. The functionality was originally introduced in https://github.com/RevenueCat/purchases-ios/pull/4343.

Other than the enum addition, no other changes are necessary.