### PR TITLE
Change result of purchase methods to PurchaseResult

### DIFF
--- a/api_tester/lib/api_tests/models/purchase_result_api_test.dart
+++ b/api_tester/lib/api_tests/models/purchase_result_api_test.dart
@@ -1,0 +1,22 @@
+import 'package:purchases_flutter/object_wrappers.dart';
+
+// ignore_for_file: unused_element
+// ignore_for_file: unused_local_variable
+// ignore_for_file: deprecated_member_use
+class _PurchaseResultApiTest {
+  void _checkFromJsonFactory(Map<String, dynamic> json) {
+    PurchaseResult transaction = PurchaseResult.fromJson(json);
+  }
+
+  void _checkConstructor(
+      CustomerInfo customerInfo,
+      StoreTransaction storeTransaction) {
+    PurchaseResult purchaseResult =
+    PurchaseResult(customerInfo, storeTransaction);
+  }
+
+  void _checkProperties(PurchaseResult purchaseResult) {
+    CustomerInfo customerInfo = purchaseResult.customerInfo;
+    StoreTransaction storeTransaction = purchaseResult.storeTransaction;
+  }
+}

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -93,67 +93,67 @@ class _PurchasesFlutterApiTest {
     GoogleProductChangeInfo? googleProductChangeInfo;
     PurchaseType purchaseType = PurchaseType.subs;
     ProductCategory productType = ProductCategory.subscription;
-    CustomerInfo customerInfo = await Purchases.purchaseProduct(
+    PurchaseResult purchaseResult = await Purchases.purchaseProduct(
         productIdentifier,
         type: purchaseType,
         upgradeInfo: upgradeInfo);
-    customerInfo = await Purchases.purchaseProduct(productIdentifier,
+    purchaseResult = await Purchases.purchaseProduct(productIdentifier,
         upgradeInfo: upgradeInfo);
-    customerInfo = await Purchases.purchaseProduct(productIdentifier);
+    purchaseResult = await Purchases.purchaseProduct(productIdentifier);
   }
 
   void _checkPurchaseStoreProduct(StoreProduct storeProduct) async {
     GoogleProductChangeInfo? googleProductChangeInfo;
-    CustomerInfo customerInfo = await Purchases.purchaseStoreProduct(
+    PurchaseResult purchaseResult = await Purchases.purchaseStoreProduct(
         storeProduct,
         googleProductChangeInfo: googleProductChangeInfo,
         googleIsPersonalizedPrice: true);
-    customerInfo = await Purchases.purchaseStoreProduct(storeProduct,
+    purchaseResult = await Purchases.purchaseStoreProduct(storeProduct,
         googleIsPersonalizedPrice: true);
-    customerInfo = await Purchases.purchaseStoreProduct(storeProduct,
+    purchaseResult = await Purchases.purchaseStoreProduct(storeProduct,
         googleProductChangeInfo: googleProductChangeInfo);
-    customerInfo = await Purchases.purchaseStoreProduct(storeProduct);
+    purchaseResult = await Purchases.purchaseStoreProduct(storeProduct);
   }
 
   void _checkPurchasePackage(Package package) async {
     UpgradeInfo? upgradeInfo;
     GoogleProductChangeInfo? googleProductChangeInfo;
-    CustomerInfo customerInfo =
+    PurchaseResult purchaseResult =
         await Purchases.purchasePackage(package, upgradeInfo: upgradeInfo);
-    customerInfo = await Purchases.purchasePackage(package,
+    purchaseResult = await Purchases.purchasePackage(package,
         googleProductChangeInfo: googleProductChangeInfo,
         googleIsPersonalizedPrice: true);
-    customerInfo = await Purchases.purchasePackage(package,
+    purchaseResult = await Purchases.purchasePackage(package,
         upgradeInfo: upgradeInfo, googleIsPersonalizedPrice: true);
-    customerInfo = await Purchases.purchasePackage(package,
+    purchaseResult = await Purchases.purchasePackage(package,
         googleIsPersonalizedPrice: true);
   }
 
   void _checkPurchaseSubscriptionOption(SubscriptionOption subscriptionOption,
       GoogleProductChangeInfo? googleProductChangeInfo) async {
-    CustomerInfo customerInfo = await Purchases.purchaseSubscriptionOption(
+    PurchaseResult purchaseResult = await Purchases.purchaseSubscriptionOption(
         subscriptionOption,
         googleProductChangeInfo: googleProductChangeInfo);
-    customerInfo = await Purchases.purchaseSubscriptionOption(
+    purchaseResult = await Purchases.purchaseSubscriptionOption(
         subscriptionOption,
         googleProductChangeInfo: googleProductChangeInfo,
         googleIsPersonalizedPrice: true);
-    customerInfo = await Purchases.purchaseSubscriptionOption(
+    purchaseResult = await Purchases.purchaseSubscriptionOption(
         subscriptionOption,
         googleIsPersonalizedPrice: true);
-    customerInfo =
+    purchaseResult =
         await Purchases.purchaseSubscriptionOption(subscriptionOption);
   }
 
   void _checkPurchaseDiscountedProduct(
       StoreProduct product, PromotionalOffer offer) async {
-    CustomerInfo customerInfo =
+    PurchaseResult purchaseResult =
         await Purchases.purchaseDiscountedProduct(product, offer);
   }
 
   void _checkPurchaseDiscountedPackage(
       Package package, PromotionalOffer offer) async {
-    CustomerInfo customerInfo =
+    PurchaseResult purchaseResult =
         await Purchases.purchaseDiscountedPackage(package, offer);
   }
 

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -568,7 +568,7 @@ class _PurchasesFlutterApiTest {
   }
 }
 
-Future<CustomerInfo> _checkFetchAndPurchaseWinBackOffersForProduct(
+Future<PurchaseResult> _checkFetchAndPurchaseWinBackOffersForProduct(
     StoreProduct product) async {
   List<WinBackOffer>? offers =
       await Purchases.getEligibleWinBackOffersForProduct(product);
@@ -576,7 +576,7 @@ Future<CustomerInfo> _checkFetchAndPurchaseWinBackOffersForProduct(
   return await Purchases.purchaseProductWithWinBackOffer(product, offers[0]);
 }
 
-Future<CustomerInfo> _checkFetchAndPurchaseWinBackOffersForPackage(
+Future<PurchaseResult> _checkFetchAndPurchaseWinBackOffersForPackage(
     Package package) async {
   List<WinBackOffer>? offers =
       await Purchases.getEligibleWinBackOffersForPackage(package);

--- a/api_tester/lib/api_tests_import.dart
+++ b/api_tester/lib/api_tests_import.dart
@@ -17,6 +17,7 @@ import 'package:api_tester/api_tests/models/price_wrapper_api_test.dart';
 import 'package:api_tester/api_tests/models/pricing_phase_wrapper_api_test.dart';
 import 'package:api_tester/api_tests/models/promotional_offer_api_test.dart';
 import 'package:api_tester/api_tests/models/purchase_configuration_api_test.dart';
+import 'package:api_tester/api_tests/models/purchase_result_api_test.dart';
 import 'package:api_tester/api_tests/models/purchases_error_api_test.dart';
 import 'package:api_tester/api_tests/models/store_api_test.dart';
 import 'package:api_tester/api_tests/models/store_product_discount_api_test.dart';

--- a/lib/models/purchase_result.dart
+++ b/lib/models/purchase_result.dart
@@ -1,0 +1,29 @@
+import 'package:equatable/equatable.dart';
+
+import 'customer_info_wrapper.dart';
+import 'store_transaction.dart';
+
+/// Represents the successful result of a purchase operation.
+class PurchaseResult extends Equatable {
+  /// The updated [CustomerInfo] after the purchase has been synced with
+  /// RevenueCat's servers.
+  final CustomerInfo customerInfo;
+  /// The [StoreTransaction] for this purchase.
+  final StoreTransaction storeTransaction;
+
+  const PurchaseResult(
+    this.customerInfo,
+    this.storeTransaction,
+  );
+
+  factory PurchaseResult.fromJson(Map<String, dynamic> json) => PurchaseResult(
+    CustomerInfo.fromJson(Map<String, dynamic>.from(json['customerInfo'])),
+    StoreTransaction.fromJson(Map<String, dynamic>.from(json['transaction'])),
+  );
+
+  @override
+  List<Object> get props => [
+    customerInfo,
+    storeTransaction,
+  ];
+}

--- a/lib/object_wrappers.dart
+++ b/lib/object_wrappers.dart
@@ -17,6 +17,7 @@ export 'models/price_wrapper.dart';
 export 'models/pricing_phase_wrapper.dart';
 export 'models/product_category.dart';
 export 'models/promotional_offer.dart';
+export 'models/purchase_result.dart';
 export 'models/purchases_completed_by.dart';
 export 'models/purchases_configuration.dart';
 export 'models/purchases_error.dart';

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -341,7 +341,7 @@ class Purchases {
   /// It is now recommended to use [Purchases.purchaseStoreProduct]
   /// to make a purchase with a [StoreProduct] if you can.
   ///
-  /// Makes a purchase. Returns a [CustomerInfo] object. Throws a
+  /// Makes a purchase. Returns a [PurchaseResult] object. Throws a
   /// [PlatformException] if the purchase is unsuccessful.
   /// Check if [PurchasesErrorHelper.getErrorCode] is
   /// [PurchasesErrorCode.purchaseCancelledError] to check if the user cancelled
@@ -357,24 +357,25 @@ class Purchases {
   /// PurchaseType.INAPP otherwise the product won't be found.
   /// PurchaseType.Subs by default. This parameter only has effect in Android.
   @Deprecated('Use purchaseStoreProduct')
-  static Future<CustomerInfo> purchaseProduct(
+  static Future<PurchaseResult> purchaseProduct(
     String productIdentifier, {
     UpgradeInfo? upgradeInfo,
     PurchaseType type = PurchaseType.subs,
   }) async {
     final prorationMode = upgradeInfo?.prorationMode;
-    final customerInfo = await _invokeReturningCustomerInfo('purchaseProduct', {
-      'productIdentifier': productIdentifier,
-      'type': type.name,
-      'googleOldProductIdentifier': upgradeInfo?.oldSKU,
-      'googleProrationMode': prorationMode?.value,
-      'googleIsPersonalizedPrice': null,
-      'presentedOfferingIdentifier': null,
-    });
-    return customerInfo;
+    final purchaseResult =
+      await _invokeReturningPurchaseResult('purchaseProduct', {
+        'productIdentifier': productIdentifier,
+        'type': type.name,
+        'googleOldProductIdentifier': upgradeInfo?.oldSKU,
+        'googleProrationMode': prorationMode?.value,
+        'googleIsPersonalizedPrice': null,
+        'presentedOfferingIdentifier': null,
+      });
+    return purchaseResult;
   }
 
-  /// Makes a purchase. Returns a [CustomerInfo] object. Throws a
+  /// Makes a purchase. Returns a [PurchaseResult] object. Throws a
   /// [PlatformException] if the purchase is unsuccessful.
   /// Check if [PurchasesErrorHelper.getErrorCode] is
   /// [PurchasesErrorCode.purchaseCancelledError] to check if the user cancelled
@@ -392,27 +393,28 @@ class Purchases {
   /// customize for you" in the purchase dialog when true.
   /// See https://developer.android.com/google/play/billing/integrate#personalized-price
   /// for more info.
-  static Future<CustomerInfo> purchaseStoreProduct(
+  static Future<PurchaseResult> purchaseStoreProduct(
     StoreProduct storeProduct, {
     GoogleProductChangeInfo? googleProductChangeInfo,
     bool? googleIsPersonalizedPrice,
   }) async {
     final prorationMode = googleProductChangeInfo?.prorationMode?.value;
-    final customerInfo = await _invokeReturningCustomerInfo('purchaseProduct', {
-      'productIdentifier': storeProduct.identifier,
-      'type': storeProduct.productCategory?.name,
-      'googleOldProductIdentifier':
-          googleProductChangeInfo?.oldProductIdentifier,
-      'googleProrationMode': prorationMode,
-      'googleIsPersonalizedPrice': googleIsPersonalizedPrice,
-      'presentedOfferingIdentifier':
-          storeProduct.presentedOfferingContext?.offeringIdentifier,
-    });
+    final purchaseResult =
+      await _invokeReturningPurchaseResult('purchaseProduct', {
+        'productIdentifier': storeProduct.identifier,
+        'type': storeProduct.productCategory?.name,
+        'googleOldProductIdentifier':
+            googleProductChangeInfo?.oldProductIdentifier,
+        'googleProrationMode': prorationMode,
+        'googleIsPersonalizedPrice': googleIsPersonalizedPrice,
+        'presentedOfferingIdentifier':
+            storeProduct.presentedOfferingContext?.offeringIdentifier,
+      });
 
-    return customerInfo;
+    return purchaseResult;
   }
 
-  /// Makes a purchase. Returns a [CustomerInfo] object. Throws a
+  /// Makes a purchase. Returns a [PurchaseResult] object. Throws a
   /// [PlatformException] if the purchase is unsuccessful.
   /// Check if [PurchasesErrorHelper.getErrorCode] is
   /// [PurchasesErrorCode.purchaseCancelledError] to check if the user cancelled
@@ -433,7 +435,7 @@ class Purchases {
   /// customize for you" in the purchase dialog when true.
   /// See https://developer.android.com/google/play/billing/integrate#personalized-price
   /// for more info.
-  static Future<CustomerInfo> purchasePackage(
+  static Future<PurchaseResult> purchasePackage(
     Package packageToPurchase, {
     @Deprecated('Use GoogleProductChangeInfo') UpgradeInfo? upgradeInfo,
     GoogleProductChangeInfo? googleProductChangeInfo,
@@ -441,21 +443,22 @@ class Purchases {
   }) async {
     final prorationMode = googleProductChangeInfo?.prorationMode?.value ??
         upgradeInfo?.prorationMode?.value;
-    final customerInfo = await _invokeReturningCustomerInfo('purchasePackage', {
-      'packageIdentifier': packageToPurchase.identifier,
-      'presentedOfferingContext':
-          packageToPurchase.presentedOfferingContext.toJson(),
-      'googleOldProductIdentifier':
-          googleProductChangeInfo?.oldProductIdentifier ?? upgradeInfo?.oldSKU,
-      'googleProrationMode': prorationMode,
-      'googleIsPersonalizedPrice': googleIsPersonalizedPrice,
-    });
-    return customerInfo;
+    final purchaseResult =
+      await _invokeReturningPurchaseResult('purchasePackage', {
+        'packageIdentifier': packageToPurchase.identifier,
+        'presentedOfferingContext':
+            packageToPurchase.presentedOfferingContext.toJson(),
+        'googleOldProductIdentifier':
+            googleProductChangeInfo?.oldProductIdentifier ?? upgradeInfo?.oldSKU,
+        'googleProrationMode': prorationMode,
+        'googleIsPersonalizedPrice': googleIsPersonalizedPrice,
+      });
+    return purchaseResult;
   }
 
   /// Google Play only.
   ///
-  /// Makes a purchase. Returns a [CustomerInfo] object. Throws a
+  /// Makes a purchase. Returns a [PurchaseResult] object. Throws a
   /// [PlatformException] if the purchase is unsuccessful.
   /// Check if [PurchasesErrorHelper.getErrorCode] is
   /// [PurchasesErrorCode.purchaseCancelledError] to check if the user cancelled
@@ -473,7 +476,7 @@ class Purchases {
   /// customize for you" in the purchase dialog when true.
   /// See https://developer.android.com/google/play/billing/integrate#personalized-price
   /// for more info.
-  static Future<CustomerInfo> purchaseSubscriptionOption(
+  static Future<PurchaseResult> purchaseSubscriptionOption(
     SubscriptionOption subscriptionOption, {
     GoogleProductChangeInfo? googleProductChangeInfo,
     bool? googleIsPersonalizedPrice,
@@ -484,8 +487,8 @@ class Purchases {
 
     final prorationMode = googleProductChangeInfo?.prorationMode?.value;
 
-    final customerInfo =
-        await _invokeReturningCustomerInfo('purchaseSubscriptionOption', {
+    final purchaseResult =
+        await _invokeReturningPurchaseResult('purchaseSubscriptionOption', {
       'productIdentifier': subscriptionOption.productId,
       'optionIdentifier': subscriptionOption.id,
       'googleOldProductIdentifier':
@@ -495,12 +498,12 @@ class Purchases {
       'presentedOfferingIdentifier':
           subscriptionOption.presentedOfferingContext?.offeringIdentifier,
     });
-    return customerInfo;
+    return purchaseResult;
   }
 
   /// iOS only. Purchase a product applying a given promotional offer.
   ///
-  /// Returns a [CustomerInfo] object. Throws a
+  /// Returns a [PurchaseResult] object. Throws a
   /// [PlatformException] if the purchase is unsuccessful.
   /// Check if [PurchasesErrorHelper.getErrorCode] is
   /// [PurchasesErrorCode.purchaseCancelledError] to check if the user cancelled
@@ -510,22 +513,23 @@ class Purchases {
   ///
   /// [promotionalOffer] Promotional offer that will be applied to the product.
   /// Retrieve this offer using [getPromotionalOffer].
-  static Future<CustomerInfo> purchaseDiscountedProduct(
+  static Future<PurchaseResult> purchaseDiscountedProduct(
     StoreProduct product,
     PromotionalOffer promotionalOffer,
   ) async {
-    final customerInfo = await _invokeReturningCustomerInfo('purchaseProduct', {
-      'productIdentifier': product.identifier,
-      'signedDiscountTimestamp': promotionalOffer.timestamp.toString(),
-      'presentedOfferingIdentifier':
-          product.presentedOfferingContext?.offeringIdentifier,
-    });
-    return customerInfo;
+    final purchaseResult =
+      await _invokeReturningPurchaseResult('purchaseProduct', {
+        'productIdentifier': product.identifier,
+        'signedDiscountTimestamp': promotionalOffer.timestamp.toString(),
+        'presentedOfferingIdentifier':
+            product.presentedOfferingContext?.offeringIdentifier,
+      });
+    return purchaseResult;
   }
 
   /// iOS only. Purchase a package applying a given promotional offer.
   ///
-  /// Returns a [CustomerInfo] object. Throws a
+  /// Returns a [PurchaseResult] object. Throws a
   /// [PlatformException] if the purchase is unsuccessful.
   /// Check if [PurchasesErrorHelper.getErrorCode] is
   /// [PurchasesErrorCode.purchaseCancelledError] to check if the user cancelled
@@ -535,17 +539,18 @@ class Purchases {
   ///
   /// [promotionalOffer] Promotional offer that will be applied to the product.
   /// Retrieve this offer using [getPromotionalOffer].
-  static Future<CustomerInfo> purchaseDiscountedPackage(
+  static Future<PurchaseResult> purchaseDiscountedPackage(
     Package packageToPurchase,
     PromotionalOffer promotionalOffer,
   ) async {
-    final customerInfo = await _invokeReturningCustomerInfo('purchasePackage', {
-      'packageIdentifier': packageToPurchase.identifier,
-      'presentedOfferingContext':
-          packageToPurchase.presentedOfferingContext.toJson(),
-      'signedDiscountTimestamp': promotionalOffer.timestamp.toString(),
-    });
-    return customerInfo;
+    final purchaseResult =
+      await _invokeReturningPurchaseResult('purchasePackage', {
+        'packageIdentifier': packageToPurchase.identifier,
+        'presentedOfferingContext':
+            packageToPurchase.presentedOfferingContext.toJson(),
+        'signedDiscountTimestamp': promotionalOffer.timestamp.toString(),
+      });
+    return purchaseResult;
   }
 
   /// Restores a user's previous purchases and links their appUserIDs to any
@@ -1221,6 +1226,16 @@ class Purchases {
       'redemptionLink': webPurchaseRedemption.redemptionLink,
     });
     return WebPurchaseRedemptionResult.fromJson(Map<String, dynamic>.from(result));
+  }
+
+  static Future<PurchaseResult> _invokeReturningPurchaseResult(String method,
+      // ignore: require_trailing_commas
+      [dynamic arguments]) async {
+    final response = await _invokeReturningMap(
+      method,
+      arguments,
+    );
+    return PurchaseResult.fromJson(response);
   }
 
   static Future<CustomerInfo> _invokeReturningCustomerInfo(String method,

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -1238,22 +1238,6 @@ class Purchases {
     return PurchaseResult.fromJson(response);
   }
 
-  static Future<CustomerInfo> _invokeReturningCustomerInfo(String method,
-      // ignore: require_trailing_commas
-      [dynamic arguments]) async {
-    final response = await _invokeReturningMap(
-      method,
-      arguments,
-    );
-    final customerInfoJson = _getCustomerInfoJsonFromMap(response);
-    return CustomerInfo.fromJson(customerInfoJson);
-  }
-
-  static Map<String, dynamic> _getCustomerInfoJsonFromMap(
-    Map<String, dynamic> response,
-  ) =>
-      Map<String, dynamic>.from(response['customerInfo']);
-
   static Future<Map<String, dynamic>> _invokeReturningMap(String method,
       // ignore: require_trailing_commas
       [dynamic arguments]) async {

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -951,7 +951,7 @@ class Purchases {
   /// iOS only, requires iOS 18.0 or greater with StoreKit 2.
   /// Purchase a product applying a given win-back offer.
   ///
-  /// Returns a [CustomerInfo] object. Throws a
+  /// Returns a [PurchaseResult] object. Throws a
   /// [PlatformException] if the purchase is unsuccessful.
   /// Check if [PurchasesErrorHelper.getErrorCode] is
   /// [PurchasesErrorCode.purchaseCancelledError] to check if the user cancelled
@@ -962,22 +962,22 @@ class Purchases {
   /// [winBackOffer] Win-back offer that will be applied to the product.
   /// Retrieve this offer using [getEligibleWinBackOffersForProduct]
   /// or [getEligibleWinBackOffersForPackage].
-  static Future<CustomerInfo> purchaseProductWithWinBackOffer(
+  static Future<PurchaseResult> purchaseProductWithWinBackOffer(
     StoreProduct product,
     WinBackOffer winBackOffer,
   ) async {
-    final customerInfo =
-        await _invokeReturningCustomerInfo('purchaseProductWithWinBackOffer', {
+    final purchaseResult =
+        await _invokeReturningPurchaseResult('purchaseProductWithWinBackOffer', {
       'productIdentifier': product.identifier,
       'winBackOfferIdentifier': winBackOffer.identifier,
     });
-    return customerInfo;
+    return purchaseResult;
   }
 
   /// iOS only, requires iOS 18.0 or greater with StoreKit 2.
   /// Purchase a package applying a given win-back offer.
   ///
-  /// Returns a [CustomerInfo] object. Throws a
+  /// Returns a [PurchaseResult] object. Throws a
   /// [PlatformException] if the purchase is unsuccessful.
   /// Check if [PurchasesErrorHelper.getErrorCode] is
   /// [PurchasesErrorCode.purchaseCancelledError] to check if the user cancelled
@@ -987,17 +987,17 @@ class Purchases {
   ///
   /// [winBackOffer] Win-back offer that will be applied to the package.
   /// Retrieve this offer using [getEligibleWinBackOffersForPackage].
-  static Future<CustomerInfo> purchasePackageWithWinBackOffer(
+  static Future<PurchaseResult> purchasePackageWithWinBackOffer(
     Package package,
     WinBackOffer winBackOffer,
   ) async {
-    final customerInfo =
-        await _invokeReturningCustomerInfo('purchasePackageWithWinBackOffer', {
+    final purchaseResult =
+        await _invokeReturningPurchaseResult('purchasePackageWithWinBackOffer', {
       'packageIdentifier': package.identifier,
       'presentedOfferingContext': package.presentedOfferingContext.toJson(),
       'winBackOfferIdentifier': winBackOffer.identifier,
     });
-    return customerInfo;
+    return purchaseResult;
   }
 
   /// iOS 15+ only. Presents a refund request sheet in the current window scene for

--- a/lib/web/purchases_flutter_web.dart
+++ b/lib/web/purchases_flutter_web.dart
@@ -12,7 +12,7 @@ import '../purchases_flutter.dart';
 class PurchasesFlutterPlugin {
   static final _unknownErrorCode = '${PurchasesErrorCode.unknownError.index}';
   static final _configurationErrorCode = '${PurchasesErrorCode.configurationError.index}';
-  static const _purchasesHybridMappingsVersion = '13.29.0';
+  static const _purchasesHybridMappingsVersion = '15.0.0';
   static const _platformName = 'flutter';
   static const _pluginVersion = '8.7.3';
   static const _purchasesHybridMappingsUrl =
@@ -162,14 +162,16 @@ class PurchasesFlutterPlugin {
       );
     }
 
-    final appUserId = arguments['appUserId'] as String?;
-
     final options = {
       'apiKey': apiKey,
-      'appUserId': appUserId,
       'flavor': _platformName,
       'flavorVersion': _pluginVersion,
     };
+    final appUserId = arguments['appUserId'] as String?;
+
+    if(appUserId != null && appUserId.isNotEmpty) {
+      options['appUserId'] = appUserId;
+    }
 
     _callStaticMethod('configure', [options]);
   }

--- a/revenuecat_examples/MagicWeather/lib/src/views/paywall.dart
+++ b/revenuecat_examples/MagicWeather/lib/src/views/paywall.dart
@@ -51,11 +51,11 @@ class _PaywallState extends State<Paywall> {
                   child: ListTile(
                       onTap: () async {
                         try {
-                          CustomerInfo customerInfo =
+                          PurchaseResult purchaseResult =
                               await Purchases.purchasePackage(
                                   myProductList[index]);
-                          EntitlementInfo? entitlement =
-                              customerInfo.entitlements.all[entitlementID];
+                          EntitlementInfo? entitlement = purchaseResult
+                              .customerInfo.entitlements.all[entitlementID];
                           appData.entitlementIsActive =
                               entitlement?.isActive ?? false;
                         } catch (e) {

--- a/revenuecat_examples/purchase_tester/lib/src/upsell.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/upsell.dart
@@ -285,9 +285,10 @@ class _PurchaseButton extends StatelessWidget {
 
   Future<void> _purchasePackage(BuildContext context, Package package) async {
     try {
-      final customerInfo = await Purchases.purchasePackage(package);
-      final isPro =
-          customerInfo.entitlements.active.containsKey(entitlementKey);
+      final purchaseResult = await Purchases.purchasePackage(package);
+      final isPro = purchaseResult.customerInfo.entitlements
+        .active.containsKey(entitlementKey);
+      print("StoreTransaction: ${purchaseResult.storeTransaction}");
       if (isPro) {
         Navigator.pushReplacement(
           context,
@@ -335,9 +336,9 @@ class _PurchaseStoreProductButton extends StatelessWidget {
   Future<void> _purchaseStoreProduct(
       BuildContext context, StoreProduct storeProduct) async {
     try {
-      final customerInfo = await Purchases.purchaseStoreProduct(storeProduct);
-      final isPro =
-          customerInfo.entitlements.active.containsKey(entitlementKey);
+      final purchaseResult = await Purchases.purchaseStoreProduct(storeProduct);
+      final isPro = purchaseResult.customerInfo.entitlements
+        .active.containsKey(entitlementKey);
       if (isPro) {
         Navigator.pushReplacement(
           context,
@@ -380,9 +381,9 @@ class _PurchaseSubscriptionOptionButton extends StatelessWidget {
             icon: const Icon(Icons.add_shopping_cart),
             onPressed: () async {
               try {
-                final customerInfo =
+                final purchaseResult =
                     await Purchases.purchaseSubscriptionOption(option);
-                final isPro = customerInfo.entitlements.active
+                final isPro = purchaseResult.customerInfo.entitlements.active
                     .containsKey(entitlementKey);
                 if (isPro) {
                   Navigator.pushReplacement(

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -42,6 +42,12 @@ void main() {
     'nonSubscriptionTransactions': [],
   };
 
+  final mockStoreTransaction = {
+    'transactionIdentifier': 'mock_transaction_id',
+    'productIdentifier': 'mock_product_id',
+    'purchaseDate': '2025-01-01T01:20:11.000Z',
+  };
+
   setUp(() {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, (call) async {
@@ -546,6 +552,7 @@ void main() {
       response = {
         'productIdentifier': 'product.identifier',
         'customerInfo': mockCustomerInfoResponse,
+        'transaction': mockStoreTransaction,
       };
       const mockStoreProduct = StoreProduct(
         'com.revenuecat.lifetime',
@@ -565,7 +572,7 @@ void main() {
           await Purchases.purchasePackage(mockPackage);
       expect(
         purchasePackageResult,
-        CustomerInfo.fromJson(mockCustomerInfoResponse),
+        PurchaseResult.fromJson(response),
       );
 
       expect(
@@ -599,6 +606,7 @@ void main() {
       response = {
         'productIdentifier': 'product.identifier',
         'customerInfo': mockCustomerInfoResponse,
+        'transaction': mockStoreTransaction,
       };
       const mockStoreProduct = StoreProduct(
         'com.revenuecat.lifetime',
@@ -625,7 +633,7 @@ void main() {
       );
       expect(
         purchasePackageResult,
-        CustomerInfo.fromJson(mockCustomerInfoResponse),
+        PurchaseResult.fromJson(response),
       );
 
       expect(
@@ -657,6 +665,7 @@ void main() {
       response = {
         'productIdentifier': 'product.identifier',
         'customerInfo': mockCustomerInfoResponse,
+        'transaction': mockStoreTransaction,
       };
       const mockStoreProduct = StoreProduct(
         'com.revenuecat.lifetime',
@@ -685,7 +694,7 @@ void main() {
       );
       expect(
         purchasePackageResult,
-        CustomerInfo.fromJson(mockCustomerInfoResponse),
+        PurchaseResult.fromJson(response),
       );
     } on PlatformException catch (e) {
       fail('there was an exception $e');
@@ -697,6 +706,7 @@ void main() {
       response = {
         'productIdentifier': 'product.identifier',
         'customerInfo': mockCustomerInfoResponse,
+        'transaction': mockStoreTransaction,
       };
       const mockStoreProduct = StoreProduct(
         'com.revenuecat.lifetime',
@@ -711,7 +721,7 @@ void main() {
       );
       expect(
         purchasePackageResult,
-        CustomerInfo.fromJson(mockCustomerInfoResponse),
+        PurchaseResult.fromJson(response),
       );
 
       expect(
@@ -742,6 +752,7 @@ void main() {
       response = {
         'productIdentifier': 'product.identifier',
         'customerInfo': mockCustomerInfoResponse,
+        'transaction': mockStoreTransaction,
       };
       const mockStoreProduct = StoreProduct(
         'com.revenuecat.lifetime',
@@ -757,7 +768,7 @@ void main() {
       );
       expect(
         purchasePackageResult,
-        CustomerInfo.fromJson(mockCustomerInfoResponse),
+        PurchaseResult.fromJson(response),
       );
 
       expect(
@@ -786,6 +797,7 @@ void main() {
       response = {
         'productIdentifier': 'product.identifier',
         'customerInfo': mockCustomerInfoResponse,
+        'transaction': mockStoreTransaction,
       };
       const mockStoreProduct = StoreProduct(
         'com.revenuecat.lifetime',
@@ -802,7 +814,7 @@ void main() {
           await Purchases.purchaseStoreProduct(mockStoreProduct);
       expect(
         purchasePackageResult,
-        CustomerInfo.fromJson(mockCustomerInfoResponse),
+        PurchaseResult.fromJson(response),
       );
 
       expect(
@@ -831,6 +843,7 @@ void main() {
       response = {
         'productIdentifier': 'product.identifier',
         'customerInfo': mockCustomerInfoResponse,
+        'transaction': mockStoreTransaction,
       };
       const mockStoreProduct = StoreProduct(
         'com.revenuecat.lifetime',
@@ -855,7 +868,7 @@ void main() {
       );
       expect(
         purchasePackageResult,
-        CustomerInfo.fromJson(mockCustomerInfoResponse),
+        PurchaseResult.fromJson(response),
       );
 
       expect(
@@ -883,6 +896,7 @@ void main() {
       response = {
         'productIdentifier': 'gold:monthly',
         'customerInfo': mockCustomerInfoResponse,
+        'transaction': mockStoreTransaction,
       };
       const phase = PricingPhase(
         Period(PeriodUnit.month, 1, 'P1M'),
@@ -910,7 +924,7 @@ void main() {
           await Purchases.purchaseSubscriptionOption(mockSubscriptionOption);
       expect(
         purchasePackageResult,
-        CustomerInfo.fromJson(mockCustomerInfoResponse),
+        PurchaseResult.fromJson(response),
       );
 
       expect(
@@ -943,6 +957,7 @@ void main() {
       response = {
         'productIdentifier': 'gold:monthly',
         'customerInfo': mockCustomerInfoResponse,
+        'transaction': mockStoreTransaction,
       };
       const phase = PricingPhase(
         Period(PeriodUnit.month, 1, 'P1M'),
@@ -977,7 +992,7 @@ void main() {
       );
       expect(
         purchasePackageResult,
-        CustomerInfo.fromJson(mockCustomerInfoResponse),
+        PurchaseResult.fromJson(response),
       );
 
       expect(


### PR DESCRIPTION
This changes the result type of the purchase methods. Instead of returning just a `CustomerInfo`, now we will return a `PurchaseResult`, which includes a `CustomerInfo` and a `StoreTransaction`
