### PR TITLE
Add purchase_tester dependency to fix issues in latest version of flutter

### DIFF
--- a/revenuecat_examples/purchase_tester/pubspec.yaml
+++ b/revenuecat_examples/purchase_tester/pubspec.yaml
@@ -15,6 +15,8 @@ dependencies:
 
   app_links: ^6.3.3
 
+  # Need to reference these to be able to get the iOS dependencies for Cocoapods added,
+  # but we override these dependencies later so these are not the versions used.
   purchases_flutter: ^9.2.1
   purchases_ui_flutter: ^9.2.1
 


### PR DESCRIPTION
Starting on version 3.35.0 of flutter, ios and macos tests started failing. Trying to debug, it seems that the Podfile.lock didn't include PHC nor purchases-ios dependencies. Looking around, I saw that we were adding these local path dependencies as overrides, but not as dependencies themselves. Adding them there made the dependencies appear again in the Podfile.lock and for it to work again. 

This shouldn't affect customers and be related to how we are depending on our SDKs from the purchase tester app.
