### PR TITLE
Support Fetching and Redeeming Win-Back Offers on Custom Paywall #1134

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -222,6 +222,9 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
             case "beginRefundRequestForEntitlement":
             case "recordPurchaseForProductID":
             case "enableAdServicesAttributionTokenCollection":
+            case "eligibleWinBackOffersForProduct":
+            case "purchaseProductWithWinBackOffer":
+            case "purchasePackageWithWinBackOffer":
                 // NOOP
                 result.success(null);
                 break;

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -559,9 +559,6 @@ Future<CustomerInfo> _checkFetchAndPurchaseWinBackOffersForProduct(
   List<WinBackOffer>? offers =
       await Purchases.getEligibleWinBackOffersForProduct(product);
 
-  if (offers == null || offers.isEmpty) {
-    throw Exception("No eligible win-back offers available for the product.");
-  }
   return await Purchases.purchaseProductWithWinBackOffer(product, offers[0]);
 }
 
@@ -570,8 +567,5 @@ Future<CustomerInfo> _checkFetchAndPurchaseWinBackOffersForPackage(
   List<WinBackOffer>? offers =
       await Purchases.getEligibleWinBackOffersForPackage(package);
 
-  if (offers == null || offers.isEmpty) {
-    throw Exception("No eligible win-back offers available for the package.");
-  }
   return await Purchases.purchasePackageWithWinBackOffer(package, offers[0]);
 }

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -553,3 +553,25 @@ class _PurchasesFlutterApiTest {
         const PurchasesAreCompletedByRevenueCat();
   }
 }
+
+Future<CustomerInfo> _checkFetchAndPurchaseWinBackOffersForProduct(
+    StoreProduct product) async {
+  List<WinBackOffer>? offers =
+      await Purchases.getEligibleWinBackOffersForProduct(product);
+
+  if (offers == null || offers.isEmpty) {
+    throw Exception("No eligible win-back offers available for the product.");
+  }
+  return await Purchases.purchaseProductWithWinBackOffer(product, offers[0]);
+}
+
+Future<CustomerInfo> _checkFetchAndPurchaseWinBackOffersForPackage(
+    Package package) async {
+  List<WinBackOffer>? offers =
+      await Purchases.getEligibleWinBackOffersForPackage(package);
+
+  if (offers == null || offers.isEmpty) {
+    throw Exception("No eligible win-back offers available for the package.");
+  }
+  return await Purchases.purchasePackageWithWinBackOffer(package, offers[0]);
+}

--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -229,7 +229,12 @@ shouldShowInAppMessagesAutomatically: shouldShowInAppMessagesAutomatically
         [self purchaseProductWithWinBackOffer:arguments[@"productIdentifier"]
                        winBackOfferIdentifier:arguments[@"winBackOfferIdentifier"]
                                        result:result];
-    } else {
+    } else if ([@"purchasePackageWithWinBackOffer" isEqualToString:call.method]) {
+        [self purchasePackageWithWinBackOffer:arguments[@"packageIdentifier"]
+                     presentedOfferingContext:arguments[@"presentedOfferingContext"]
+                       winBackOfferIdentifier:arguments[@"winBackOfferIdentifier"]
+                                     result:result];
+        }else {
         result(FlutterMethodNotImplemented);
     }
 }
@@ -560,12 +565,7 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
         }];
     } else {
         NSLog(@"[Purchases] Warning: Win-back offers are only available on iOS 18.0 or greater.");
-        NSError *error = [NSError errorWithDomain:@"com.revenuecat.purchases"
-                                            code:24
-                                        userInfo:@{
-                                            NSLocalizedDescriptionKey: @"iOS win-back offers are only available on iOS 18.0 or greater.",
-                                            @"readable_error_code": @"UnsupportedPlatformVersion"
-                                        }];
+        NSError *error = [self createUnsupportedErrorWithDescription:@"iOS win-back offers are only available on iOS 18.0 or greater."];
         RCErrorContainer *errorContainer = [[RCErrorContainer alloc] initWithError:error
                                                                     extraPayload:@{}];
         [self rejectWithResult:result error:errorContainer];
@@ -581,14 +581,27 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
                                completionBlock:[self getResponseCompletionBlock:result]];
     } else {
         NSLog(@"[Purchases] Warning: Win-back offers are only available on iOS 18.0 or greater.");
-        NSError *error = [NSError errorWithDomain:@"com.revenuecat.purchases"
-                                            code:24
-                                        userInfo:@{
-                                            NSLocalizedDescriptionKey: @"iOS win-back offers are only available on iOS 18.0 or greater.",
-                                            @"readable_error_code": @"UnsupportedPlatformVersion"
-                                        }];
+        NSError *error = [self createUnsupportedErrorWithDescription:@"iOS win-back offers are only available on iOS 18.0 or greater."];
         RCErrorContainer *errorContainer = [[RCErrorContainer alloc] initWithError:error
                                                                     extraPayload:@{}];
+        [self rejectWithResult:result error:errorContainer];
+    }
+}
+
+- (void)purchasePackageWithWinBackOffer:(NSString *)packageIdentifier
+               presentedOfferingContext:(NSDictionary *)presentedOfferingContext
+                 winBackOfferIdentifier:(NSString *)winBackOfferIdentifier
+                                 result:(FlutterResult)result {
+    if (@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)) {
+        [RCCommonFunctionality purchasePackage:packageIdentifier
+                      presentedOfferingContext:presentedOfferingContext
+                                winBackOfferID:winBackOfferIdentifier
+                               completionBlock:[self getResponseCompletionBlock:result]];
+    } else {
+        NSLog(@"[Purchases] Warning: Win-back offers are only available on iOS 18.0 or greater.");
+        NSError *error = [self createUnsupportedErrorWithDescription:@"iOS win-back offers are only available on iOS 18.0 or greater."];
+        RCErrorContainer *errorContainer = [[RCErrorContainer alloc] initWithError:error
+                                                                      extraPayload:@{}];
         [self rejectWithResult:result error:errorContainer];
     }
 }
