### PR TITLE
Add `onPurchaseCancelled` handler to `PaywallView` and `PaywallFooterView`

### DIFF
--- a/api_tester/lib/api_tests/purchases_ui_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_ui_flutter_api_test.dart
@@ -70,6 +70,8 @@ class _PurchasesFlutterApiTest {
           onPurchaseCompleted:
               (CustomerInfo customerInfo, StoreTransaction storeTransaction) {
           },
+          onPurchaseCancelled: () {
+          },
           onPurchaseError: (PurchasesError error) {
           },
           onRestoreCompleted: (CustomerInfo customerInfo) {
@@ -146,6 +148,8 @@ class _PurchasesFlutterApiTest {
           onPurchaseCompleted:
               (CustomerInfo customerInfo, StoreTransaction storeTransaction) {
           },
+          onPurchaseCancelled: () {
+          },
           onPurchaseError: (PurchasesError error) {
           },
           onRestoreCompleted: (CustomerInfo customerInfo) {
@@ -170,6 +174,8 @@ class _PurchasesFlutterApiTest {
           },
           onPurchaseCompleted:
               (CustomerInfo customerInfo, StoreTransaction storeTransaction) {
+          },
+          onPurchaseCancelled: () {
           },
           onPurchaseError: (PurchasesError error) {
           },

--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallFooterView.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallFooterView.kt
@@ -63,6 +63,10 @@ internal class PaywallFooterView(
                 )
             }
 
+            override fun onPurchaseCancelled() {
+                methodChannel.invokeMethod("onPurchaseCancelled", null)
+            }
+
             override fun onPurchaseError(error: Map<String, Any?>) {
                 methodChannel.invokeMethod("onPurchaseError", error)
             }

--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallView.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallView.kt
@@ -48,6 +48,10 @@ internal class PaywallView(
                 )
             }
 
+            override fun onPurchaseCancelled() {
+                methodChannel.invokeMethod("onPurchaseCancelled", null)
+            }
+
             override fun onPurchaseError(error: Map<String, Any?>) {
                 methodChannel.invokeMethod("onPurchaseError", error)
             }

--- a/purchases_ui_flutter/ios/Classes/PurchasesUiPaywallFooterView.swift
+++ b/purchases_ui_flutter/ios/Classes/PurchasesUiPaywallFooterView.swift
@@ -98,6 +98,10 @@ extension PurchasesUiPaywallFooterView: PaywallViewControllerDelegateWrapper {
         ])
     }
 
+    func paywallViewController(_ controller: PaywallViewController) {
+        channel.invokeMethod("onPurchaseCancelled", arguments: nil)
+    }
+
     func paywallViewController(_ controller: PaywallViewController,
                                didFailPurchasingWith errorDictionary: [String : Any]) {
         channel.invokeMethod("onPurchaseError", arguments: errorDictionary)

--- a/purchases_ui_flutter/ios/Classes/PurchasesUiPaywallFooterView.swift
+++ b/purchases_ui_flutter/ios/Classes/PurchasesUiPaywallFooterView.swift
@@ -98,7 +98,7 @@ extension PurchasesUiPaywallFooterView: PaywallViewControllerDelegateWrapper {
         ])
     }
 
-    func paywallViewController(_ controller: PaywallViewController) {
+    func paywallViewControllerDidCancelPurchase(_ controller: PaywallViewController) {
         channel.invokeMethod("onPurchaseCancelled", arguments: nil)
     }
 

--- a/purchases_ui_flutter/ios/Classes/PurchasesUiPaywallView.swift
+++ b/purchases_ui_flutter/ios/Classes/PurchasesUiPaywallView.swift
@@ -141,7 +141,7 @@ extension PurchasesUiPaywallView: PaywallViewControllerDelegateWrapper {
         ])
     }
 
-    func paywallViewController(_ controller: PaywallViewController) {
+    func paywallViewControllerDidCancelPurchase(_ controller: PaywallViewController) {
         _methodChannel.invokeMethod("onPurchaseCancelled", arguments: nil)
     }
 

--- a/purchases_ui_flutter/ios/Classes/PurchasesUiPaywallView.swift
+++ b/purchases_ui_flutter/ios/Classes/PurchasesUiPaywallView.swift
@@ -141,6 +141,10 @@ extension PurchasesUiPaywallView: PaywallViewControllerDelegateWrapper {
         ])
     }
 
