### PR TITLE
Add prepaid periodType

### DIFF
--- a/api_tester/lib/api_tests/models/entitlement_info_wrapper_api_test.dart
+++ b/api_tester/lib/api_tests/models/entitlement_info_wrapper_api_test.dart
@@ -8,6 +8,7 @@ class _EntitlementInfoApiTest {
       case PeriodType.intro:
       case PeriodType.normal:
       case PeriodType.trial:
+      case PeriodType.prepaid:
       case PeriodType.unknown:
         break;
     }

--- a/lib/models/entitlement_info_wrapper.dart
+++ b/lib/models/entitlement_info_wrapper.dart
@@ -20,6 +20,10 @@ enum PeriodType {
   @JsonValue('TRIAL')
   trial,
 
+  /// If the entitlement is under a prepaid period.
+  @JsonValue('PREPAID')
+  prepaid,
+
   /// If the period type couldn't be determined.
   unknown
 }

--- a/lib/models/entitlement_info_wrapper.g.dart
+++ b/lib/models/entitlement_info_wrapper.g.dart
@@ -76,6 +76,7 @@ const _$PeriodTypeEnumMap = {
   PeriodType.intro: 'INTRO',
   PeriodType.normal: 'NORMAL',
   PeriodType.trial: 'TRIAL',
+  PeriodType.prepaid: 'PREPAID',
   PeriodType.unknown: 'unknown',
 };
 

--- a/test/entitlement_info_test.dart
+++ b/test/entitlement_info_test.dart
@@ -50,6 +50,32 @@ void main() {
     expect(entitlementInfo.periodType, PeriodType.unknown);
   });
 
+  test('prepaid period type if PREPAID is contained in json', () {
+    final entitlementInfoJson = {
+      'identifier': 'almost_pro',
+      'isActive': true,
+      'willRenew': true,
+      'periodType': 'PREPAID',
+      'latestPurchaseDateMillis': 1.58759855E9,
+      'latestPurchaseDate': '2020-04-22T23:35:50.000Z',
+      'originalPurchaseDateMillis': 1.591725245E9,
+      'originalPurchaseDate': '2020-06-09T17:54:05.000Z',
+      'expirationDateMillis': null,
+      'expirationDate': null,
+      'store': 'PLAY_STORE',
+      'productIdentifier': 'consumable',
+      'isSandbox': true,
+      'unsubscribeDetectedAt': null,
+      'unsubscribeDetectedAtMillis': null,
+      'billingIssueDetectedAt': null,
+      'billingIssueDetectedAtMillis': null,
+      'verification': 'VERIFIED',
+    };
+    final entitlementInfo = EntitlementInfo.fromJson(entitlementInfoJson);
+
+    expect(entitlementInfo.periodType, PeriodType.prepaid);
+  });
+
   test('unknown store if missing from json', () {
     final entitlementInfoJson = {
       'identifier': 'almost_pro',


### PR DESCRIPTION
Adds the prepaid PeriodType case, along with the API tests and a parsing test