### PR TITLE
Add `paddle` store

### DIFF
--- a/api_tester/lib/api_tests/models/store_api_test.dart
+++ b/api_tester/lib/api_tests/models/store_api_test.dart
@@ -14,6 +14,7 @@ class _StoreApiTest {
       case Store.amazon:
       case Store.rcBilling:
       case Store.externalStore:
+      case Store.paddle:
         break;
     }
   }

--- a/lib/models/entitlement_info_wrapper.g.dart
+++ b/lib/models/entitlement_info_wrapper.g.dart
@@ -69,6 +69,7 @@ const _$StoreEnumMap = {
   Store.unknownStore: 'unknownStore',
   Store.amazon: 'AMAZON',
   Store.rcBilling: 'RC_BILLING',
+  Store.paddle: 'PADDLE',
   Store.externalStore: 'EXTERNAL',
 };
 

--- a/lib/models/store.dart
+++ b/lib/models/store.dart
@@ -32,6 +32,9 @@ enum Store {
   @JsonValue('RC_BILLING')
   rcBilling,
 
+  @JsonValue('PADDLE')
+  paddle,
+
   @JsonValue('EXTERNAL')
   externalStore,
 }


### PR DESCRIPTION
Depends on https://github.com/RevenueCat/purchases-hybrid-common/pull/1150. Adds the `Paddle` store to Flutter.

#### TODO
- [X] Hold until PHC with changes has been deployed and updated.