### PR TITLE
Increase android related versions in purchase_tester

### DIFF
--- a/revenuecat_examples/purchase_tester/android/app/build.gradle
+++ b/revenuecat_examples/purchase_tester/android/app/build.gradle
@@ -24,8 +24,8 @@ if (flutterVersionName == null) {
 
 android {
     namespace 'com.revenuecat.purchases_sample'
-    compileSdk 34
-    ndkVersion "25.1.8937393"
+    compileSdk 35
+    ndkVersion "26.3.11579264"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/revenuecat_examples/purchase_tester/android/settings.gradle
+++ b/revenuecat_examples/purchase_tester/android/settings.gradle
@@ -19,8 +19,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.2.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.7.10" apply false
+    id "com.android.application" version "8.7.0" apply false
+    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
 }
 
 include ":app"


### PR DESCRIPTION
- I got a compilation error because integration_test requires a higher compileSdk and ndkVersion 
- I also got a warning that kotlin 1.7.10 was going to be deprecated so I checked out a brand new project and updated the versions in settings.gradle to match that