### PR TITLE
Support `automaticDeviceIdentifierCollectionEnabled` when configuring SDK

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -120,9 +120,12 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 String verificationMode = call.argument("entitlementVerificationMode");
                 Boolean pendingTransactionsForPrepaidPlansEnabled = call
                         .argument("pendingTransactionsForPrepaidPlansEnabled");
+                Boolean automaticDeviceIdentifierCollectionEnabled = call
+                        .argument("automaticDeviceIdentifierCollectionEnabled");
                 setupPurchases(apiKey, appUserId, purchasesAreCompletedBy, useAmazon,
                         shouldShowInAppMessagesAutomatically, verificationMode,
-                        pendingTransactionsForPrepaidPlansEnabled, result);
+                        pendingTransactionsForPrepaidPlansEnabled,
+                        automaticDeviceIdentifierCollectionEnabled, result);
                 break;
             case "setAllowSharingStoreAccount":
                 Boolean allowSharing = call.argument("allowSharing");
@@ -370,6 +373,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
             @Nullable String purchasesAreCompletedBy, @Nullable Boolean useAmazon,
             @Nullable Boolean shouldShowInAppMessagesAutomatically, @Nullable String verificationMode,
             @Nullable Boolean pendingTransactionsForPrepaidPlansEnabled,
+            @Nullable Boolean automaticDeviceIdentifierCollectionEnabled,
             final Result result) {
         if (this.applicationContext != null) {
             PlatformInfo platformInfo = new PlatformInfo(PLATFORM_NAME, PLUGIN_VERSION);
@@ -387,7 +391,8 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                     new DangerousSettings(),
                     shouldShowInAppMessagesAutomatically,
                     verificationMode,
-                    pendingTransactionsForPrepaidPlansEnabled);
+                    pendingTransactionsForPrepaidPlansEnabled,
+                    automaticDeviceIdentifierCollectionEnabled);
             setUpdatedCustomerInfoListener();
             result.success(null);
         } else {

--- a/api_tester/lib/api_tests/models/purchase_configuration_api_test.dart
+++ b/api_tester/lib/api_tests/models/purchase_configuration_api_test.dart
@@ -23,6 +23,7 @@ class _PurchaseConfigurationApiTest {
     configuration.store = null;
     configuration.store = Store.playStore;
     configuration.storeKitVersion = storeKitVersion;
+    configuration.automaticDeviceIdentifierCollectionEnabled = true;
 
     // deprecated, but we still need to check that the API hasn't been removed.
     configuration.pendingTransactionsForPrepaidPlansEnabled = true;
@@ -47,5 +48,6 @@ class _PurchaseConfigurationApiTest {
     configuration.store = null;
     configuration.store = Store.playStore;
     configuration.storeKitVersion = storeKitVersion;
+    configuration.automaticDeviceIdentifierCollectionEnabled = true;
   }
 }

--- a/ios/Classes/PurchasesFlutterPlugin.m
+++ b/ios/Classes/PurchasesFlutterPlugin.m
@@ -56,6 +56,11 @@ NSString *PurchasesLogHandlerEvent = @"Purchases-LogHandlerEvent";
         NSString * _Nullable verificationMode = arguments[@"entitlementVerificationMode"];
         NSString * _Nullable userDefaultsSuiteName = arguments[@"userDefaultsSuiteName"];
         NSString *storeKitVersion = arguments[@"storeKitVersion"];
+        BOOL automaticDeviceIdentifierCollectionEnabled = YES;
+        object = arguments[@"automaticDeviceIdentifierCollectionEnabled"];
+        if (object != [NSNull null] && object != nil) {
+            automaticDeviceIdentifierCollectionEnabled = [object boolValue];
+        }
         [self setupPurchases:apiKey
                    appUserID:appUserID
      purchasesAreCompletedBy:purchasesAreCompletedBy
@@ -63,6 +68,7 @@ NSString *PurchasesLogHandlerEvent = @"Purchases-LogHandlerEvent";
              storeKitVersion: storeKitVersion
 shouldShowInAppMessagesAutomatically: shouldShowInAppMessagesAutomatically
             verificationMode:verificationMode
+automaticDeviceIdentifierCollectionEnabled:automaticDeviceIdentifierCollectionEnabled
                       result:result];
     } else if ([@"setAllowSharingStoreAccount" isEqualToString:call.method]) {
         [self setAllowSharingStoreAccount:[arguments[@"allowSharing"] boolValue] result:result];
@@ -263,6 +269,7 @@ purchasesAreCompletedBy:(nullable NSString *)purchasesAreCompletedBy
        storeKitVersion:(nullable NSString *)storeKitVersion
 shouldShowInAppMessagesAutomatically:(BOOL)shouldShowInAppMessagesAutomatically
       verificationMode:(nullable NSString *)verificationMode
+automaticDeviceIdentifierCollectionEnabled:(BOOL)automaticDeviceIdentifierCollectionEnabled
                 result:(FlutterResult)result {
     if ([appUserID isKindOfClass:NSNull.class]) {
         appUserID = nil;
@@ -280,7 +287,9 @@ shouldShowInAppMessagesAutomatically:(BOOL)shouldShowInAppMessagesAutomatically
                                               storeKitVersion:storeKitVersion
                                             dangerousSettings:nil
                          shouldShowInAppMessagesAutomatically:shouldShowInAppMessagesAutomatically
-                                             verificationMode:verificationMode];
+                                             verificationMode:verificationMode
+                                           diagnosticsEnabled:NO
+                   automaticDeviceIdentifierCollectionEnabled:automaticDeviceIdentifierCollectionEnabled];
     purchases.delegate = self;
 
     result(nil);

--- a/lib/models/purchases_configuration.dart
+++ b/lib/models/purchases_configuration.dart
@@ -57,6 +57,17 @@ class PurchasesConfiguration {
   /// in Google Play). Note that entitlements are not granted until payment is done.
   /// Disabled by default.
   bool pendingTransactionsForPrepaidPlansEnabled = false;
+
+  /// Enable this setting to allow the collection of identifiers when setting the identifier for an
+  /// attribution network. For example, when calling [Purchases.setAdjustID] or [Purchases.setAppsflyerID],
+  /// the SDK would collect the Android advertising ID, IP and device versions, if available, and send them
+  /// to RevenueCat. This is required by some attribution networks to attribute installs and re-installs.
+  ///
+  /// Enabling this setting does NOT mean we will always collect the identifiers. We will only do so when
+  /// setting an attribution network ID AND the user has not limited ad tracking on their device.
+  ///
+  /// Default is enabled.
+  bool automaticDeviceIdentifierCollectionEnabled = true;
 }
 
 /// A [PurchasesConfiguration] convenience object that

--- a/lib/models/purchases_configuration.dart
+++ b/lib/models/purchases_configuration.dart
@@ -60,7 +60,7 @@ class PurchasesConfiguration {
 
   /// Enable this setting to allow the collection of identifiers when setting the identifier for an
   /// attribution network. For example, when calling [Purchases.setAdjustID] or [Purchases.setAppsflyerID],
-  /// the SDK would collect the Android advertising ID, IP and device versions, if available, and send them
+  /// the SDK would collect device identifiers, if available, and send them
   /// to RevenueCat. This is required by some attribution networks to attribute installs and re-installs.
   ///
   /// Enabling this setting does NOT mean we will always collect the identifiers. We will only do so when

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -183,6 +183,8 @@ class Purchases {
             purchasesConfiguration.entitlementVerificationMode.name,
         'pendingTransactionsForPrepaidPlansEnabled':
             purchasesConfiguration.pendingTransactionsForPrepaidPlansEnabled,
+        'automaticDeviceIdentifierCollectionEnabled':
+            purchasesConfiguration.automaticDeviceIdentifierCollectionEnabled,
       },
     );
   }

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -100,6 +100,7 @@ void main() {
             'shouldShowInAppMessagesAutomatically': true,
             'entitlementVerificationMode': 'DISABLED',
             'pendingTransactionsForPrepaidPlansEnabled': false,
+            'automaticDeviceIdentifierCollectionEnabled': true,
           },
         ),
       ],
