### PR TITLE
Add Virtual Currency Balances

### DIFF
--- a/api_tester/lib/api_tests/models/customer_info_wrapper_api_test.dart
+++ b/api_tester/lib/api_tests/models/customer_info_wrapper_api_test.dart
@@ -20,6 +20,7 @@ class _CustomerInfoApiTest {
       String firstSeen,
       String originalAppUserId,
       Map<String, String?> allExpirationDates,
+      Map<String, VirtualCurrencyInfo> virtualCurrencies,
       String requestDate,
       String? latestExpirationDate,
       String? originalPurchaseDate,
@@ -34,6 +35,7 @@ class _CustomerInfoApiTest {
         firstSeen,
         originalAppUserId,
         allExpirationDates,
+        virtualCurrencies,
         requestDate);
     customerInfo = CustomerInfo(
         entitlements,
@@ -44,6 +46,7 @@ class _CustomerInfoApiTest {
         firstSeen,
         originalAppUserId,
         allExpirationDates,
+        virtualCurrencies,
         requestDate,
         latestExpirationDate: latestExpirationDate,
         originalPurchaseDate: originalPurchaseDate,
@@ -62,6 +65,8 @@ class _CustomerInfoApiTest {
     String firstSeen = customerInfo.firstSeen;
     String originalAppUserId = customerInfo.originalAppUserId;
     Map<String, String?> allExpirationDates = customerInfo.allExpirationDates;
+    Map<String, VirtualCurrencyInfo> virtualCurrencies =
+        customerInfo.virtualCurrencies;
     String requestDate = customerInfo.requestDate;
     String? latestExpirationDate = customerInfo.latestExpirationDate;
     String? originalPurchaseDate = customerInfo.originalPurchaseDate;

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -560,9 +560,10 @@ class _PurchasesFlutterApiTest {
 
   void _checkGetVirtualCurrencyBalance(
       CustomerInfo customerInfo, String virtualCurrencyIdentifier) async {
-    VirtualCurrencyInfo virtualCurrencyInfo =
-        customerInfo.virtualCurrencies[virtualCurrencyIdentifier];
-    int balance = virtualCurrencyInfo.balance;
+    VirtualCurrencyInfo? virtualCurrencyInfo = customerInfo.virtualCurrencies[virtualCurrencyIdentifier];
+    if (virtualCurrencyInfo != null) {
+      int balance = virtualCurrencyInfo.balance;
+    }
   }
 }
 

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -557,6 +557,13 @@ class _PurchasesFlutterApiTest {
     WebPurchaseRedemption? webPurchaseRedemption = await Purchases.parseAsWebPurchaseRedemption(urlString);
     WebPurchaseRedemptionResult? result = await Purchases.redeemWebPurchase(webPurchaseRedemption!);
   }
+
+  void _checkGetVirtualCurrencyBalance(
+      CustomerInfo customerInfo, String virtualCurrencyIdentifier) async {
+    VirtualCurrencyInfo virtualCurrencyInfo =
+        customerInfo.virtualCurrencies[virtualCurrencyIdentifier];
+    int balance = virtualCurrencyInfo.balance;
+  }
 }
 
 Future<CustomerInfo> _checkFetchAndPurchaseWinBackOffersForProduct(

--- a/lib/models/customer_info_wrapper.dart
+++ b/lib/models/customer_info_wrapper.dart
@@ -2,6 +2,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 
 import 'entitlement_infos_wrapper.dart';
 import 'store_transaction.dart';
+import 'virtual_currency_info.dart';
 
 part 'customer_info_wrapper.freezed.dart';
 part 'customer_info_wrapper.g.dart';
@@ -35,6 +36,9 @@ class CustomerInfo with _$CustomerInfo {
 
     /// Map of skus to expiration dates
     Map<String, String?> allExpirationDates,
+
+    /// Map of virtual currency identifiers to their info
+    Map<String, VirtualCurrencyInfo> virtualCurrencies,
 
     /// Date when this info was requested
     String requestDate, {

--- a/lib/models/customer_info_wrapper.dart
+++ b/lib/models/customer_info_wrapper.dart
@@ -37,7 +37,7 @@ class CustomerInfo with _$CustomerInfo {
     /// Map of skus to expiration dates
     Map<String, String?> allExpirationDates,
 
-    /// Map of virtual currency identifiers to their info
+    /// Map of virtual currency codes to their info
     Map<String, VirtualCurrencyInfo> virtualCurrencies,
 
     /// Date when this info was requested

--- a/lib/models/customer_info_wrapper.freezed.dart
+++ b/lib/models/customer_info_wrapper.freezed.dart
@@ -49,6 +49,10 @@ mixin _$CustomerInfo {
   Map<String, String?> get allExpirationDates =>
       throw _privateConstructorUsedError;
 
+  /// Map of virtual currency identifiers to their info
+  Map<String, VirtualCurrencyInfo> get virtualCurrencies =>
+      throw _privateConstructorUsedError;
+
   /// Date when this info was requested
   String get requestDate => throw _privateConstructorUsedError;
 
@@ -99,6 +103,7 @@ abstract class $CustomerInfoCopyWith<$Res> {
       String firstSeen,
       String originalAppUserId,
       Map<String, String?> allExpirationDates,
+      Map<String, VirtualCurrencyInfo> virtualCurrencies,
       String requestDate,
       String? latestExpirationDate,
       String? originalPurchaseDate,
@@ -131,6 +136,7 @@ class _$CustomerInfoCopyWithImpl<$Res, $Val extends CustomerInfo>
     Object? firstSeen = null,
     Object? originalAppUserId = null,
     Object? allExpirationDates = null,
+    Object? virtualCurrencies = null,
     Object? requestDate = null,
     Object? latestExpirationDate = freezed,
     Object? originalPurchaseDate = freezed,
@@ -170,6 +176,10 @@ class _$CustomerInfoCopyWithImpl<$Res, $Val extends CustomerInfo>
           ? _value.allExpirationDates
           : allExpirationDates // ignore: cast_nullable_to_non_nullable
               as Map<String, String?>,
+      virtualCurrencies: null == virtualCurrencies
+          ? _value.virtualCurrencies
+          : virtualCurrencies // ignore: cast_nullable_to_non_nullable
+              as Map<String, VirtualCurrencyInfo>,
       requestDate: null == requestDate
           ? _value.requestDate
           : requestDate // ignore: cast_nullable_to_non_nullable
@@ -221,6 +231,7 @@ abstract class _$$CustomerInfoImplCopyWith<$Res>
       String firstSeen,
       String originalAppUserId,
       Map<String, String?> allExpirationDates,
+      Map<String, VirtualCurrencyInfo> virtualCurrencies,
       String requestDate,
       String? latestExpirationDate,
       String? originalPurchaseDate,
@@ -252,6 +263,7 @@ class __$$CustomerInfoImplCopyWithImpl<$Res>
     Object? firstSeen = null,
     Object? originalAppUserId = null,
     Object? allExpirationDates = null,
+    Object? virtualCurrencies = null,
     Object? requestDate = null,
     Object? latestExpirationDate = freezed,
     Object? originalPurchaseDate = freezed,
@@ -291,6 +303,10 @@ class __$$CustomerInfoImplCopyWithImpl<$Res>
           ? _value._allExpirationDates
           : allExpirationDates // ignore: cast_nullable_to_non_nullable
               as Map<String, String?>,
+      null == virtualCurrencies
+          ? _value._virtualCurrencies
+          : virtualCurrencies // ignore: cast_nullable_to_non_nullable
+              as Map<String, VirtualCurrencyInfo>,
       null == requestDate
           ? _value.requestDate
           : requestDate // ignore: cast_nullable_to_non_nullable
@@ -327,6 +343,7 @@ class _$CustomerInfoImpl implements _CustomerInfo {
       this.firstSeen,
       this.originalAppUserId,
       final Map<String, String?> allExpirationDates,
+      final Map<String, VirtualCurrencyInfo> virtualCurrencies,
       this.requestDate,
       {this.latestExpirationDate,
       this.originalPurchaseDate,
@@ -336,7 +353,8 @@ class _$CustomerInfoImpl implements _CustomerInfo {
         _activeSubscriptions = activeSubscriptions,
         _allPurchasedProductIdentifiers = allPurchasedProductIdentifiers,
         _nonSubscriptionTransactions = nonSubscriptionTransactions,
-        _allExpirationDates = allExpirationDates;
+        _allExpirationDates = allExpirationDates,
+        _virtualCurrencies = virtualCurrencies;
 
   factory _$CustomerInfoImpl.fromJson(Map<String, dynamic> json) =>
       _$$CustomerInfoImplFromJson(json);
@@ -414,6 +432,18 @@ class _$CustomerInfoImpl implements _CustomerInfo {
     return EqualUnmodifiableMapView(_allExpirationDates);
   }
 
+  /// Map of virtual currency identifiers to their info
+  final Map<String, VirtualCurrencyInfo> _virtualCurrencies;
+
+  /// Map of virtual currency identifiers to their info
+  @override
+  Map<String, VirtualCurrencyInfo> get virtualCurrencies {
+    if (_virtualCurrencies is EqualUnmodifiableMapView)
+      return _virtualCurrencies;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(_virtualCurrencies);
+  }
+
   /// Date when this info was requested
   @override
   final String requestDate;
@@ -446,7 +476,7 @@ class _$CustomerInfoImpl implements _CustomerInfo {
 
   @override
   String toString() {
-    return 'CustomerInfo(entitlements: $entitlements, allPurchaseDates: $allPurchaseDates, activeSubscriptions: $activeSubscriptions, allPurchasedProductIdentifiers: $allPurchasedProductIdentifiers, nonSubscriptionTransactions: $nonSubscriptionTransactions, firstSeen: $firstSeen, originalAppUserId: $originalAppUserId, allExpirationDates: $allExpirationDates, requestDate: $requestDate, latestExpirationDate: $latestExpirationDate, originalPurchaseDate: $originalPurchaseDate, originalApplicationVersion: $originalApplicationVersion, managementURL: $managementURL)';
+    return 'CustomerInfo(entitlements: $entitlements, allPurchaseDates: $allPurchaseDates, activeSubscriptions: $activeSubscriptions, allPurchasedProductIdentifiers: $allPurchasedProductIdentifiers, nonSubscriptionTransactions: $nonSubscriptionTransactions, firstSeen: $firstSeen, originalAppUserId: $originalAppUserId, allExpirationDates: $allExpirationDates, virtualCurrencies: $virtualCurrencies, requestDate: $requestDate, latestExpirationDate: $latestExpirationDate, originalPurchaseDate: $originalPurchaseDate, originalApplicationVersion: $originalApplicationVersion, managementURL: $managementURL)';
   }
 
   @override
@@ -472,6 +502,8 @@ class _$CustomerInfoImpl implements _CustomerInfo {
                 other.originalAppUserId == originalAppUserId) &&
             const DeepCollectionEquality()
                 .equals(other._allExpirationDates, _allExpirationDates) &&
+            const DeepCollectionEquality()
+                .equals(other._virtualCurrencies, _virtualCurrencies) &&
             (identical(other.requestDate, requestDate) ||
                 other.requestDate == requestDate) &&
             (identical(other.latestExpirationDate, latestExpirationDate) ||
@@ -498,6 +530,7 @@ class _$CustomerInfoImpl implements _CustomerInfo {
       firstSeen,
       originalAppUserId,
       const DeepCollectionEquality().hash(_allExpirationDates),
+      const DeepCollectionEquality().hash(_virtualCurrencies),
       requestDate,
       latestExpirationDate,
       originalPurchaseDate,
@@ -530,6 +563,7 @@ abstract class _CustomerInfo implements CustomerInfo {
       final String firstSeen,
       final String originalAppUserId,
       final Map<String, String?> allExpirationDates,
+      final Map<String, VirtualCurrencyInfo> virtualCurrencies,
       final String requestDate,
       {final String? latestExpirationDate,
       final String? originalPurchaseDate,
@@ -572,8 +606,11 @@ abstract class _CustomerInfo implements CustomerInfo {
   @override
   Map<String, String?> get allExpirationDates;
 
-  /// Date when this info was requested
+  /// Map of virtual currency identifiers to their info
+  Map<String, VirtualCurrencyInfo> get virtualCurrencies;
   @override
+
+  /// Date when this info was requested
   String get requestDate;
 
   /// The latest expiration date of all purchased skus

--- a/lib/models/customer_info_wrapper.freezed.dart
+++ b/lib/models/customer_info_wrapper.freezed.dart
@@ -49,7 +49,7 @@ mixin _$CustomerInfo {
   Map<String, String?> get allExpirationDates =>
       throw _privateConstructorUsedError;
 
-  /// Map of virtual currency identifiers to their info
+  /// Map of virtual currency codes to their info
   Map<String, VirtualCurrencyInfo> get virtualCurrencies =>
       throw _privateConstructorUsedError;
 
@@ -432,10 +432,10 @@ class _$CustomerInfoImpl implements _CustomerInfo {
     return EqualUnmodifiableMapView(_allExpirationDates);
   }
 
-  /// Map of virtual currency identifiers to their info
+  /// Map of virtual currency codes to their info
   final Map<String, VirtualCurrencyInfo> _virtualCurrencies;
 
-  /// Map of virtual currency identifiers to their info
+  /// Map of virtual currency codes to their info
   @override
   Map<String, VirtualCurrencyInfo> get virtualCurrencies {
     if (_virtualCurrencies is EqualUnmodifiableMapView)
@@ -606,7 +606,7 @@ abstract class _CustomerInfo implements CustomerInfo {
   @override
   Map<String, String?> get allExpirationDates;
 
-  /// Map of virtual currency identifiers to their info
+  /// Map of virtual currency codes to their info
   @override
   Map<String, VirtualCurrencyInfo> get virtualCurrencies;
 

--- a/lib/models/customer_info_wrapper.freezed.dart
+++ b/lib/models/customer_info_wrapper.freezed.dart
@@ -607,10 +607,11 @@ abstract class _CustomerInfo implements CustomerInfo {
   Map<String, String?> get allExpirationDates;
 
   /// Map of virtual currency identifiers to their info
-  Map<String, VirtualCurrencyInfo> get virtualCurrencies;
   @override
+  Map<String, VirtualCurrencyInfo> get virtualCurrencies;
 
   /// Date when this info was requested
+  @override
   String get requestDate;
 
   /// The latest expiration date of all purchased skus

--- a/lib/models/customer_info_wrapper.g.dart
+++ b/lib/models/customer_info_wrapper.g.dart
@@ -23,6 +23,10 @@ _$CustomerInfoImpl _$$CustomerInfoImplFromJson(Map json) => _$CustomerInfoImpl(
       json['firstSeen'] as String,
       json['originalAppUserId'] as String,
       Map<String, String?>.from(json['allExpirationDates'] as Map),
+      (json['virtualCurrencies'] as Map).map(
+        (k, e) => MapEntry(k as String,
+            VirtualCurrencyInfo.fromJson(Map<String, dynamic>.from(e as Map))),
+      ),
       json['requestDate'] as String,
       latestExpirationDate: json['latestExpirationDate'] as String?,
       originalPurchaseDate: json['originalPurchaseDate'] as String?,
@@ -41,6 +45,8 @@ Map<String, dynamic> _$$CustomerInfoImplToJson(_$CustomerInfoImpl instance) =>
       'firstSeen': instance.firstSeen,
       'originalAppUserId': instance.originalAppUserId,
       'allExpirationDates': instance.allExpirationDates,
+      'virtualCurrencies':
+          instance.virtualCurrencies.map((k, e) => MapEntry(k, e.toJson())),
       'requestDate': instance.requestDate,
       'latestExpirationDate': instance.latestExpirationDate,
       'originalPurchaseDate': instance.originalPurchaseDate,

--- a/lib/models/virtual_currency_info.dart
+++ b/lib/models/virtual_currency_info.dart
@@ -1,0 +1,16 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'virtual_currency_info.freezed.dart';
+part 'virtual_currency_info.g.dart';
+
+// Contains information about a virtual currency.
+@freezed
+class VirtualCurrencyInfo with _$VirtualCurrencyInfo {
+  const factory VirtualCurrencyInfo(
+    /// The user's balance of the virtual currency.
+    int balance,
+  ) = _VirtualCurrencyInfo;
+
+  factory VirtualCurrencyInfo.fromJson(Map<String, dynamic> json) =>
+      _$VirtualCurrencyInfoFromJson(json);
+}

--- a/lib/models/virtual_currency_info.freezed.dart
+++ b/lib/models/virtual_currency_info.freezed.dart
@@ -23,8 +23,12 @@ mixin _$VirtualCurrencyInfo {
   /// The user's balance of the virtual currency.
   int get balance => throw _privateConstructorUsedError;
 
+  /// Serializes this VirtualCurrencyInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of VirtualCurrencyInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $VirtualCurrencyInfoCopyWith<VirtualCurrencyInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -48,6 +52,8 @@ class _$VirtualCurrencyInfoCopyWithImpl<$Res, $Val extends VirtualCurrencyInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of VirtualCurrencyInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -81,6 +87,8 @@ class __$$VirtualCurrencyInfoImplCopyWithImpl<$Res>
       $Res Function(_$VirtualCurrencyInfoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of VirtualCurrencyInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -120,11 +128,13 @@ class _$VirtualCurrencyInfoImpl implements _VirtualCurrencyInfo {
             (identical(other.balance, balance) || other.balance == balance));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, balance);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of VirtualCurrencyInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$VirtualCurrencyInfoImplCopyWith<_$VirtualCurrencyInfoImpl> get copyWith =>
@@ -146,12 +156,14 @@ abstract class _VirtualCurrencyInfo implements VirtualCurrencyInfo {
   factory _VirtualCurrencyInfo.fromJson(Map<String, dynamic> json) =
       _$VirtualCurrencyInfoImpl.fromJson;
 
-  @override
-
   /// The user's balance of the virtual currency.
-  int get balance;
   @override
-  @JsonKey(ignore: true)
+  int get balance;
+
+  /// Create a copy of VirtualCurrencyInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$VirtualCurrencyInfoImplCopyWith<_$VirtualCurrencyInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/models/virtual_currency_info.freezed.dart
+++ b/lib/models/virtual_currency_info.freezed.dart
@@ -1,0 +1,157 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'virtual_currency_info.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+VirtualCurrencyInfo _$VirtualCurrencyInfoFromJson(Map<String, dynamic> json) {
+  return _VirtualCurrencyInfo.fromJson(json);
+}
+
+/// @nodoc
+mixin _$VirtualCurrencyInfo {
+  /// The user's balance of the virtual currency.
+  int get balance => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $VirtualCurrencyInfoCopyWith<VirtualCurrencyInfo> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $VirtualCurrencyInfoCopyWith<$Res> {
+  factory $VirtualCurrencyInfoCopyWith(
+          VirtualCurrencyInfo value, $Res Function(VirtualCurrencyInfo) then) =
+      _$VirtualCurrencyInfoCopyWithImpl<$Res, VirtualCurrencyInfo>;
+  @useResult
+  $Res call({int balance});
+}
+
+/// @nodoc
+class _$VirtualCurrencyInfoCopyWithImpl<$Res, $Val extends VirtualCurrencyInfo>
+    implements $VirtualCurrencyInfoCopyWith<$Res> {
+  _$VirtualCurrencyInfoCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? balance = null,
+  }) {
+    return _then(_value.copyWith(
+      balance: null == balance
+          ? _value.balance
+          : balance // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$VirtualCurrencyInfoImplCopyWith<$Res>
+    implements $VirtualCurrencyInfoCopyWith<$Res> {
+  factory _$$VirtualCurrencyInfoImplCopyWith(_$VirtualCurrencyInfoImpl value,
+          $Res Function(_$VirtualCurrencyInfoImpl) then) =
+      __$$VirtualCurrencyInfoImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({int balance});
+}
+
+/// @nodoc
+class __$$VirtualCurrencyInfoImplCopyWithImpl<$Res>
+    extends _$VirtualCurrencyInfoCopyWithImpl<$Res, _$VirtualCurrencyInfoImpl>
+    implements _$$VirtualCurrencyInfoImplCopyWith<$Res> {
+  __$$VirtualCurrencyInfoImplCopyWithImpl(_$VirtualCurrencyInfoImpl _value,
+      $Res Function(_$VirtualCurrencyInfoImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? balance = null,
+  }) {
+    return _then(_$VirtualCurrencyInfoImpl(
+      null == balance
+          ? _value.balance
+          : balance // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$VirtualCurrencyInfoImpl implements _VirtualCurrencyInfo {
+  const _$VirtualCurrencyInfoImpl(this.balance);
+
+  factory _$VirtualCurrencyInfoImpl.fromJson(Map<String, dynamic> json) =>
+      _$$VirtualCurrencyInfoImplFromJson(json);
+
+  /// The user's balance of the virtual currency.
+  @override
+  final int balance;
+
+  @override
+  String toString() {
+    return 'VirtualCurrencyInfo(balance: $balance)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VirtualCurrencyInfoImpl &&
+            (identical(other.balance, balance) || other.balance == balance));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, balance);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$VirtualCurrencyInfoImplCopyWith<_$VirtualCurrencyInfoImpl> get copyWith =>
+      __$$VirtualCurrencyInfoImplCopyWithImpl<_$VirtualCurrencyInfoImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$VirtualCurrencyInfoImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _VirtualCurrencyInfo implements VirtualCurrencyInfo {
+  const factory _VirtualCurrencyInfo(final int balance) =
+      _$VirtualCurrencyInfoImpl;
+
+  factory _VirtualCurrencyInfo.fromJson(Map<String, dynamic> json) =
+      _$VirtualCurrencyInfoImpl.fromJson;
+
+  @override
+
+  /// The user's balance of the virtual currency.
+  int get balance;
+  @override
+  @JsonKey(ignore: true)
+  _$$VirtualCurrencyInfoImplCopyWith<_$VirtualCurrencyInfoImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/models/virtual_currency_info.g.dart
+++ b/lib/models/virtual_currency_info.g.dart
@@ -1,0 +1,18 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'virtual_currency_info.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$VirtualCurrencyInfoImpl _$$VirtualCurrencyInfoImplFromJson(Map json) =>
+    _$VirtualCurrencyInfoImpl(
+      (json['balance'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$$VirtualCurrencyInfoImplToJson(
+        _$VirtualCurrencyInfoImpl instance) =>
+    <String, dynamic>{
+      'balance': instance.balance,
+    };

--- a/lib/object_wrappers.dart
+++ b/lib/object_wrappers.dart
@@ -28,6 +28,7 @@ export 'models/storekit_version.dart';
 export 'models/subscription_option_wrapper.dart';
 export 'models/upgrade_info.dart';
 export 'models/verification_result.dart';
+export 'models/virtual_currency_info.dart';
 export 'models/web_purchase_redemption.dart';
 export 'models/web_purchase_redemption_result.dart';
 export 'models/win_back_offer.dart';

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -40,6 +40,26 @@ void main() {
     'allPurchaseDates': {},
     'originalApplicationVersion': '1.2.3',
     'nonSubscriptionTransactions': [],
+    'virtualCurrencies': {},
+  };
+
+  final mockCustomerInfoResponseWithVirtualCurrencies = {
+    'originalAppUserId': 'pepe',
+    'entitlements': {'all': {}, 'active': {}, 'verification': 'NOT_REQUESTED'},
+    'activeSubscriptions': [],
+    'latestExpirationDate': '2021-04-09T14:48:00.000Z',
+    'allExpirationDates': {},
+    'allPurchasedProductIdentifiers': [],
+    'firstSeen': '2021-01-09T14:48:00.000Z',
+    'requestDate': '2021-04-09T14:48:00.000Z',
+    'allPurchaseDates': {},
+    'originalApplicationVersion': '1.2.3',
+    'nonSubscriptionTransactions': [],
+    'virtualCurrencies': {
+      'RC_COIN': {
+        'balance': 100,
+      }
+    },
   };
 
   setUp(() {
@@ -1470,5 +1490,13 @@ void main() {
       },
     );
     expect(expiredOrNull, isNotNull);
+  });
+
+  test('virtual currency balances are parsed correctly in customer info', () async {
+    final customerInfo = CustomerInfo.fromJson(mockCustomerInfoResponseWithVirtualCurrencies);
+    expect(customerInfo.virtualCurrencies, isNotNull);
+    expect(customerInfo.virtualCurrencies.length, equals(1));
+    expect(customerInfo.virtualCurrencies['RC_COIN'], isNotNull);
+    expect(customerInfo.virtualCurrencies['RC_COIN']?.balance, equals(100));
   });
 }

--- a/test/virtual_currency_info_test.dart
+++ b/test/virtual_currency_info_test.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:purchases_flutter/models/virtual_currency_info.dart';
+
+void main() {
+  test('fromJson correctly parses balances', () {
+    final result = VirtualCurrencyInfo.fromJson({
+      'balance': 100,
+    });
+
+    expect(result, isNotNull);
+    expect(result.balance, equals(100));
+  });
+}

--- a/test/web_purchase_redemption_result_test.dart
+++ b/test/web_purchase_redemption_result_test.dart
@@ -40,6 +40,7 @@ void main() {
       'allPurchaseDates': {},
       'originalApplicationVersion': '1.2.3',
       'nonSubscriptionTransactions': [],
+      'virtualCurrencies': {},
     };
     final result = WebPurchaseRedemptionResult.fromJson({
       'result': 'SUCCESS',


### PR DESCRIPTION
This PR introduces the ability for developers to check virtual currency balances from the `CustomerInfo` object. This PR:
- Introduces the new `VirtualCurrencyInfo` object
- Adds `virtualCurrencies` property to `CustomerInfo`
- Updates the API tester
- Adds tests for parsing virtual currency information from JSON
- Updates existing tests to pass with the updated CustomerInfo JSON schema

### Testing
For testing, I:
- Manually confirmed that the values were present in simulators
- Updated the automated tests

### Next Steps
Once this PR is approved and we have the API tests working, I'll create a virtual currencies beta release from the `virtual-currency-dev` branch.

> Note: The API tests are currently failing due to an unrelated issue in the main branch. We can still merge this into `virtual-currency-dev` with the API tests failing, and then bring in the change from main into there.