### PR TITLE
Flutter Web: Start purchase flow + fix some mappings in offerings

### DIFF
--- a/lib/models/package_wrapper.dart
+++ b/lib/models/package_wrapper.dart
@@ -69,6 +69,9 @@ class Package with _$Package {
 
     /// Offering context this package belongs to.
     PresentedOfferingContext presentedOfferingContext,
+
+    /// Package data provided by the native SDKs. Not to be used directly.
+    Map<dynamic, dynamic> nativePackage,
   ) = _Package;
 
   factory Package.fromJson(Map<String, dynamic> json) =>

--- a/lib/models/package_wrapper.freezed.dart
+++ b/lib/models/package_wrapper.freezed.dart
@@ -38,6 +38,9 @@ mixin _$Package {
   PresentedOfferingContext get presentedOfferingContext =>
       throw _privateConstructorUsedError;
 
+  /// Package data provided by the native SDKs. Not to be used directly.
+  Map<dynamic, dynamic> get nativePackage => throw _privateConstructorUsedError;
+
   /// Serializes this Package to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
 
@@ -57,7 +60,8 @@ abstract class $PackageCopyWith<$Res> {
       @JsonKey(name: 'packageType', unknownEnumValue: PackageType.unknown)
       PackageType packageType,
       @JsonKey(name: 'product') StoreProduct storeProduct,
-      PresentedOfferingContext presentedOfferingContext});
+      PresentedOfferingContext presentedOfferingContext,
+      Map<dynamic, dynamic> nativePackage});
 
   $StoreProductCopyWith<$Res> get storeProduct;
   $PresentedOfferingContextCopyWith<$Res> get presentedOfferingContext;
@@ -82,6 +86,7 @@ class _$PackageCopyWithImpl<$Res, $Val extends Package>
     Object? packageType = null,
     Object? storeProduct = null,
     Object? presentedOfferingContext = null,
+    Object? nativePackage = null,
   }) {
     return _then(_value.copyWith(
       identifier: null == identifier
@@ -100,6 +105,10 @@ class _$PackageCopyWithImpl<$Res, $Val extends Package>
           ? _value.presentedOfferingContext
           : presentedOfferingContext // ignore: cast_nullable_to_non_nullable
               as PresentedOfferingContext,
+      nativePackage: null == nativePackage
+          ? _value.nativePackage
+          : nativePackage // ignore: cast_nullable_to_non_nullable
+              as Map<dynamic, dynamic>,
     ) as $Val);
   }
 
@@ -137,7 +146,8 @@ abstract class _$$PackageImplCopyWith<$Res> implements $PackageCopyWith<$Res> {
       @JsonKey(name: 'packageType', unknownEnumValue: PackageType.unknown)
       PackageType packageType,
       @JsonKey(name: 'product') StoreProduct storeProduct,
-      PresentedOfferingContext presentedOfferingContext});
+      PresentedOfferingContext presentedOfferingContext,
+      Map<dynamic, dynamic> nativePackage});
 
   @override
   $StoreProductCopyWith<$Res> get storeProduct;
@@ -162,6 +172,7 @@ class __$$PackageImplCopyWithImpl<$Res>
     Object? packageType = null,
     Object? storeProduct = null,
     Object? presentedOfferingContext = null,
+    Object? nativePackage = null,
   }) {
     return _then(_$PackageImpl(
       null == identifier
@@ -180,6 +191,10 @@ class __$$PackageImplCopyWithImpl<$Res>
           ? _value.presentedOfferingContext
           : presentedOfferingContext // ignore: cast_nullable_to_non_nullable
               as PresentedOfferingContext,
+      null == nativePackage
+          ? _value._nativePackage
+          : nativePackage // ignore: cast_nullable_to_non_nullable
+              as Map<dynamic, dynamic>,
     ));
   }
 }
@@ -192,7 +207,9 @@ class _$PackageImpl implements _Package {
       @JsonKey(name: 'packageType', unknownEnumValue: PackageType.unknown)
       this.packageType,
       @JsonKey(name: 'product') this.storeProduct,
-      this.presentedOfferingContext);
+      this.presentedOfferingContext,
+      final Map<dynamic, dynamic> nativePackage)
+      : _nativePackage = nativePackage;
 
   factory _$PackageImpl.fromJson(Map<String, dynamic> json) =>
       _$$PackageImplFromJson(json);
