### PR TITLE
Add codelab guides to the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,20 @@ To use this plugin, add `purchases_flutter` as a [dependency in your pubspec.yam
 
 ## Getting Started
 For more detailed information, you can view our complete documentation at [docs.revenuecat.com](https://docs.revenuecat.com/docs/flutter).
+
+## Codelab
+
+This codelab is a step-by-step tutorial designed to help you learn and master the [RevenueCat SDK](https://www.revenuecat.com/docs/welcome/overview) taking you from the absolute basics to more advanced implementation. Whether you're just getting started or looking to deepen your understanding, this guide walks you through everything you need to go from zero to hero with RevenueCat.
+
+1. [RevenueCat Google Play Integration](https://revenuecat.github.io/codelab/google-play/codelab-1-google-play-integration/index.html#0): In this codelab, you'll learn how to:
+
+   - Properly configure products on Google Play.
+   - Set up the RevenueCat dashboard and connect it to your Google Play products.
+   - Understanding Product, Offering, Package, and Entitlement.
+   - Create paywalls using the [Paywall Editor](https://www.revenuecat.com/docs/tools/paywalls/creating-paywalls#using-the-editor).
+
+2. [Flutter Purchases & Paywalls Overview](https://revenuecat.github.io/codelab/flutter/codelab-4-flutter-sdk/index.html#0): In this codelab, you will:
+- Integrate the RevenueCat SDK into your Flutter project
+- Implement in-app purchases in your Flutter application
+- Learn how to distinguish between paying and non-paying users
+- Build a paywall screen, which is based on the server-driven UI approach


### PR DESCRIPTION
Add codelab guides for Google Play & Flutter SDK to the README file.