@@ -129,6 +130,7 @@ void main() {
             'shouldShowInAppMessagesAutomatically': true,
             'entitlementVerificationMode': 'DISABLED',
             'pendingTransactionsForPrepaidPlansEnabled': false,
+            'automaticDeviceIdentifierCollectionEnabled': true,
           },
         ),
       ],
@@ -156,6 +158,7 @@ void main() {
             'shouldShowInAppMessagesAutomatically': true,
             'entitlementVerificationMode': 'DISABLED',
             'pendingTransactionsForPrepaidPlansEnabled': false,
+            'automaticDeviceIdentifierCollectionEnabled': true,
           },
         ),
       ],
@@ -186,6 +189,7 @@ void main() {
             'shouldShowInAppMessagesAutomatically': true,
             'entitlementVerificationMode': 'DISABLED',
             'pendingTransactionsForPrepaidPlansEnabled': false,
+            'automaticDeviceIdentifierCollectionEnabled': true,
           },
         ),
       ],
@@ -1094,6 +1098,7 @@ void main() {
             'shouldShowInAppMessagesAutomatically': true,
             'entitlementVerificationMode': 'DISABLED',
             'pendingTransactionsForPrepaidPlansEnabled': false,
+            'automaticDeviceIdentifierCollectionEnabled': true,
           },
         ),
       ],