@@ -218,9 +235,20 @@ class _$PackageImpl implements _Package {
   @override
   final PresentedOfferingContext presentedOfferingContext;
 
+  /// Package data provided by the native SDKs. Not to be used directly.
+  final Map<dynamic, dynamic> _nativePackage;
+
+  /// Package data provided by the native SDKs. Not to be used directly.
+  @override
+  Map<dynamic, dynamic> get nativePackage {
+    if (_nativePackage is EqualUnmodifiableMapView) return _nativePackage;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(_nativePackage);
+  }
+
   @override
   String toString() {
-    return 'Package(identifier: $identifier, packageType: $packageType, storeProduct: $storeProduct, presentedOfferingContext: $presentedOfferingContext)';
+    return 'Package(identifier: $identifier, packageType: $packageType, storeProduct: $storeProduct, presentedOfferingContext: $presentedOfferingContext, nativePackage: $nativePackage)';
   }
 
   @override
@@ -236,13 +264,20 @@ class _$PackageImpl implements _Package {
                 other.storeProduct == storeProduct) &&
             (identical(
                     other.presentedOfferingContext, presentedOfferingContext) ||
-                other.presentedOfferingContext == presentedOfferingContext));
+                other.presentedOfferingContext == presentedOfferingContext) &&
+            const DeepCollectionEquality()
+                .equals(other._nativePackage, _nativePackage));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(runtimeType, identifier, packageType,
-      storeProduct, presentedOfferingContext);
+  int get hashCode => Object.hash(
+      runtimeType,
+      identifier,
+      packageType,
+      storeProduct,
+      presentedOfferingContext,
+      const DeepCollectionEquality().hash(_nativePackage));
 
   /// Create a copy of Package
   /// with the given fields replaced by the non-null parameter values.
@@ -266,7 +301,8 @@ abstract class _Package implements Package {
       @JsonKey(name: 'packageType', unknownEnumValue: PackageType.unknown)
       final PackageType packageType,
       @JsonKey(name: 'product') final StoreProduct storeProduct,
-      final PresentedOfferingContext presentedOfferingContext) = _$PackageImpl;
+      final PresentedOfferingContext presentedOfferingContext,
+      final Map<dynamic, dynamic> nativePackage) = _$PackageImpl;
 
   factory _Package.fromJson(Map<String, dynamic> json) = _$PackageImpl.fromJson;
 
@@ -290,6 +326,10 @@ abstract class _Package implements Package {
   /// Offering context this package belongs to.
   @override
   PresentedOfferingContext get presentedOfferingContext;
+
+  /// Package data provided by the native SDKs. Not to be used directly.
+  @override
+  Map<dynamic, dynamic> get nativePackage;
 
   /// Create a copy of Package
   /// with the given fields replaced by the non-null parameter values.

--- a/lib/models/package_wrapper.g.dart
+++ b/lib/models/package_wrapper.g.dart
@@ -13,6 +13,7 @@ _$PackageImpl _$$PackageImplFromJson(Map json) => _$PackageImpl(
       StoreProduct.fromJson(Map<String, dynamic>.from(json['product'] as Map)),
       PresentedOfferingContext.fromJson(
           Map<String, dynamic>.from(json['presentedOfferingContext'] as Map)),
+      json['nativePackage'] as Map,
     );
 
 Map<String, dynamic> _$$PackageImplToJson(_$PackageImpl instance) =>
@@ -21,6 +22,7 @@ Map<String, dynamic> _$$PackageImplToJson(_$PackageImpl instance) =>
       'packageType': _$PackageTypeEnumMap[instance.packageType]!,
       'product': instance.storeProduct.toJson(),
       'presentedOfferingContext': instance.presentedOfferingContext.toJson(),
+      'nativePackage': instance.nativePackage,
     };
 
 const _$PackageTypeEnumMap = {

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -449,6 +449,7 @@ class Purchases {
           googleProductChangeInfo?.oldProductIdentifier ?? upgradeInfo?.oldSKU,
       'googleProrationMode': prorationMode,
       'googleIsPersonalizedPrice': googleIsPersonalizedPrice,
+      'nativePackage': packageToPurchase.nativePackage,
     });
     return customerInfo;
   }

