### PR TITLE
Add proguard-rules.pro to `purchases-ui-flutter`

### DIFF
--- a/purchases_ui_flutter/android/build.gradle
+++ b/purchases_ui_flutter/android/build.gradle
@@ -47,7 +47,11 @@ android {
         minSdkVersion 24
         compileSdk 34
     }
-
+    buildTypes {
+        release {
+            consumerProguardFiles 'proguard-rules.pro'
+        }
+    }
     dependencies {
         implementation "com.revenuecat.purchases:purchases-hybrid-common-ui:$common_version"
         implementation 'androidx.compose.ui:ui-android:1.5.4'

--- a/purchases_ui_flutter/android/proguard-rules.pro
+++ b/purchases_ui_flutter/android/proguard-rules.pro
@@ -1,0 +1,1 @@
+-keep class org.xmlpull.v1.** { *; }

--- a/purchases_ui_flutter/android/proguard-rules.pro
+++ b/purchases_ui_flutter/android/proguard-rules.pro
@@ -1,1 +1,4 @@
+# The org.xmlpull package is part of the Android framework, so the classes are always available.
+# However, some apps add it to their classpath, either explicitly or transitively. When
+# this happens, it becomes susceptible to be shrunk. The following rule avoids that.
 -keep class org.xmlpull.v1.** { *; }


### PR DESCRIPTION
Fixes:

- https://github.com/RevenueCat/purchases-flutter/issues/1245
- https://github.com/RevenueCat/purchases-flutter/issues/1269
- https://community.revenuecat.com/general-questions-7/app-crashing-when-paywall-is-open-on-flutter-5826?postid=20041#post20041

This is not really caused by us, as we don't have a direct dependency on `org.xmlpull` but we keep getting reports so we have decided to add it to our own proguard rules. This library is bundled by the OS, and if the library doesn't exist it won't have any effect, but if one of the dependencies of the app adding our plugin has a direct dependency and overrides it, it will the classes.

I think the key here (and why this doesn’t happen for purchases-android) is that in flutter apps, packages are compiled by the developers as Android modules. So if one of the flutter packages has a dependency on a different version of `org.xmlpull.v1` than the one the system bundles (and the one we compile purchases-android against), the app will be compiled using that version. Since R8 optimizes each app individually, it will analyze `org.xmlpull.v1` and strip out “unused” code from that direct dependency, and our code crashes because it was compiled to depend on those references that have been stripped.
 