@@ -1122,6 +1127,7 @@ void main() {
             'shouldShowInAppMessagesAutomatically': true,
             'entitlementVerificationMode': 'DISABLED',
             'pendingTransactionsForPrepaidPlansEnabled': true,
+            'automaticDeviceIdentifierCollectionEnabled': true,
           },
         ),
       ],
@@ -1151,6 +1157,7 @@ void main() {
             'shouldShowInAppMessagesAutomatically': true,
             'entitlementVerificationMode': 'DISABLED',
             'pendingTransactionsForPrepaidPlansEnabled': false,
+            'automaticDeviceIdentifierCollectionEnabled': true,
           },
         ),
       ],
@@ -1181,6 +1188,35 @@ void main() {
             'shouldShowInAppMessagesAutomatically': true,
             'entitlementVerificationMode': 'DISABLED',
             'pendingTransactionsForPrepaidPlansEnabled': false,
+            'automaticDeviceIdentifierCollectionEnabled': true,
+          },
+        ),
+      ],
+    );
+  });
+
+  test('configure with automaticDeviceIdentifierCollectionEnabled false', () async {
+    await Purchases.configure(
+      PurchasesConfiguration('api_key')
+        ..appUserID = 'cesar'
+        ..automaticDeviceIdentifierCollectionEnabled = false,
+    );
+    expect(
+      log,
+      <Matcher>[
+        isMethodCall(
+          'setupPurchases',
+          arguments: <String, dynamic>{
+            'apiKey': 'api_key',
+            'appUserId': 'cesar',
+            'purchasesAreCompletedBy': 'REVENUECAT',
+            'userDefaultsSuiteName': null,
+            'storeKitVersion': 'DEFAULT',
+            'useAmazon': false,
+            'shouldShowInAppMessagesAutomatically': true,
+            'entitlementVerificationMode': 'DISABLED',
+            'pendingTransactionsForPrepaidPlansEnabled': false,
+            'automaticDeviceIdentifierCollectionEnabled': false,
           },
         ),
       ],


### PR DESCRIPTION
This adds a new API that can be used to disable automatic collection of device identifiers when using one of the attribution networks we support like Adjust or Appsflyer (among others). This can be set at configuration time like this:
```
PurchasesConfiguration configuration = PurchasesConfiguration("fakeApiKey")
  ..automaticDeviceIdentifierCollectionEnabled = enabled;
Purchases.configure(configuration);
```

Note that you can still collect these identifiers with this option disabled by calling `Purchases.shared.collectDeviceIdentifiers()`