--- a/lib/web/purchases_flutter_web.dart
+++ b/lib/web/purchases_flutter_web.dart
@@ -923,21 +923,28 @@ class PurchasesFlutterPlugin {
     return packages;
   }
 
-  Map<String, dynamic> _convertJsProduct(dynamic jsProduct) => {
-        'identifier': jsProduct['identifier'],
-        'title': jsProduct['title'],
-        'description': jsProduct['description'],
-        'price': jsProduct['currentPrice']?['amountMicros'] ?? 0,
-        'priceString': jsProduct['currentPrice']?['formattedPrice'],
-        'currencyCode': jsProduct['currentPrice']?['currency'],
-        'productType': _convertProductType(jsProduct['productType']),
-        'subscriptionOptions': _convertSubscriptionOptions(
-          jsProduct['subscriptionOptions'],
-          jsProduct['identifier'],
-        ),
-        'presentedOfferingIdentifier': jsProduct['presentedOfferingContext']
-            ?['offeringIdentifier'],
-      };
+  Map<String, dynamic> _convertJsProduct(dynamic jsProduct) {
+    final presentedOfferingContext = _convertPresentedOfferingContext(
+      jsProduct['presentedOfferingContext'],
+    );
+
+    return {
+      'identifier': jsProduct['identifier'],
+      'title': jsProduct['title'],
+      'description': jsProduct['description'],
+      'price': jsProduct['currentPrice']?['amountMicros'] ?? 0,
+      'priceString': jsProduct['currentPrice']?['formattedPrice'],
+      'currencyCode': jsProduct['currentPrice']?['currency'],
+      'productType': _convertProductType(jsProduct['productType']),
+      'subscriptionOptions': _convertSubscriptionOptions(
+        jsProduct['subscriptionOptions'],
+        jsProduct['identifier'],
+      ),
+      'presentedOfferingContext': presentedOfferingContext,
+      'presentedOfferingIdentifier':
+          presentedOfferingContext?['offeringIdentifier'],
+    };
+  }
 
   String _convertPackageType(String identifier) {
     switch (identifier) {
@@ -977,27 +984,16 @@ class PurchasesFlutterPlugin {
   }
 
   Map<String, dynamic> _convertJsPackage(dynamic jsPackage) {
-    final presentedOfferingContext =
-        jsPackage['rcBillingProduct']?['presentedOfferingContext'];
-    Map<String, dynamic>? targetingContext;
-    if (presentedOfferingContext?['targetingContext'] != null) {
-      targetingContext = {
-        'ruleId': presentedOfferingContext?['targetingContext']?['ruleId'],
-        'revision': presentedOfferingContext?['targetingContext']?['revision'],
-      };
-    } else {
-      targetingContext = null;
-    }
+    final presentedOfferingContext = _convertPresentedOfferingContext(
+      jsPackage['presentedOfferingContext'],
+    );
+
     return {
       'identifier': jsPackage['identifier'],
       'packageType': _convertPackageType(jsPackage['identifier']),
       'product': _convertJsProduct(jsPackage['rcBillingProduct']),
+      'presentedOfferingContext': presentedOfferingContext,
       'offeringIdentifier': presentedOfferingContext?['offeringIdentifier'],
-      'presentedOfferingContext': {
-        'offeringIdentifier': presentedOfferingContext?['offeringIdentifier'],
-        'placementIdentifier': presentedOfferingContext?['placementIdentifier'],
-        'targetingContext': targetingContext,
-      },
       'nativePackage': _jsObjectToMap(jsPackage),
     };
   }
@@ -1134,5 +1130,27 @@ class PurchasesFlutterPlugin {
     }
 
     return map;
+  }
+
+  Map<String, dynamic>? _convertPresentedOfferingContext(
+    dynamic presentedOfferingContext,
+  ) {
+    if (presentedOfferingContext == null) {
+      return null;
+    }
+
+    Map<String, dynamic>? targetingContext;
+    if (presentedOfferingContext['targetingContext'] != null) {
+      targetingContext = {
+        'ruleId': presentedOfferingContext['targetingContext']['ruleId'],
+        'revision': presentedOfferingContext['targetingContext']['revision'],
+      };
+    }
+
+    return {
+      'offeringIdentifier': presentedOfferingContext['offeringIdentifier'],
+      'placementIdentifier': presentedOfferingContext['placementIdentifier'],
+      'targetingContext': targetingContext,
+    };
   }
 }