+    func paywallViewController(_ controller: PaywallViewController) {
+        _methodChannel.invokeMethod("onPurchaseCancelled", arguments: nil)
+    }
+
     func paywallViewController(_ controller: PaywallViewController, 
                                didFailPurchasingWith errorDictionary: [String : Any]) {
         _methodChannel.invokeMethod("onPurchaseError", arguments: errorDictionary)

--- a/purchases_ui_flutter/lib/views/internal_paywall_footer_view.dart
+++ b/purchases_ui_flutter/lib/views/internal_paywall_footer_view.dart
@@ -18,6 +18,7 @@ class InternalPaywallFooterView extends StatelessWidget {
   final Function(Package rcPackage)? onPurchaseStarted;
   final Function(CustomerInfo customerInfo, StoreTransaction storeTransaction)?
   onPurchaseCompleted;
+  final Function()? onPurchaseCancelled;
   final Function(PurchasesError)? onPurchaseError;
   final Function(CustomerInfo customerInfo)? onRestoreCompleted;
   final Function(PurchasesError)? onRestoreError;
@@ -29,6 +30,7 @@ class InternalPaywallFooterView extends StatelessWidget {
     this.offering,
     this.onPurchaseStarted,
     this.onPurchaseCompleted,
+    this.onPurchaseCancelled,
     this.onPurchaseError,
     this.onRestoreCompleted,
     this.onRestoreError,
@@ -86,6 +88,7 @@ class InternalPaywallFooterView extends StatelessWidget {
     final handler = PaywallViewMethodHandler(
       onPurchaseStarted,
       onPurchaseCompleted,
+      onPurchaseCancelled,
       onPurchaseError,
       onRestoreCompleted,
       onRestoreError,

--- a/purchases_ui_flutter/lib/views/paywall_footer_view.dart
+++ b/purchases_ui_flutter/lib/views/paywall_footer_view.dart
@@ -45,6 +45,7 @@ class PaywallFooterView extends OriginalTemplatePaywallFooterView {
     Offering? offering,
     Function(Package rcPackage)? onPurchaseStarted,
     Function(CustomerInfo customerInfo, StoreTransaction storeTransaction)? onPurchaseCompleted,
+    Function()? onPurchaseCancelled,
     Function(PurchasesError)? onPurchaseError,
     Function(CustomerInfo customerInfo)? onRestoreCompleted,
     Function(PurchasesError)? onRestoreError,
@@ -55,6 +56,7 @@ class PaywallFooterView extends OriginalTemplatePaywallFooterView {
       offering: offering,
       onPurchaseStarted: onPurchaseStarted,
       onPurchaseCompleted: onPurchaseCompleted,
+      onPurchaseCancelled: onPurchaseCancelled,
       onPurchaseError: onPurchaseError,
       onRestoreCompleted: onRestoreCompleted,
       onRestoreError: onRestoreError,
@@ -97,6 +99,7 @@ class OriginalTemplatePaywallFooterView extends StatefulWidget {
   final Function(Package rcPackage)? onPurchaseStarted;
   final Function(CustomerInfo customerInfo, StoreTransaction storeTransaction)?
   onPurchaseCompleted;
+  final Function()? onPurchaseCancelled;
   final Function(PurchasesError)? onPurchaseError;
   final Function(CustomerInfo customerInfo)? onRestoreCompleted;
   final Function(PurchasesError)? onRestoreError;
@@ -108,6 +111,7 @@ class OriginalTemplatePaywallFooterView extends StatefulWidget {
     this.offering,
     this.onPurchaseStarted,
     this.onPurchaseCompleted,
+    this.onPurchaseCancelled,
     this.onPurchaseError,
     this.onRestoreCompleted,
     this.onRestoreError,
@@ -153,6 +157,7 @@ class _PaywallFooterViewState extends State<OriginalTemplatePaywallFooterView> {
             offering: widget.offering,
             onPurchaseStarted: widget.onPurchaseStarted,
             onPurchaseCompleted: widget.onPurchaseCompleted,
+            onPurchaseCancelled: widget.onPurchaseCancelled,
             onPurchaseError: widget.onPurchaseError,
             onRestoreCompleted: widget.onRestoreCompleted,
             onRestoreError: widget.onRestoreError,

--- a/purchases_ui_flutter/lib/views/paywall_view.dart
+++ b/purchases_ui_flutter/lib/views/paywall_view.dart
@@ -25,6 +25,9 @@ import 'paywall_view_method_handler.dart';
 ///
 /// [onPurchaseStarted] (Optional) Callback that gets called when a purchase
 /// is started.
+/// 
+/// [onPurchaseCancelled] (Optional) Callback that gets called when a purchase
+/// is cancelled.
 ///
 /// [onPurchaseCompleted] (Optional) Callback that gets called when a purchase
 /// is completed.
@@ -48,6 +51,7 @@ class PaywallView extends StatelessWidget {
   final Function(Package rcPackage)? onPurchaseStarted;
   final Function(CustomerInfo customerInfo, StoreTransaction storeTransaction)?
       onPurchaseCompleted;
+  final Function()? onPurchaseCancelled;
   final Function(PurchasesError)? onPurchaseError;
   final Function(CustomerInfo customerInfo)? onRestoreCompleted;
   final Function(PurchasesError)? onRestoreError;
@@ -59,6 +63,7 @@ class PaywallView extends StatelessWidget {
     this.displayCloseButton,
     this.onPurchaseStarted,
     this.onPurchaseCompleted,
+    this.onPurchaseCancelled,
     this.onPurchaseError,
     this.onRestoreCompleted,
     this.onRestoreError,
@@ -121,6 +126,7 @@ class PaywallView extends StatelessWidget {
     final handler = PaywallViewMethodHandler(
       onPurchaseStarted,
       onPurchaseCompleted,
+      onPurchaseCancelled,
       onPurchaseError,
       onRestoreCompleted,
       onRestoreError,

--- a/purchases_ui_flutter/lib/views/paywall_view_method_handler.dart
+++ b/purchases_ui_flutter/lib/views/paywall_view_method_handler.dart
@@ -9,6 +9,7 @@ class PaywallViewMethodHandler {
   final Function(Package rcPackage)? onPurchaseStarted;
   final Function(CustomerInfo customerInfo, StoreTransaction storeTransaction)?
   onPurchaseCompleted;
+  final Function()? onPurchaseCancelled;
   final Function(PurchasesError)? onPurchaseError;
   final Function(CustomerInfo customerInfo)? onRestoreCompleted;
   final Function(PurchasesError)? onRestoreError;
@@ -17,6 +18,7 @@ class PaywallViewMethodHandler {
   const PaywallViewMethodHandler(
       this.onPurchaseStarted,
       this.onPurchaseCompleted,
+      this.onPurchaseCancelled,
       this.onPurchaseError,
       this.onRestoreCompleted,
       this.onRestoreError,
@@ -30,6 +32,9 @@ class PaywallViewMethodHandler {
         break;
       case 'onPurchaseCompleted':
         _handleOnPurchaseCompleted(call);
+        break;
+      case 'onPurchaseCancelled':
+        onPurchaseCancelled?.call();
         break;
       case 'onPurchaseError':
         _handleOnPurchaseError(call);

--- a/revenuecat_examples/purchase_tester/lib/src/paywall.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/paywall.dart
@@ -31,6 +31,9 @@ class _PaywallScreenState extends State<PaywallScreen> {
           print('Purchase completed for customerInfo:\n $customerInfo\n '
               'and storeTransaction:\n $storeTransaction');
         },
+        onPurchaseCancelled: () {
+          print('Purchase cancelled');
+        },
         onPurchaseError: (PurchasesError error) {
           print('Purchase error: $error');
         },

--- a/revenuecat_examples/purchase_tester/lib/src/paywall_footer_screen.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/paywall_footer_screen.dart
@@ -33,6 +33,9 @@ class _PaywallFooterScreenState extends State<PaywallFooterScreen> {
               print('Purchase completed for customerInfo:\n $customerInfo\n '
                   'and storeTransaction:\n $storeTransaction');
             },
+            onPurchaseCancelled: () {
+              print('Purchase cancelled');
+            },
             onPurchaseError: (PurchasesError error) {
               print('Purchase error: $error');
             },


### PR DESCRIPTION
This PR adds support for the onPurchaseCancelled callback to PaywallView and PaywallFooterView. [Linear](https://linear.app/revenuecat/issue/MON-979/flutter-paywalls-dont-have-onpurchasecancelled-callback) MON-979.