@@ -730,6 +743,12 @@ readyForPromotedProduct:(RCStoreProduct *)product
 
 - (NSString *)platformFlavorVersion {
     return @"8.2.2";
+}
+
+- (NSError *)createUnsupportedErrorWithDescription:(NSString *)description {
+    return [[NSError alloc] initWithDomain:RCPurchasesErrorCodeDomain
+                                      code:RCUnsupportedError
+                                  userInfo:@{NSLocalizedDescriptionKey : description}];
 }
 
 @end

--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -405,7 +405,7 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
                                           result:(FlutterResult)result {
     [RCCommonFunctionality checkTrialOrIntroductoryPriceEligibility:products
                                                     completionBlock:^(NSDictionary<NSString *, NSDictionary *> *_Nonnull responseDictionary) {
-        result([NSDictionary dictionaryWithDictionary:responseDictionary]);
+                      result([NSDictionary dictionaryWithDictionary:responseDictionary]);
     }];
 }
 

--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -606,7 +606,7 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
     }
 }
 
-#if TARGET_OS_IPHONE
+ #if TARGET_OS_IPHONE
 - (void)beginRefundRequestForActiveEntitlementWithResult:(FlutterResult)result {
     if (@available(iOS 15, *)) {
         [RCCommonFunctionality beginRefundRequestForActiveEntitlementCompletion:[self getBeginRefundResponseCompletionBlock:result]];
@@ -642,7 +642,7 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
 }
 
 - (void)showInAppMessages:(NSArray<NSNumber*>*)rawValues result:(FlutterResult)result {
-#if TARGET_OS_IPHONE
+    #if TARGET_OS_IPHONE
     if (@available(iOS 16.0, *)) {
         if (rawValues == nil) {
             [RCCommonFunctionality showStoreMessagesCompletion:^{
@@ -658,10 +658,10 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
         NSLog(@"[Purchases] Warning: tried to show in-app messages, but it's only available on iOS 16.0 or greater.");
         result(nil);
     }
-#else
+    #else
     NSLog(@"[Purchases] Warning: tried to show in-app messages, but it's only supported on iOS.");
     result(nil);
-#endif
+    #endif
 
 }
 

--- a/lib/models/win_back_offer.dart
+++ b/lib/models/win_back_offer.dart
@@ -1,0 +1,33 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'win_back_offer.freezed.dart';
+part 'win_back_offer.g.dart';
+
+@freezed
+class WinBackOffer with _$WinBackOffer {
+  const factory WinBackOffer(
+    /// Identifier of the discount.
+    String identifier,
+
+    /// Identifier of the discount.
+    double price,
+
+    /// Formatted price, including its currency sign, such as €3.99.
+    String priceString,
+
+    /// Number of subscription billing periods for which the user will be given the discount, such as 3.
+    int cycles,
+
+    /// Billing period of the discount, specified in ISO 8601 format.
+    String period,
+
+    /// Unit for the billing period of the discount, can be DAY, WEEK, MONTH or YEAR.
+    String periodUnit,
+
+    /// Number of units for the billing period of the discount.
+    int periodNumberOfUnits,
+  ) = _WinBackOffer;
+
+  factory WinBackOffer.fromJson(Map<String, dynamic> json) =>
+      _$WinBackOfferFromJson(json);
+}

--- a/lib/models/win_back_offer.freezed.dart
+++ b/lib/models/win_back_offer.freezed.dart
@@ -41,8 +41,12 @@ mixin _$WinBackOffer {
   /// Number of units for the billing period of the discount.
   int get periodNumberOfUnits => throw _privateConstructorUsedError;
 
+  /// Serializes this WinBackOffer to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of WinBackOffer
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $WinBackOfferCopyWith<WinBackOffer> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -73,6 +77,8 @@ class _$WinBackOfferCopyWithImpl<$Res, $Val extends WinBackOffer>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of WinBackOffer
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -143,6 +149,8 @@ class __$$WinBackOfferImplCopyWithImpl<$Res>
       _$WinBackOfferImpl _value, $Res Function(_$WinBackOfferImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of WinBackOffer
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -247,12 +255,14 @@ class _$WinBackOfferImpl implements _WinBackOffer {
                 other.periodNumberOfUnits == periodNumberOfUnits));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, identifier, price, priceString,
       cycles, period, periodUnit, periodNumberOfUnits);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of WinBackOffer
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$WinBackOfferImplCopyWith<_$WinBackOfferImpl> get copyWith =>
@@ -279,36 +289,38 @@ abstract class _WinBackOffer implements WinBackOffer {
   factory _WinBackOffer.fromJson(Map<String, dynamic> json) =
       _$WinBackOfferImpl.fromJson;
 
-  @override
-
   /// Identifier of the discount.
+  @override
   String get identifier;
-  @override
 
   /// Identifier of the discount.
-  double get price;
   @override
+  double get price;
 
   /// Formatted price, including its currency sign, such as €3.99.
-  String get priceString;
   @override
+  String get priceString;
 
   /// Number of subscription billing periods for which the user will be given the discount, such as 3.
-  int get cycles;
   @override
+  int get cycles;
 
   /// Billing period of the discount, specified in ISO 8601 format.
-  String get period;
   @override
+  String get period;
 
   /// Unit for the billing period of the discount, can be DAY, WEEK, MONTH or YEAR.
-  String get periodUnit;
   @override
+  String get periodUnit;
 
   /// Number of units for the billing period of the discount.
-  int get periodNumberOfUnits;
   @override
-  @JsonKey(ignore: true)
+  int get periodNumberOfUnits;
+
+  /// Create a copy of WinBackOffer
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$WinBackOfferImplCopyWith<_$WinBackOfferImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/models/win_back_offer.freezed.dart
+++ b/lib/models/win_back_offer.freezed.dart
@@ -1,0 +1,314 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'win_back_offer.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+WinBackOffer _$WinBackOfferFromJson(Map<String, dynamic> json) {
+  return _WinBackOffer.fromJson(json);
+}
+
+/// @nodoc
+mixin _$WinBackOffer {
+  /// Identifier of the discount.
+  String get identifier => throw _privateConstructorUsedError;
+
+  /// Identifier of the discount.
+  double get price => throw _privateConstructorUsedError;
+
+  /// Formatted price, including its currency sign, such as €3.99.
+  String get priceString => throw _privateConstructorUsedError;
+
+  /// Number of subscription billing periods for which the user will be given the discount, such as 3.
+  int get cycles => throw _privateConstructorUsedError;
+
+  /// Billing period of the discount, specified in ISO 8601 format.
+  String get period => throw _privateConstructorUsedError;
+
+  /// Unit for the billing period of the discount, can be DAY, WEEK, MONTH or YEAR.
+  String get periodUnit => throw _privateConstructorUsedError;
+
+  /// Number of units for the billing period of the discount.
+  int get periodNumberOfUnits => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $WinBackOfferCopyWith<WinBackOffer> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $WinBackOfferCopyWith<$Res> {
+  factory $WinBackOfferCopyWith(
+          WinBackOffer value, $Res Function(WinBackOffer) then) =
+      _$WinBackOfferCopyWithImpl<$Res, WinBackOffer>;
+  @useResult
+  $Res call(
+      {String identifier,
+      double price,
+      String priceString,
+      int cycles,
+      String period,
+      String periodUnit,
+      int periodNumberOfUnits});
+}
+
+/// @nodoc
+class _$WinBackOfferCopyWithImpl<$Res, $Val extends WinBackOffer>
+    implements $WinBackOfferCopyWith<$Res> {
+  _$WinBackOfferCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? identifier = null,
+    Object? price = null,
+    Object? priceString = null,
+    Object? cycles = null,
+    Object? period = null,
+    Object? periodUnit = null,
+    Object? periodNumberOfUnits = null,
+  }) {
+    return _then(_value.copyWith(
+      identifier: null == identifier
+          ? _value.identifier
+          : identifier // ignore: cast_nullable_to_non_nullable
+              as String,
+      price: null == price
+          ? _value.price
+          : price // ignore: cast_nullable_to_non_nullable
+              as double,
+      priceString: null == priceString
+          ? _value.priceString
+          : priceString // ignore: cast_nullable_to_non_nullable
+              as String,
+      cycles: null == cycles
+          ? _value.cycles
+          : cycles // ignore: cast_nullable_to_non_nullable
+              as int,
+      period: null == period
+          ? _value.period
+          : period // ignore: cast_nullable_to_non_nullable
+              as String,
+      periodUnit: null == periodUnit
+          ? _value.periodUnit
+          : periodUnit // ignore: cast_nullable_to_non_nullable
+              as String,
+      periodNumberOfUnits: null == periodNumberOfUnits
+          ? _value.periodNumberOfUnits
+          : periodNumberOfUnits // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$WinBackOfferImplCopyWith<$Res>
+    implements $WinBackOfferCopyWith<$Res> {
+  factory _$$WinBackOfferImplCopyWith(
+          _$WinBackOfferImpl value, $Res Function(_$WinBackOfferImpl) then) =
+      __$$WinBackOfferImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String identifier,
+      double price,
+      String priceString,
+      int cycles,
+      String period,
+      String periodUnit,
+      int periodNumberOfUnits});
+}
+
+/// @nodoc
+class __$$WinBackOfferImplCopyWithImpl<$Res>
+    extends _$WinBackOfferCopyWithImpl<$Res, _$WinBackOfferImpl>
+    implements _$$WinBackOfferImplCopyWith<$Res> {
+  __$$WinBackOfferImplCopyWithImpl(
+      _$WinBackOfferImpl _value, $Res Function(_$WinBackOfferImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? identifier = null,
+    Object? price = null,
+    Object? priceString = null,
+    Object? cycles = null,
+    Object? period = null,
+    Object? periodUnit = null,
+    Object? periodNumberOfUnits = null,
+  }) {
+    return _then(_$WinBackOfferImpl(
+      null == identifier
+          ? _value.identifier
+          : identifier // ignore: cast_nullable_to_non_nullable
+              as String,
+      null == price
+          ? _value.price
+          : price // ignore: cast_nullable_to_non_nullable
+              as double,
+      null == priceString
+          ? _value.priceString
+          : priceString // ignore: cast_nullable_to_non_nullable
+              as String,
+      null == cycles
+          ? _value.cycles
+          : cycles // ignore: cast_nullable_to_non_nullable
+              as int,
+      null == period
+          ? _value.period
+          : period // ignore: cast_nullable_to_non_nullable
+              as String,
+      null == periodUnit
+          ? _value.periodUnit
+          : periodUnit // ignore: cast_nullable_to_non_nullable
+              as String,
+      null == periodNumberOfUnits
+          ? _value.periodNumberOfUnits
+          : periodNumberOfUnits // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$WinBackOfferImpl implements _WinBackOffer {
+  const _$WinBackOfferImpl(this.identifier, this.price, this.priceString,
+      this.cycles, this.period, this.periodUnit, this.periodNumberOfUnits);
+
+  factory _$WinBackOfferImpl.fromJson(Map<String, dynamic> json) =>
+      _$$WinBackOfferImplFromJson(json);
+
+  /// Identifier of the discount.
+  @override
+  final String identifier;
+
+  /// Identifier of the discount.
+  @override
+  final double price;
+
+  /// Formatted price, including its currency sign, such as €3.99.
+  @override
+  final String priceString;
+
+  /// Number of subscription billing periods for which the user will be given the discount, such as 3.
+  @override
+  final int cycles;
+
+  /// Billing period of the discount, specified in ISO 8601 format.
+  @override
+  final String period;
+
+  /// Unit for the billing period of the discount, can be DAY, WEEK, MONTH or YEAR.
+  @override
+  final String periodUnit;
+
+  /// Number of units for the billing period of the discount.
+  @override
+  final int periodNumberOfUnits;
+
+  @override
+  String toString() {
+    return 'WinBackOffer(identifier: $identifier, price: $price, priceString: $priceString, cycles: $cycles, period: $period, periodUnit: $periodUnit, periodNumberOfUnits: $periodNumberOfUnits)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$WinBackOfferImpl &&
+            (identical(other.identifier, identifier) ||
+                other.identifier == identifier) &&
+            (identical(other.price, price) || other.price == price) &&
+            (identical(other.priceString, priceString) ||
+                other.priceString == priceString) &&
+            (identical(other.cycles, cycles) || other.cycles == cycles) &&
+            (identical(other.period, period) || other.period == period) &&
+            (identical(other.periodUnit, periodUnit) ||
+                other.periodUnit == periodUnit) &&
+            (identical(other.periodNumberOfUnits, periodNumberOfUnits) ||
+                other.periodNumberOfUnits == periodNumberOfUnits));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, identifier, price, priceString,
+      cycles, period, periodUnit, periodNumberOfUnits);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$WinBackOfferImplCopyWith<_$WinBackOfferImpl> get copyWith =>
+      __$$WinBackOfferImplCopyWithImpl<_$WinBackOfferImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$WinBackOfferImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _WinBackOffer implements WinBackOffer {
+  const factory _WinBackOffer(
+      final String identifier,
+      final double price,
+      final String priceString,
+      final int cycles,
+      final String period,
+      final String periodUnit,
+      final int periodNumberOfUnits) = _$WinBackOfferImpl;
+
+  factory _WinBackOffer.fromJson(Map<String, dynamic> json) =
+      _$WinBackOfferImpl.fromJson;
+
+  @override
+
+  /// Identifier of the discount.
+  String get identifier;
+  @override
+
+  /// Identifier of the discount.
+  double get price;
+  @override
+
+  /// Formatted price, including its currency sign, such as €3.99.
+  String get priceString;
+  @override
+
+  /// Number of subscription billing periods for which the user will be given the discount, such as 3.
+  int get cycles;
+  @override
+
+  /// Billing period of the discount, specified in ISO 8601 format.
+  String get period;
+  @override
+
+  /// Unit for the billing period of the discount, can be DAY, WEEK, MONTH or YEAR.
+  String get periodUnit;
+  @override
+
+  /// Number of units for the billing period of the discount.
+  int get periodNumberOfUnits;
+  @override
+  @JsonKey(ignore: true)
+  _$$WinBackOfferImplCopyWith<_$WinBackOfferImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/models/win_back_offer.g.dart
+++ b/lib/models/win_back_offer.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'win_back_offer.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$WinBackOfferImpl _$$WinBackOfferImplFromJson(Map json) => _$WinBackOfferImpl(
+      json['identifier'] as String,
+      (json['price'] as num).toDouble(),
+      json['priceString'] as String,
+      (json['cycles'] as num).toInt(),
+      json['period'] as String,
+      json['periodUnit'] as String,
+      (json['periodNumberOfUnits'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$$WinBackOfferImplToJson(_$WinBackOfferImpl instance) =>
+    <String, dynamic>{
+      'identifier': instance.identifier,
+      'price': instance.price,
+      'priceString': instance.priceString,
+      'cycles': instance.cycles,
+      'period': instance.period,
+      'periodUnit': instance.periodUnit,
+      'periodNumberOfUnits': instance.periodNumberOfUnits,
+    };

--- a/lib/object_wrappers.dart
+++ b/lib/object_wrappers.dart
@@ -28,3 +28,4 @@ export 'models/storekit_version.dart';
 export 'models/subscription_option_wrapper.dart';
 export 'models/upgrade_info.dart';
 export 'models/verification_result.dart';
+export 'models/win_back_offer.dart';

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -966,8 +966,16 @@ class Purchases {
   static Future<CustomerInfo> purchasePackageWithWinBackOffer(
     Package package,
     WinBackOffer winBackOffer,
-  ) async =>
-      purchaseProductWithWinBackOffer(package.storeProduct, winBackOffer);
+  ) async {
+    print("purchasePackageWithWinBackOffer");
+    final customerInfo =
+        await _invokeReturningCustomerInfo('purchasePackageWithWinBackOffer', {
+      'packageIdentifier': package.identifier,
+      'presentedOfferingContext': package.presentedOfferingContext.toJson(),
+      'winBackOfferIdentifier': winBackOffer.identifier,
+    });
+    return customerInfo;
+  }
 
   /// iOS 15+ only. Presents a refund request sheet in the current window scene for
   /// the latest transaction associated with the active entitlement.

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
-import 'models/win_back_offer.dart';
 import 'object_wrappers.dart';
 
 export 'object_wrappers.dart';
@@ -922,7 +921,7 @@ class Purchases {
   /// [package] The [Package] the user intends to purchase.
   static Future<List<WinBackOffer>> getEligibleWinBackOffersForPackage(
     Package package,
-  ) =>
+  ) async =>
       getEligibleWinBackOffersForProduct(package.storeProduct);
 
   /// iOS only, requires iOS 18.0 or greater with StoreKit 2.
@@ -967,7 +966,7 @@ class Purchases {
   static Future<CustomerInfo> purchasePackageWithWinBackOffer(
     Package package,
     WinBackOffer winBackOffer,
-  ) =>
+  ) async =>
       purchaseProductWithWinBackOffer(package.storeProduct, winBackOffer);
 
   /// iOS 15+ only. Presents a refund request sheet in the current window scene for

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
+import 'models/win_back_offer.dart';
 import 'object_wrappers.dart';
 
 export 'object_wrappers.dart';
@@ -893,6 +894,81 @@ class Purchases {
     });
     return PromotionalOffer.fromJson(Map<String, dynamic>.from(result));
   }
+
+  /// iOS only, requires iOS 18.0 or greater with StoreKit 2.
+  ///
+  /// Use this function to retrieve the eligible [WinBackOffer]s that a subscriber
+  /// is eligible for for a given [StoreProduct].
+  ///
+  /// [product] The [StoreProduct] the user intends to purchase.
+  static Future<List<WinBackOffer>> getEligibleWinBackOffersForProduct(
+    StoreProduct product,
+  ) async {
+    final result =
+        await _channel.invokeMethod('eligibleWinBackOffersForProduct', {
+      'productIdentifier': product.identifier,
+    });
+
+    return (result as List)
+        .map((e) => WinBackOffer.fromJson(Map<String, dynamic>.from(e)))
+        .toList();
+  }
+
+  /// iOS only, requires iOS 18.0 or greater with StoreKit 2.
+  ///
+  /// Use this function to retrieve the eligible [WinBackOffer]s that a subscriber
+  /// is eligible for for a given [Package].
+  ///
+  /// [package] The [Package] the user intends to purchase.
+  static Future<List<WinBackOffer>> getEligibleWinBackOffersForPackage(
+    Package package,
+  ) =>
+      getEligibleWinBackOffersForProduct(package.storeProduct);
+
+  /// iOS only, requires iOS 18.0 or greater with StoreKit 2.
+  /// Purchase a product applying a given win-back offer.
+  ///
+  /// Returns a [CustomerInfo] object. Throws a
+  /// [PlatformException] if the purchase is unsuccessful.
+  /// Check if [PurchasesErrorHelper.getErrorCode] is
+  /// [PurchasesErrorCode.purchaseCancelledError] to check if the user cancelled
+  /// the purchase.
+  ///
+  /// [storeProduct] The product to purchase.
+  ///
+  /// [winBackOffer] Win-back offer that will be applied to the product.
+  /// Retrieve this offer using [getEligibleWinBackOffersForProduct]
+  /// or [getEligibleWinBackOffersForPackage].
+  static Future<CustomerInfo> purchaseProductWithWinBackOffer(
+    StoreProduct product,
+    WinBackOffer winBackOffer,
+  ) async {
+    final customerInfo =
+        await _invokeReturningCustomerInfo('purchaseProductWithWinBackOffer', {
+      'productIdentifier': product.identifier,
+      'winBackOfferIdentifier': winBackOffer.identifier,
+    });
+    return customerInfo;
+  }
+
+  /// iOS only, requires iOS 18.0 or greater with StoreKit 2.
+  /// Purchase a package applying a given win-back offer.
+  ///
+  /// Returns a [CustomerInfo] object. Throws a
+  /// [PlatformException] if the purchase is unsuccessful.
+  /// Check if [PurchasesErrorHelper.getErrorCode] is
+  /// [PurchasesErrorCode.purchaseCancelledError] to check if the user cancelled
+  /// the purchase.
+  ///
+  /// [package] The package to purchase.
+  ///
+  /// [winBackOffer] Win-back offer that will be applied to the package.
+  /// Retrieve this offer using [getEligibleWinBackOffersForPackage].
+  static Future<CustomerInfo> purchasePackageWithWinBackOffer(
+    Package package,
+    WinBackOffer winBackOffer,
+  ) =>
+      purchaseProductWithWinBackOffer(package.storeProduct, winBackOffer);
 
   /// iOS 15+ only. Presents a refund request sheet in the current window scene for
   /// the latest transaction associated with the active entitlement.

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -967,7 +967,6 @@ class Purchases {
     Package package,
     WinBackOffer winBackOffer,
   ) async {
-    print("purchasePackageWithWinBackOffer");
     final customerInfo =
         await _invokeReturningCustomerInfo('purchasePackageWithWinBackOffer', {
       'packageIdentifier': package.identifier,

--- a/revenuecat_examples/purchase_tester/ios/Runner.xcodeproj/project.pbxproj
+++ b/revenuecat_examples/purchase_tester/ios/Runner.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		FD68EFDC2CFE4A21000F11DB /* SKConfig.storekit in Resources */ = {isa = PBXBuildFile; fileRef = FD68EFDB2CFE4A21000F11DB /* SKConfig.storekit */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -55,6 +56,7 @@
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9F7F07B8FE3007CC9AF0459D /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		A559C8670BC6F437FF2985F1 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		FD68EFDB2CFE4A21000F11DB /* SKConfig.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = SKConfig.storekit; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -132,6 +134,7 @@
 				97C146F11CF9000F007C117D /* Supporting Files */,
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
+				FD68EFDB2CFE4A21000F11DB /* SKConfig.storekit */,
 			);
 			path = Runner;
 			sourceTree = "<group>";
@@ -215,6 +218,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FD68EFDC2CFE4A21000F11DB /* SKConfig.storekit in Resources */,
 				97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */,
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
 				9740EEB41CF90195004384FC /* Debug.xcconfig in Resources */,

--- a/revenuecat_examples/purchase_tester/ios/Runner/SKConfig.storekit
+++ b/revenuecat_examples/purchase_tester/ios/Runner/SKConfig.storekit
@@ -1,0 +1,153 @@
+{
+  "appPolicies" : {
+    "eula" : "",
+    "policies" : [
+      {
+        "locale" : "en_US",
+        "policyText" : "",
+        "policyURL" : ""
+      }
+    ]
+  },
+  "identifier" : "68E538F8",
+  "nonRenewingSubscriptions" : [
+
+  ],
+  "products" : [
+
+  ],
+  "settings" : {
+    "_compatibilityTimeRate" : {
+      "3" : 6
+    },
+    "_failTransactionsEnabled" : false,
+    "_locale" : "en_US",
+    "_storefront" : "USA",
+    "_storeKitErrors" : [
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Load Products"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Purchase"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Verification"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "App Store Sync"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Subscription Status"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "App Transaction"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Manage Subscriptions Sheet"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Refund Request Sheet"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Offer Code Redeem Sheet"
+      }
+    ],
+    "_timeRate" : 1003
+  },
+  "subscriptionGroups" : [
+    {
+      "id" : "7EA56C60",
+      "localizations" : [
+
+      ],
+      "name" : "main_subscription_group",
+      "subscriptions" : [
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "4.99",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "539C7F18",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "Pro subscription",
+              "displayName" : "Pro",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "com.revenuecat.monthly_4.99.1_week_intro",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Winback Testing",
+          "subscriptionGroupID" : "7EA56C60",
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+            {
+              "internalID" : "A397E108",
+              "isEligible" : true,
+              "offerID" : "winback.1w0",
+              "paymentMode" : "free",
+              "referenceName" : "1w0 Winback Offer",
+              "subscriptionPeriod" : "P1W"
+            }
+          ]
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "10.00",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "029F3EB0",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "",
+              "displayName" : "",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "rc_1099_1w",
+          "recurringSubscriptionPeriod" : "P1W",
+          "referenceName" : "RC 10.99 1w",
+          "subscriptionGroupID" : "7EA56C60",
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+
+          ]
+        }
+      ]
+    }
+  ],
+  "version" : {
+    "major" : 4,
+    "minor" : 0
+  }
+}

--- a/revenuecat_examples/purchase_tester/lib/src/upsell.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/upsell.dart
@@ -11,6 +11,7 @@ import 'constant.dart';
 import 'cats.dart';
 import 'initial.dart';
 import 'paywall.dart';
+import 'winback_testing_screen.dart';
 
 class UpsellScreen extends StatefulWidget {
   const UpsellScreen({Key? key}) : super(key: key);
@@ -81,6 +82,26 @@ class _UpsellScreenState extends State<UpsellScreen> {
                       });
                     },
                     child: const Text('Sync Attributes and Offerings'),
+                  ),
+                ]))),
+      ),
+      Padding(
+        padding: const EdgeInsets.symmetric(vertical: 20),
+        child: Card(
+            margin: const EdgeInsets.all(8.0),
+            child: Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Column(children: [
+                  const Text("Win-Back Offer Testing"),
+                  ElevatedButton(
+                    onPressed: () async {
+                      Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => WinbackTestingScreen(),
+                          ));
+                    },
+                    child: const Text("Go to Win-Back Offer Testing Screen"),
                   ),
                 ]))),
       ),