--- a/lib/web/purchases_flutter_web.dart
+++ b/lib/web/purchases_flutter_web.dart
@@ -185,12 +185,6 @@ class PurchasesFlutterPlugin {
         purchases = purchases['Purchases'];
       }
 
-      // Check if SDK is already configured
-      final isConfigured = purchases.callMethod('isConfigured') as bool;
-      if (isConfigured) {
-        return;
-      }
-
       final apiKey = arguments['apiKey'] as String?;
       if (apiKey == null) {
         throw PlatformException(
@@ -475,22 +469,23 @@ class PurchasesFlutterPlugin {
 
     final completer = Completer<Map<String, dynamic>>();
     final nativePackageJsified = js.JsObject.jsify(arguments['nativePackage']);
-    final promise = instance.callMethod('purchasePackage', [nativePackageJsified]);
+    final promise =
+        instance.callMethod('purchasePackage', [nativePackageJsified]);
     promise.callMethod(
       'then',
       [
         js.allowInterop(
-              (result) => print("TEST SUCCESS PURCHASING PACKAGE"),
+          (result) => print("TEST SUCCESS PURCHASING PACKAGE"),
         ),
       ],
     ).callMethod('catch', [
       js.allowInterop(
-            (error) => completer.completeError(
-              PlatformException(
-                code: 'PurchasePackage',
-                message: error.toString(),
-              ),
-            ),
+        (error) => completer.completeError(
+          PlatformException(
+            code: 'PurchasePackage',
+            message: error.toString(),
+          ),
+        ),
       ),
     ]);
 
@@ -904,9 +899,8 @@ class PurchasesFlutterPlugin {
     }
 
     return {
-      'current': currentOffering != null
-          ? _convertJsOffering(currentOffering)
-          : null,
+      'current':
+          currentOffering != null ? _convertJsOffering(currentOffering) : null,
       'all': allOfferingsMap,
     };
   }
@@ -932,10 +926,10 @@ class PurchasesFlutterPlugin {
         'priceString': jsProduct['currentPrice']?['formattedPrice'],
         'currencyCode': jsProduct['currentPrice']?['currency'],
         'productType': _convertProductType(jsProduct['productType']),
-        'subscriptionOptions':
-            _convertSubscriptionOptions(jsProduct['subscriptionOptions'],
-                jsProduct['identifier'],
-            ),
+        'subscriptionOptions': _convertSubscriptionOptions(
+          jsProduct['subscriptionOptions'],
+          jsProduct['identifier'],
+        ),
         'presentedOfferingIdentifier': jsProduct['presentedOfferingContext']
             ?['offeringIdentifier'],
       };
@@ -978,10 +972,10 @@ class PurchasesFlutterPlugin {
   }
 
   Map<String, dynamic> _convertJsPackage(dynamic jsPackage) {
-    final presentedOfferingContext = jsPackage['rcBillingProduct']
-    ?['presentedOfferingContext'];
+    final presentedOfferingContext =
+        jsPackage['rcBillingProduct']?['presentedOfferingContext'];
     Map<String, dynamic>? targetingContext;
-    if (presentedOfferingContext?[ 'targetingContext'] != null) {
+    if (presentedOfferingContext?['targetingContext'] != null) {
       targetingContext = {
         'ruleId': presentedOfferingContext?['targetingContext']?['ruleId'],
         'revision': presentedOfferingContext?['targetingContext']?['revision'],
@@ -993,13 +987,10 @@ class PurchasesFlutterPlugin {
       'identifier': jsPackage['identifier'],
       'packageType': _convertPackageType(jsPackage['identifier']),
       'product': _convertJsProduct(jsPackage['rcBillingProduct']),
-      'offeringIdentifier': presentedOfferingContext
-      ?['offeringIdentifier'],
+      'offeringIdentifier': presentedOfferingContext?['offeringIdentifier'],
       'presentedOfferingContext': {
-        'offeringIdentifier': presentedOfferingContext
-        ?['offeringIdentifier'],
-        'placementIdentifier': presentedOfferingContext
-        ?['placementIdentifier'],
+        'offeringIdentifier': presentedOfferingContext?['offeringIdentifier'],
+        'placementIdentifier': presentedOfferingContext?['placementIdentifier'],
         'targetingContext': targetingContext,
       },
       'nativePackage': _jsObjectToMap(jsPackage),
@@ -1051,7 +1042,8 @@ class PurchasesFlutterPlugin {
           'value': option['base']?['period']?['number'],
         },
         'isPrepaid': false,
-        'presentedOfferingContext': null, // TODO: Implement presented offering context
+        'presentedOfferingContext':
+            null, // TODO: Implement presented offering context
       });
     }
 
@@ -1076,12 +1068,14 @@ class PurchasesFlutterPlugin {
         'offerPaymentMode': null, // TODO: Support offer payment mode
       };
 
-  String _convertPeriodUnit(String periodUnit) => {
-      'day': 'DAY',
-      'week': 'WEEK',
-      'month': 'MONTH',
-      'year': 'YEAR',
-    }[periodUnit] ?? 'UNKNOWN';
+  String _convertPeriodUnit(String periodUnit) =>
+      {
+        'day': 'DAY',
+        'week': 'WEEK',
+        'month': 'MONTH',
+        'year': 'YEAR',
+      }[periodUnit] ??
+      'UNKNOWN';
 
   Map<String, dynamic> _convertJsOffering(dynamic jsOffering) {
     Map<String, dynamic> metadata = {};
@@ -1092,19 +1086,17 @@ class PurchasesFlutterPlugin {
       'identifier': jsOffering['identifier'],
       'serverDescription': jsOffering['serverDescription'],
       'metadata': metadata,
-      'availablePackages':
-        _convertJsPackages(jsOffering['availablePackages']),
+      'availablePackages': _convertJsPackages(jsOffering['availablePackages']),
       'lifetime':
-        _findPackageByType(jsOffering['availablePackages'], rcLifetime),
+          _findPackageByType(jsOffering['availablePackages'], rcLifetime),
       'annual': _findPackageByType(jsOffering['availablePackages'], rcAnnual),
       'sixMonth':
-        _findPackageByType(jsOffering['availablePackages'], rcSixMonth),
+          _findPackageByType(jsOffering['availablePackages'], rcSixMonth),
       'threeMonth':
-        _findPackageByType(jsOffering['availablePackages'], rcThreeMonth),
+          _findPackageByType(jsOffering['availablePackages'], rcThreeMonth),
       'twoMonth':
-        _findPackageByType(jsOffering['availablePackages'], rcTwoMonth),
-      'monthly':
-        _findPackageByType(jsOffering['availablePackages'], rcMonthly),
+          _findPackageByType(jsOffering['availablePackages'], rcTwoMonth),
+      'monthly': _findPackageByType(jsOffering['availablePackages'], rcMonthly),
       'weekly': _findPackageByType(jsOffering['availablePackages'], rcWeekly),
     };
   }

--- a/lib/web/purchases_flutter_web.dart
+++ b/lib/web/purchases_flutter_web.dart
@@ -4,14 +4,19 @@ import 'dart:js' as js;
 import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
-const String rcLifetime = '\$rc_lifetime';
-const String rcAnnual = '\$rc_annual';
-const String rcSixMonth = '\$rc_six_month';
-const String rcThreeMonth = '\$rc_three_month';
-const String rcTwoMonth = '\$rc_two_month';
-const String rcMonthly = '\$rc_monthly';
-const String rcWeekly = '\$rc_weekly';
 const String rcPrefix = '\$rc_';
+
+class WebPackageType {
+  static const String unknown = 'unknown';
+  static const String custom = 'custom';
+  static const String lifetime = '${rcPrefix}lifetime';
+  static const String annual = '${rcPrefix}annual';
+  static const String sixMonth = '${rcPrefix}six_month';
+  static const String threeMonth = '${rcPrefix}three_month';
+  static const String twoMonth = '${rcPrefix}two_month';
+  static const String monthly = '${rcPrefix}monthly';
+  static const String weekly = '${rcPrefix}weekly';
+}
 
 enum LogLevel {
   verbose,
@@ -936,19 +941,19 @@ class PurchasesFlutterPlugin {
 
   String _convertPackageType(String identifier) {
     switch (identifier) {
-      case rcLifetime:
+      case WebPackageType.lifetime:
         return 'LIFETIME';
-      case rcAnnual:
+      case WebPackageType.annual:
         return 'ANNUAL';
-      case rcSixMonth:
+      case WebPackageType.sixMonth:
         return 'SIX_MONTH';
-      case rcThreeMonth:
+      case WebPackageType.threeMonth:
         return 'THREE_MONTH';
-      case rcTwoMonth:
+      case WebPackageType.twoMonth:
         return 'TWO_MONTH';
-      case rcMonthly:
+      case WebPackageType.monthly:
         return 'MONTHLY';
-      case rcWeekly:
+      case WebPackageType.weekly:
         return 'WEEKLY';
       default:
         if (identifier.startsWith(rcPrefix)) {
@@ -1087,17 +1092,20 @@ class PurchasesFlutterPlugin {
       'serverDescription': jsOffering['serverDescription'],
       'metadata': metadata,
       'availablePackages': _convertJsPackages(jsOffering['availablePackages']),
-      'lifetime':
-          _findPackageByType(jsOffering['availablePackages'], rcLifetime),
-      'annual': _findPackageByType(jsOffering['availablePackages'], rcAnnual),
-      'sixMonth':
-          _findPackageByType(jsOffering['availablePackages'], rcSixMonth),
-      'threeMonth':
-          _findPackageByType(jsOffering['availablePackages'], rcThreeMonth),
-      'twoMonth':
-          _findPackageByType(jsOffering['availablePackages'], rcTwoMonth),
-      'monthly': _findPackageByType(jsOffering['availablePackages'], rcMonthly),
-      'weekly': _findPackageByType(jsOffering['availablePackages'], rcWeekly),
+      'lifetime': _findPackageByType(
+          jsOffering['availablePackages'], WebPackageType.lifetime),
+      'annual': _findPackageByType(
+          jsOffering['availablePackages'], WebPackageType.annual),
+      'sixMonth': _findPackageByType(
+          jsOffering['availablePackages'], WebPackageType.sixMonth),
+      'threeMonth': _findPackageByType(
+          jsOffering['availablePackages'], WebPackageType.threeMonth),
+      'twoMonth': _findPackageByType(
+          jsOffering['availablePackages'], WebPackageType.twoMonth),
+      'monthly': _findPackageByType(
+          jsOffering['availablePackages'], WebPackageType.monthly),
+      'weekly': _findPackageByType(
+          jsOffering['availablePackages'], WebPackageType.weekly),
     };
   }
 

--- a/revenuecat_examples/purchase_tester/lib/main.dart
+++ b/revenuecat_examples/purchase_tester/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:purchases_flutter/purchases_flutter.dart';
 import 'package:purchases_flutter_example/src/constant.dart';
@@ -8,7 +9,12 @@ import 'store_config.dart';
 import 'src/app.dart';
 
 void main() async {
-  if (Platform.isIOS || Platform.isMacOS) {
+  if (kIsWeb) {
+    StoreConfig(
+      store: Store.rcBilling,
+      apiKey: webApiKey,
+    );
+  } else if (Platform.isIOS || Platform.isMacOS) {
     StoreConfig(
       store: Store.appStore,
       apiKey: appleApiKey,

--- a/revenuecat_examples/purchase_tester/lib/src/constant.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/constant.dart
@@ -7,4 +7,7 @@ const googleApiKey = 'googl_api_key';
 //TO DO: add the Amazon API key for your app from the RevenueCat dashboard: https://app.revenuecat.com
 const amazonApiKey = 'amazon_api_key';
 
+//TO DO: add the Web API key for your app from the RevenueCat dashboard: https://app.revenuecat.com
+const webApiKey = 'web_api_key';
+
 const entitlementKey = 'pro';


### PR DESCRIPTION
This PR allows to start the purchasePackage method and display the purchase flow. It doesn't currently have a response though.

Additionally, this performs some fixes in some mappings around to be able to read offerings correctly from the latest purchase tester.

Purchase tester running on web:

https://github.com/user-attachments/assets/b9b51385-daba-42bd-9a9c-8f3b149a6e32


