### PR TITLE
Bump min supported versions and add tests for min SDK compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,7 @@ jobs:
     steps:
         - checkout
         - flutter/install_sdk_and_pub:
-            version: 3.3.0
+            version: 3.16.3
         - flutter-get-dependencies:
             project: purchases_ui_flutter
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,6 +203,32 @@ jobs:
           name: Run tests for purchases_ui_flutter
           command: cd purchases_ui_flutter && flutter test
 
+  test_main_sdk_min_version_compatibility:
+    description: "Test min version compatibility for purchases_flutter SDK"
+    docker:
+      - image: ghcr.io/cirruslabs/flutter:3.0.0
+    steps:
+      - checkout
+      - build-flutter-project
+      - flutter-get-dependencies:
+          project: revenuecat_examples/MagicWeather
+      - flutter-get-dependencies:
+          project: revenuecat_examples/purchase_tester
+      - flutter-get-dependencies:
+          project: api_tester
+      - flutter-get-dependencies:
+          project: purchases_ui_flutter
+
+  test_ui_sdk_min_version_compatibility:
+    description: "Tet UI min version compatibility for purchases_ui_flutter SDK"
+    docker:
+      - image: ghcr.io/cirruslabs/flutter:3.0.0
+    steps:
+        - checkout
+        - build-flutter-project
+        - flutter-get-dependencies:
+            project: purchases_ui_flutter
+
   api_test:
     description: "Run API tests for Flutter"
     docker:
@@ -412,6 +438,8 @@ workflows:
       - ios-integration-test
       - macos-integration-test
       - android-integration-test-build
+      - test_main_sdk_min_version_compatibility
+      - test_ui_sdk_min_version_compatibility
 
   deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,13 +19,19 @@ aliases:
         ignore: /.*/
       branches:
         only: main
+  android-machine-emulator: &android-machine-emulator
+    executor:
+      name: android/android-machine
+      resource-class: large
+      tag: 2024.04.1
 
 orbs:
-  android: circleci/android@0.2.1
+  android: circleci/android@2.5.0
   gcp-cli: circleci/gcp-cli@2.1.0
   swissknife: roopakv/swissknife@0.65.0
   revenuecat: revenuecat/sdks-common-config@2.1.0
   macos: circleci/macos@2.3.2
+  flutter: circleci/flutter@2.1.0
 
 parameters:
   action:
@@ -205,27 +211,19 @@ jobs:
 
   test_main_sdk_min_version_compatibility:
     description: "Test min version compatibility for purchases_flutter SDK"
-    docker:
-      - image: ghcr.io/cirruslabs/flutter:3.0.0
+    <<: *android-machine-emulator
     steps:
       - checkout
-      - build-flutter-project
-      - flutter-get-dependencies:
-          project: revenuecat_examples/MagicWeather
-      - flutter-get-dependencies:
-          project: revenuecat_examples/purchase_tester
-      - flutter-get-dependencies:
-          project: api_tester
-      - flutter-get-dependencies:
-          project: purchases_ui_flutter
+      - flutter/install_sdk_and_pub:
+          version: 3.0.0
 
   test_ui_sdk_min_version_compatibility:
     description: "Tet UI min version compatibility for purchases_ui_flutter SDK"
-    docker:
-      - image: ghcr.io/cirruslabs/flutter:3.0.0
+    <<: *android-machine-emulator
     steps:
         - checkout
-        - build-flutter-project
+        - flutter/install_sdk_and_pub:
+            version: 3.0.0
         - flutter-get-dependencies:
             project: purchases_ui_flutter
 
@@ -430,14 +428,14 @@ workflows:
       not:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
-      - lint
-      - test
-      - api_test
-      - freezed
-      - dry-run-release: *release-branches
-      - ios-integration-test
-      - macos-integration-test
-      - android-integration-test-build
+#      - lint
+#      - test
+#      - api_test
+#      - freezed
+#      - dry-run-release: *release-branches
+#      - ios-integration-test
+#      - macos-integration-test
+#      - android-integration-test-build
       - test_main_sdk_min_version_compatibility
       - test_ui_sdk_min_version_compatibility
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,11 +19,14 @@ aliases:
         ignore: /.*/
       branches:
         only: main
-  android-machine-emulator: &android-machine-emulator
+  android-executor: &android-executor
     executor:
-      name: android/android-machine
+      name: android/android-docker
       resource-class: large
-      tag: 2024.04.1
+      tag: 2024.11.1
+    environment:
+      JVM_OPTS: -Xmx6g
+      GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
 
 orbs:
   android: circleci/android@2.5.0
@@ -211,15 +214,15 @@ jobs:
 
   test_main_sdk_min_version_compatibility:
     description: "Test min version compatibility for purchases_flutter SDK"
-    <<: *android-machine-emulator
+    <<: *android-executor
     steps:
       - checkout
       - flutter/install_sdk_and_pub:
           version: 3.3.0
 
   test_ui_sdk_min_version_compatibility:
-    description: "Tet UI min version compatibility for purchases_ui_flutter SDK"
-    <<: *android-machine-emulator
+    description: "Test UI min version compatibility for purchases_ui_flutter SDK"
+    <<: *android-executor
     steps:
         - checkout
         - flutter/install_sdk_and_pub:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,7 +215,7 @@ jobs:
     steps:
       - checkout
       - flutter/install_sdk_and_pub:
-          version: 3.0.0
+          version: 3.3.0
 
   test_ui_sdk_min_version_compatibility:
     description: "Tet UI min version compatibility for purchases_ui_flutter SDK"
@@ -223,7 +223,7 @@ jobs:
     steps:
         - checkout
         - flutter/install_sdk_and_pub:
-            version: 3.0.0
+            version: 3.3.0
         - flutter-get-dependencies:
             project: purchases_ui_flutter
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -428,14 +428,14 @@ workflows:
       not:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
-#      - lint
-#      - test
-#      - api_test
-#      - freezed
-#      - dry-run-release: *release-branches
-#      - ios-integration-test
-#      - macos-integration-test
-#      - android-integration-test-build
+      - lint
+      - test
+      - api_test
+      - freezed
+      - dry-run-release: *release-branches
+      - ios-integration-test
+      - macos-integration-test
+      - android-integration-test-build
       - test_main_sdk_min_version_compatibility
       - test_ui_sdk_min_version_compatibility
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,14 +17,13 @@ dependencies:
   json_annotation: ^4.8.0
 
 dev_dependencies:
-  analyzer: 7.3.0
   build_runner: ^2.1.10
   flutter_driver:
     sdk: flutter
   flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
-  freezed: ^2.5.8
+  freezed: ^2.0.2
   json_serializable: ^6.0.0
 
 flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,8 +7,8 @@ issue_tracker: https://github.com/RevenueCat/purchases-flutter/issues
 documentation: https://docs.revenuecat.com/docs
 
 environment:
-  sdk: ">=2.15.0 <4.0.0"
-  flutter: ">=1.10.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/purchases_ui_flutter/pubspec.yaml
+++ b/purchases_ui_flutter/pubspec.yaml
@@ -8,7 +8,7 @@ documentation: https://docs.revenuecat.com/docs
 environment:
   # TODO: Check constraints are ok
   sdk: '>=3.2.3 <4.0.0'
-  flutter: '>=3.3.0'
+  flutter: '>=3.16.3'
 
 dependencies:
   purchases_flutter: ^8.7.3


### PR DESCRIPTION
This bumps the min Flutter/Dart versions to the actual mins we support in the SDKs and adds some tests to verify we are still compatible with the min SDK version we say we are compatible.