--- a/revenuecat_examples/purchase_tester/lib/src/winback_testing_screen.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/winback_testing_screen.dart
@@ -1,0 +1,274 @@
+import 'package:flutter/material.dart';
+import 'package:purchases_flutter/purchases_flutter.dart';
+import 'package:purchases_flutter/models/win_back_offer.dart';
+
+class WinbackTestingScreen extends StatefulWidget {
+  const WinbackTestingScreen({Key? key}) : super(key: key);
+
+  @override
+  State<WinbackTestingScreen> createState() => _WinbackTestingScreenState();
+}
+
+class _WinbackTestingScreenState extends State<WinbackTestingScreen> {
+  StoreProduct? _product;
+  List<WinBackOffer> _productWinBackOffers = [];
+  Package? _package;
+  List<WinBackOffer> _packageWinBackOffers = [];
+  String? _error;
+
+  Future<void> _fetchProduct() async {
+    try {
+      final products = await Purchases.getProducts(
+          ['com.revenuecat.monthly_4.99.1_week_intro']);
+      if (products.isNotEmpty) {
+        setState(() {
+          _product = products[0];
+        });
+      } else {
+        setState(() {
+          _error = 'No products available';
+        });
+      }
+    } catch (err) {
+      setState(() {
+        _error = 'Failed to fetch products: ${err.toString()}';
+      });
+    }
+  }
+
+  Future<void> _purchaseProduct(StoreProduct product) async {
+    try {
+      final purchaseResult = await Purchases.purchaseStoreProduct(product);
+      print('Purchase successful: $purchaseResult');
+    } catch (err) {
+      print('Purchase failed: $err');
+    }
+  }
+
+  Future<void> _fetchEligibleWinBackOffersForProduct(
+      StoreProduct product) async {
+    try {
+      final offers =
+          await Purchases.getEligibleWinBackOffersForProduct(product);
+      print('Found win-back offers: $offers');
+      setState(() {
+        _productWinBackOffers = offers ?? [];
+      });
+    } catch (err) {
+      print('Error fetching win-back offers: $err');
+      setState(() {
+        _productWinBackOffers = [];
+      });
+    }
+  }
+
+  Future<void> _fetchEligibleWinBackOffersForPackage(Package package) async {
+    try {
+      final offers =
+          await Purchases.getEligibleWinBackOffersForPackage(package);
+      setState(() {
+        _packageWinBackOffers = offers ?? [];
+      });
+    } catch (err) {
+      print('Error fetching win-back offers: $err');
+      setState(() {
+        _packageWinBackOffers = [];
+      });
+    }
+  }
+
+  Future<void> _purchaseWinBackOfferForProduct(
+      StoreProduct product, WinBackOffer offer) async {
+    try {
+      final result =
+          await Purchases.purchaseProductWithWinBackOffer(product, offer);
+      print('Win-Back Offer purchase successful: $result');
+    } catch (err) {
+      print('Win-Back Offer purchase failed: $err');
+    }
+  }
+
+  Future<void> _fetchPackage() async {
+    final offerings = await Purchases.getOfferings();
+    print(offerings.current?.availablePackages);
+    final monthlyPackage = offerings.current?.availablePackages
+        .where((pkg) => pkg.identifier == '\$rc_monthly')
+        .firstOrNull;
+
+    if (monthlyPackage != null) {
+      setState(() {
+        _package = monthlyPackage;
+      });
+    }
+  }
+
+  Future<void> _purchasePackage(Package package) async {
+    try {
+      final purchaseResult = await Purchases.purchasePackage(package);
+      print('Purchase successful: $purchaseResult');
+    } catch (err) {
+      print('Purchase failed: $err');
+    }
+  }
+
+  Future<void> _purchaseWinBackOfferForPackage(
+      Package package, WinBackOffer offer) async {
+    try {
+      final result =
+          await Purchases.purchasePackageWithWinBackOffer(package, offer);
+      print('Win-Back Offer purchase successful: $result');
+    } catch (err) {
+      print('Win-Back Offer purchase failed: $err');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Win-Back Testing'),
+      ),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const Text(
+                'Use this screen to fetch eligible win-back offers, purchase products without a win-back offer, and purchase products with an eligible win-back offer.',
+              ),
+              const SizedBox(height: 8),
+              const Text(
+                'This test relies on products and offers defined in the SKConfig file, so be sure to launch the PurchaseTester app from Xcode with the SKConfig file configured.',
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: _fetchProduct,
+                child: const Text('Fetch Product'),
+              ),
+              if (_error != null)
+                Text(
+                  _error!,
+                  style: const TextStyle(color: Colors.red),
+                ),
+              if (_product != null) ...[
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Text(_product!.title),
+                        Text(_product!.description),
+                        Text(_product!.priceString),
+                        ElevatedButton(
+                          onPressed: () => _purchaseProduct(_product!),
+                          child: const Text('Purchase'),
+                        ),
+                        ElevatedButton(
+                          onPressed: () =>
+                              _fetchEligibleWinBackOffersForProduct(_product!),
+                          child: const Text(
+                              'Fetch Eligible Win-Back Offers for this Product'),
+                        ),
+                        if (_productWinBackOffers.isNotEmpty)
+                          Column(
+                            crossAxisAlignment: CrossAxisAlignment.stretch,
+                            children: _productWinBackOffers
+                                .map(
+                                  (offer) => Card(
+                                    child: Padding(
+                                      padding: const EdgeInsets.all(8.0),
+                                      child: Column(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.stretch,
+                                        children: [
+                                          Text(
+                                              'Identifier: ${offer.identifier}'),
+                                          Text('Price: ${offer.priceString}'),
+                                          Text('Cycles: ${offer.cycles}'),
+                                          Text('Period: ${offer.period}'),
+                                          Text(
+                                              'Period Unit: ${offer.periodUnit}'),
+                                          Text(
+                                              'Period Number of Units: ${offer.periodNumberOfUnits}'),
+                                          ElevatedButton(
+                                            onPressed: () =>
+                                                _purchaseWinBackOfferForProduct(
+                                                    _product!, offer),
+                                            child: const Text(
+                                                'Purchase Win-Back Offer'),
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                  ),
+                                )
+                                .toList(),
+                          ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+              ElevatedButton(
+                onPressed: _fetchPackage,
+                child: const Text('Fetch Package'),
+              ),
+              if (_package != null)
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Text(_package!.identifier),
+                        Text(_package!.storeProduct.description),
+                        Text(_package!.storeProduct.priceString),
+                        ElevatedButton(
+                          onPressed: () => _purchasePackage(_package!),
+                          child: const Text('Purchase'),
+                        ),
+                        ElevatedButton(
+                          onPressed: () =>
+                              _fetchEligibleWinBackOffersForPackage(_package!),
+                          child: const Text(
+                              'Fetch Eligible Win-Back Offers for this Package'),
+                        ),
+                        ..._packageWinBackOffers.map(
+                          (offer) => Card(
+                            child: Padding(
+                              padding: const EdgeInsets.all(8.0),
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.stretch,
+                                children: [
+                                  Text('Identifier: ${offer.identifier}'),
+                                  Text('Price: ${offer.priceString}'),
+                                  Text('Cycles: ${offer.cycles}'),
+                                  Text('Period: ${offer.period}'),
+                                  Text('Period Unit: ${offer.periodUnit}'),
+                                  Text(
+                                      'Period Number of Units: ${offer.periodNumberOfUnits}'),
+                                  ElevatedButton(
+                                    onPressed: () =>
+                                        _purchaseWinBackOfferForPackage(
+                                            _package!, offer),
+                                    child:
+                                        const Text('Purchase Win-Back Offer'),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This PR exposes four new functions to allow developers to fetch & redeem win-back offers that a subscriber is eligible for in their custom paywalls. These functions only function on iOS 18.0+ and require StoreKit 2 to be used.

### Fetching Eligible Win-Back Offers
```dart
  static Future<List<WinBackOffer>> getEligibleWinBackOffersForProduct(
    StoreProduct product,
  ) async

static Future<List<WinBackOffer>> getEligibleWinBackOffersForPackage(
    Package package,
  ) async
```

### Redeeming Win-Back Offers
```dart
static Future<CustomerInfo> purchaseProductWithWinBackOffer(
    StoreProduct product,
    WinBackOffer winBackOffer,
  ) async

 static Future<CustomerInfo> purchasePackageWithWinBackOffer(
    Package package,
    WinBackOffer winBackOffer,
  ) async
```

### Other Changes
The PurchaseTester app was updated with a new screen to support testing these flows

### Docs
Code snippets for these functions are added to the public docs in this PR: https://github.com/RevenueCat/docusaurus/pull/526

### Testing
All flows were tested manually through the new screen in the PurchaseTester app, and the API tester has been updated with the new functions.
