### PR TITLE
Fix wrong SDK version on web for analytics

### DIFF
--- a/lib/web/purchases_flutter_web.dart
+++ b/lib/web/purchases_flutter_web.dart
@@ -14,7 +14,7 @@ class PurchasesFlutterPlugin {
   static final _configurationErrorCode = '${PurchasesErrorCode.configurationError.index}';
   static const _purchasesHybridMappingsVersion = '15.0.0';
   static const _platformName = 'flutter';
-  static const _pluginVersion = '8.7.3';
+  static const _pluginVersion = '9.0.0';
   static const _purchasesHybridMappingsUrl =
       'https://cdn.jsdelivr.net/npm/@revenuecat/purchases-js-hybrid-mappings@$_purchasesHybridMappingsVersion/dist/index.umd.js';
 


### PR DESCRIPTION
After merging the v9 base branch in #1407, we didn't update the version of the SDK, so it wasn't caught by our automations. This mismatch can cause some of our analytics to not be set correctly. This fixes the number so it works moving forward.