### PR TITLE
`syncPurchases` method with return value of `CustomerInfo`

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -201,6 +201,9 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
             case "syncPurchases":
                 syncPurchases(result);
                 break;
+            case "syncPurchasesWith":
+                syncPurchasesWith(result);
+                break;
             case "isAnonymous":
                 isAnonymous(result);
                 break;
@@ -518,6 +521,10 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
     private void syncPurchases(final Result result) {
         CommonKt.syncPurchases();
         result.success(null);
+    }
+
+    private void syncPurchasesWith(final Result result) {
+        CommonKt.syncPurchases(getOnResult(result));
     }
 
     private void isAnonymous(final Result result) {

--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -104,6 +104,8 @@ NSString *PurchasesLogHandlerEvent = @"Purchases-LogHandlerEvent";
         [self getCustomerInfoWithResult:result];
     } else if ([@"syncPurchases" isEqualToString:call.method]) {
         [self syncPurchasesWithResult:result];
+    } else if ([@"syncPurchasesWith" isEqualToString:call.method]) {
+        [self syncPurchasesWithResult:result];
     } else if ([@"enableAdServicesAttributionTokenCollection" isEqualToString:call.method]) {
         [self enableAdServicesAttributionTokenCollection:result];
     } else if ([@"recordPurchaseForProductID" isEqualToString:call.method]) {

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -634,6 +634,19 @@ class Purchases {
   ///  successful purchase.
   static Future<void> syncPurchases() => _channel.invokeMethod('syncPurchases');
 
+  ///  This method will send all the purchases to the RevenueCat backend.
+  ///
+  ///  **WARNING**: Call this when using your own implementation of in-app
+  ///  purchases.
+  ///
+  ///  This method should be called anytime a sync is needed, like after a
+  ///  successful purchase.
+  static Future<CustomerInfo> syncPurchasesWith() async {
+    final result = await _channel.invokeMethod('syncPurchasesWith');
+    return CustomerInfo.fromJson(Map<String, dynamic>.from(result));
+  }
+
+
   /// iOS only. Enable automatic collection of Apple Search Ad attribution. Disabled by
   /// default
   static Future<void> enableAdServicesAttributionTokenCollection() =>


### PR DESCRIPTION
Thank you for contributing to Purchases. Before pressing the "Create Pull Request" button, please provide the following:

  - [ ] A description about what and why you are contributing, even if it's trivial.

  - [ ] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [ ] If applicable, unit tests.

I am adding `syncPurchaseWith` method that returns `CustomerInfo` after syncing purchases. The current `syncPurchases` method returns void and we need to wait until new `CustomerInfo` arrives in the `addCustomerInfoUpdateListener` - which we don't know when and if it will arrive there. In my case I need this new `CustomerInfo` immediately after syncing because logic of showing paywalls depends on this info.
