### PR TITLE
feat(OneSignal): add setOnesignalUserID method to be able to use the user-centric API integration

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -277,6 +277,10 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 String onesignalID = call.argument("onesignalID");
                 setOnesignalID(onesignalID, result);
                 break;
+            case "setOnesignalUserID":
+                String onesignalUserID = call.argument("onesignalUserID");
+                setOnesignalUserID(onesignalUserID, result);
+                break;
             case "setAirshipChannelID":
                 String airshipChannelID = call.argument("airshipChannelID");
                 setAirshipChannelID(airshipChannelID, result);
@@ -603,6 +607,11 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
 
     private void setOnesignalID(String onesignalID, final Result result) {
         SubscriberAttributesKt.setOnesignalID(onesignalID);
+        result.success(null);
+    }
+
+    private void setOnesignalUserID(String onesignalUserID, final Result result) {
+        SubscriberAttributesKt.setOnesignalUserID(onesignalUserID);
         result.success(null);
     }
 

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -318,6 +318,11 @@ class _PurchasesFlutterApiTest {
     Future<void> future = Purchases.setOnesignalID(id);
   }
 
+  void _checkSetOnesignalUserId() {
+    String id = "fakeId";
+    Future<void> future = Purchases.setOnesignalUserID(id);
+  }
+
   void _checkSetAirshipChannelId() async {
     String id = "fakeId";
     await Purchases.setAirshipChannelID(id);

--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -157,6 +157,9 @@ NSString *PurchasesLogHandlerEvent = @"Purchases-LogHandlerEvent";
     } else if ([@"setOnesignalID" isEqualToString:call.method]) {
         NSString *onesignalID = arguments[@"onesignalID"];
         [self setOnesignalID:onesignalID result:result];
+    } else if ([@"setOnesignalUserID" isEqualToString:call.method]) {
+        NSString *onesignalUserID = arguments[@"onesignalUserID"];
+        [self setOnesignalUserID:onesignalUserID result:result];
     } else if ([@"setAirshipChannelID" isEqualToString:call.method]) {
         NSString *airshipChannelID = arguments[@"airshipChannelID"];
         [self setAirshipChannelID:airshipChannelID result:result];
@@ -480,6 +483,11 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
 
 - (void)setOnesignalID:(nullable NSString *)onesignalID result:(FlutterResult)result {
     [RCCommonFunctionality setOnesignalID:onesignalID];
+    result(nil);
+}
+
+- (void)setOnesignalUserID:(nullable NSString *)onesignalUserID result:(FlutterResult)result {
+    [RCCommonFunctionality setOnesignalUserID:onesignalUserID];
     result(nil);
 }
 

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -794,11 +794,18 @@ class Purchases {
       );
 
   /// Subscriber attribute associated with the OneSignal Player Id for the user
-  /// Required for the RevenueCat OneSignal integration
+  /// Required for the Device-centric RevenueCat OneSignal integration
   ///
   /// [onesignalID] Empty String or null will delete the subscriber attribute.
   static Future<void> setOnesignalID(String onesignalID) =>
       _channel.invokeMethod('setOnesignalID', {'onesignalID': onesignalID});
+
+  /// Subscriber attribute associated with the OneSignal Player Id for the user
+  /// Required for the User-centric RevenueCat OneSignal integration
+  ///
+  /// [onesignalUserID] Empty String or null will delete the subscriber attribute.
+  static Future<void> setOnesignalUserID(String onesignalUserID) => _channel
+      .invokeMethod('setOnesignalUserID', {'onesignalUserID': onesignalUserID});
 
   /// Subscriber attribute associated with the Airship Channel Id for the user
   /// Required for the RevenueCat Airship integration


### PR DESCRIPTION
In my professionnal project, I had to integrate OneSignal using this documentation: https://www.revenuecat.com/docs/integrations/third-party-integrations/onesignal#11-user-centric-api-versions-of-onesignal-110-and-above

But I encounter difficulties because the Flutter SDK only implements the method for the device-centric version `setOnesignalID` and not the user-centric version `setOnesignalUserID`. It was quite confusing and I lost time (and also the RevenueCat support) because of this.

Thanks in advance 🙏 