### PR TITLE
Add `storefront` API to obtain the country of the store account

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -39,6 +39,8 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import kotlin.UninitializedPropertyAccessException;
+import kotlin.Unit;
+import kotlin.jvm.functions.Function1;
 
 /**
  * PurchasesFlutterPlugin
@@ -172,6 +174,9 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 break;
             case "getAppUserID":
                 getAppUserID(result);
+                break;
+            case "getStorefront":
+                getStorefront(result);
                 break;
             case "restorePurchases":
                 restorePurchases(result);
@@ -481,6 +486,16 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
 
     private void getAppUserID(final Result result) {
         result.success(CommonKt.getAppUserID());
+    }
+
+    private void getStorefront(final Result result) {
+        CommonKt.getStorefront(new Function1<Map<String, ? extends Object>, Unit>() {
+            @Override
+            public Unit invoke(Map<String, ?> storefrontMap) {
+                result.success(storefrontMap);
+                return null;
+            }
+        });
     }
 
     private void restorePurchases(final Result result) {

--- a/api_tester/lib/api_tests/models/storefront_api_test.dart
+++ b/api_tester/lib/api_tests/models/storefront_api_test.dart
@@ -10,7 +10,6 @@ class _StorefrontApiTest {
   void _checkConstructor(
     String countryCode,
   ) {
-    Storefront storefront = Storefront(countryCode);
     Storefront storefront = Storefront(countryCode: countryCode);
   }
 

--- a/api_tester/lib/api_tests/models/storefront_api_test.dart
+++ b/api_tester/lib/api_tests/models/storefront_api_test.dart
@@ -1,0 +1,20 @@
+import 'package:purchases_flutter/object_wrappers.dart';
+
+// ignore_for_file: unused_element
+// ignore_for_file: unused_local_variable
+class _StorefrontApiTest {
+  void _checkFromJsonFactory(Map<String, dynamic> json) {
+    Storefront storefront = Storefront.fromJson(json);
+  }
+
+  void _checkConstructor(
+    String countryCode,
+  ) {
+    Storefront storefront = Storefront(countryCode);
+    Storefront storefront = Storefront(countryCode: countryCode);
+  }
+
+  void _checkProperties(Storefront storefront) {
+    String countryCode = storefront.countryCode;
+  }
+}

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -165,6 +165,10 @@ class _PurchasesFlutterApiTest {
     String appUserId = await Purchases.appUserID;
   }
 
+  void _checkStorefront() async {
+    Storefront? storefront = await Purchases.storefront;
+  }
+
   void _checkLogIn() async {
     LogInResult logInResult = await Purchases.logIn("fakeUserId");
   }

--- a/api_tester/lib/api_tests_import.dart
+++ b/api_tester/lib/api_tests_import.dart
@@ -22,6 +22,7 @@ import 'package:api_tester/api_tests/models/store_api_test.dart';
 import 'package:api_tester/api_tests/models/store_product_discount_api_test.dart';
 import 'package:api_tester/api_tests/models/store_product_wrapper_api_test.dart';
 import 'package:api_tester/api_tests/models/store_transaction_api_test.dart';
+import 'package:api_tester/api_tests/models/storefront_api_test.dart';
 import 'package:api_tester/api_tests/models/subscription_option_wrapper_api_test.dart';
 import 'package:api_tester/api_tests/models/web_purchase_redemption_api_test.dart';
 import 'package:api_tester/api_tests/models/web_purchase_redemption_result_api_test.dart';

--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -86,6 +86,8 @@ shouldShowInAppMessagesAutomatically: shouldShowInAppMessagesAutomatically
                        result:result];
     } else if ([@"getAppUserID" isEqualToString:call.method]) {
         [self getAppUserIDWithResult:result];
+    } else if ([@"getStorefront" isEqualToString:call.method]) {
+        [self getStorefrontWithResult:result];
     } else if ([@"restorePurchases" isEqualToString:call.method]) {
         [self restorePurchasesWithResult:result];
     } else if ([@"logOut" isEqualToString:call.method]) {
@@ -350,6 +352,12 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
 
 - (void)getAppUserIDWithResult:(FlutterResult)result {
     result([RCCommonFunctionality appUserID]);
+}
+
+- (void)getStorefrontWithResult:(FlutterResult)result {
+    [RCCommonFunctionality getStorefrontWithCompletion:^(NSDictionary<NSString *,id> * _Nullable storefrontMap) {
+        result(storefrontMap);
+    }];
 }
 
 - (void)logInAppUserID:(NSString * _Nullable)appUserID

--- a/lib/models/storefront.dart
+++ b/lib/models/storefront.dart
@@ -1,0 +1,13 @@
+/// Contains the information about the current store account.
+class Storefront {
+  /// Country code of the current store account.
+  String countryCode;
+
+  Storefront({
+    required this.countryCode,
+  });
+
+  factory Storefront.fromJson(Map<String, dynamic> json) => Storefront(
+    countryCode: json['countryCode'] as String,
+  );
+}

--- a/lib/object_wrappers.dart
+++ b/lib/object_wrappers.dart
@@ -24,6 +24,7 @@ export 'models/store.dart';
 export 'models/store_product_discount.dart';
 export 'models/store_product_wrapper.dart';
 export 'models/store_transaction.dart';
+export 'models/storefront.dart';
 export 'models/storekit_version.dart';
 export 'models/subscription_option_wrapper.dart';
 export 'models/upgrade_info.dart';

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -562,6 +562,15 @@ class Purchases {
   static Future<String> get appUserID async =>
       await _channel.invokeMethod('getAppUserID') as String;
 
+  /// Gets the current storefront for the store account.
+  static Future<Storefront?> get storefront async {
+    final storefrontJson = await _channel.invokeMethod('getStorefront');
+    if (storefrontJson == null) {
+      return null;
+    }
+    return Storefront.fromJson(Map<String, dynamic>.from(storefrontJson));
+  }
+
   /// This function will logIn the current user with an appUserID.
   /// Typically this would be used after logging in a user to identify them without
   /// calling configure

--- a/revenuecat_examples/purchase_tester/lib/src/upsell.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/upsell.dart
@@ -37,6 +37,14 @@ class _UpsellScreenState extends State<UpsellScreen> {
       print(e);
     }
 
+    Storefront? storefront;
+    try {
+      storefront = await Purchases.storefront;
+      print("Current storefront: ${storefront?.countryCode}");
+    } on PlatformException catch (e) {
+      print("Error getting storefront: $e");
+    }
+
     if (!mounted) return;
 
     setState(() {


### PR DESCRIPTION
This adds a new async API: `Purchases.storefront`, which will return storefront information about the store account used. Currently only the country code. It can be used like this:
```
Storefront? storefront = await Purchases.storefront;
```

Will be null when the storefront information can't be obtained (For example, in simulators without a storekit config file).