### PR TITLE
Add customerEmail param to PurchaseParams

### DIFF
--- a/api_tester/lib/api_tests/models/purchase_params_api_test.dart
+++ b/api_tester/lib/api_tests/models/purchase_params_api_test.dart
@@ -8,7 +8,8 @@ class _PurchaseParamsApiTest {
     Package package,
     GoogleProductChangeInfo? googleProductChangeInfo,
     bool? googleIsPersonalizedPrice,
-    PromotionalOffer? promotionalOffer
+    PromotionalOffer? promotionalOffer,
+    String? customerEmail,
   ) {
     PurchaseParams purchaseParams = PurchaseParams.package(
       package: package,
@@ -28,13 +29,21 @@ class _PurchaseParamsApiTest {
       googleIsPersonalizedPrice: googleIsPersonalizedPrice,
       promotionalOffer: promotionalOffer,
     );
+    purchaseParams = PurchaseParams.package(
+      package: package,
+      googleProductChangeInfo: googleProductChangeInfo,
+      googleIsPersonalizedPrice: googleIsPersonalizedPrice,
+      promotionalOffer: promotionalOffer,
+      customerEmail: customerEmail,
+    );
   }
 
   void _checkStoreProductConstructor(
     StoreProduct storeProduct,
     GoogleProductChangeInfo? googleProductChangeInfo,
     bool? googleIsPersonalizedPrice,
-    PromotionalOffer? promotionalOffer
+    PromotionalOffer? promotionalOffer,
+    String? customerEmail,
   ) {
     PurchaseParams purchaseParams = PurchaseParams.storeProduct(
       storeProduct: storeProduct,
@@ -54,12 +63,20 @@ class _PurchaseParamsApiTest {
       googleIsPersonalizedPrice: googleIsPersonalizedPrice,
       promotionalOffer: promotionalOffer,
     );
+    purchaseParams = PurchaseParams.storeProduct(
+      storeProduct: storeProduct,
+      googleProductChangeInfo: googleProductChangeInfo,
+      googleIsPersonalizedPrice: googleIsPersonalizedPrice,
+      promotionalOffer: promotionalOffer,
+      customerEmail: customerEmail,
+    );
   }
 
   void _checkSubscriptionOptionConstructor(
     SubscriptionOption subscriptionOption,
     GoogleProductChangeInfo? googleProductChangeInfo,
-    bool? googleIsPersonalizedPrice
+    bool? googleIsPersonalizedPrice,
+    String? customerEmail,
   ) {
     PurchaseParams purchaseParams = PurchaseParams.subscriptionOption(
       subscriptionOption: subscriptionOption,
@@ -73,6 +90,12 @@ class _PurchaseParamsApiTest {
       googleProductChangeInfo: googleProductChangeInfo,
       googleIsPersonalizedPrice: googleIsPersonalizedPrice,
     );
+    purchaseParams = PurchaseParams.subscriptionOption(
+      subscriptionOption: subscriptionOption,
+      googleProductChangeInfo: googleProductChangeInfo,
+      googleIsPersonalizedPrice: googleIsPersonalizedPrice,
+      customerEmail: customerEmail,
+    );
   }
 
   void _checkProperties(PurchaseParams purchaseParams) {
@@ -82,5 +105,6 @@ class _PurchaseParamsApiTest {
     GoogleProductChangeInfo? googleProductChangeInfo = purchaseParams.googleProductChangeInfo;
     bool? googleIsPersonalizedPrice = purchaseParams.googleIsPersonalizedPrice;
     PromotionalOffer? promotionalOffer = purchaseParams.promotionalOffer;
+    String? customerEmail = purchaseParams.customerEmail;
   }
 }

--- a/lib/models/purchase_params.dart
+++ b/lib/models/purchase_params.dart
@@ -12,6 +12,7 @@ class PurchaseParams {
   final GoogleProductChangeInfo? googleProductChangeInfo;
   final bool? googleIsPersonalizedPrice;
   final PromotionalOffer? promotionalOffer;
+  final String? customerEmail;
 
   const PurchaseParams._(
     this.package,
@@ -20,6 +21,7 @@ class PurchaseParams {
     this.googleProductChangeInfo,
     this.googleIsPersonalizedPrice,
     this.promotionalOffer,
+    this.customerEmail,
   );
 
   /// Creates purchase parameters for a package.
@@ -38,11 +40,16 @@ class PurchaseParams {
   ///
   /// [promotionalOffer] iOS only. Promotional offer that will be applied to the product.
   /// Retrieve this offer using [Purchases.getPromotionalOffer].
+  ///
+  /// [customerEmail] Web only. The email of the user. If undefined, RevenueCat
+  /// will ask the customer for their email.
+  ///
   const PurchaseParams.package({
     required Package package,
     GoogleProductChangeInfo? googleProductChangeInfo,
     bool? googleIsPersonalizedPrice,
     PromotionalOffer? promotionalOffer,
+    String? customerEmail,
   }) : this._(
         package,
         null,
@@ -50,6 +57,7 @@ class PurchaseParams {
         googleProductChangeInfo,
         googleIsPersonalizedPrice,
         promotionalOffer,
+        customerEmail,
       );
 
   /// Creates purchase parameters for a store product.
@@ -68,11 +76,16 @@ class PurchaseParams {
   ///
   /// [promotionalOffer] iOS only. Promotional offer that will be applied to the product.
   /// Retrieve this offer using [Purchases.getPromotionalOffer].
+  ///
+  /// [customerEmail] Web only. The email of the user. If undefined, RevenueCat
+  /// will ask the customer for their email.
+  ///
   const PurchaseParams.storeProduct({
     required StoreProduct storeProduct,
     GoogleProductChangeInfo? googleProductChangeInfo,
     bool? googleIsPersonalizedPrice,
     PromotionalOffer? promotionalOffer,
+    String? customerEmail,
   }) : this._(
         null,
         storeProduct,
@@ -80,6 +93,7 @@ class PurchaseParams {
         googleProductChangeInfo,
         googleIsPersonalizedPrice,
         promotionalOffer,
+        customerEmail,
       );
 
   /// Creates purchase parameters for a subscription option. Google Play-only.
@@ -95,10 +109,15 @@ class PurchaseParams {
   /// customize for you" in the purchase dialog when true.
   /// See https://developer.android.com/google/play/billing/integrate#personalized-price
   /// for more info.
+  ///
+  /// [customerEmail] Web only. The email of the user. If undefined, RevenueCat
+  /// will ask the customer for their email.
+  ///
   const PurchaseParams.subscriptionOption({
     required SubscriptionOption subscriptionOption,
     GoogleProductChangeInfo? googleProductChangeInfo,
     bool? googleIsPersonalizedPrice,
+    String? customerEmail,
   }) : this._(
         null,
         null,
@@ -106,5 +125,6 @@ class PurchaseParams {
         googleProductChangeInfo,
         googleIsPersonalizedPrice,
         null,
+        customerEmail,
       );
 }

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -570,6 +570,7 @@ class Purchases {
     final googleIsPersonalizedPrice = purchaseParams.googleIsPersonalizedPrice;
     final prorationMode = googleProductChangeInfo?.prorationMode?.value;
     final signedDiscountTimestamp = purchaseParams.promotionalOffer?.timestamp.toString();
+    final customerEmail = purchaseParams.customerEmail;
     final presentedOfferingContext = purchaseParams.package?.presentedOfferingContext ??
         purchaseParams.product?.presentedOfferingContext ??
         purchaseParams.subscriptionOption?.presentedOfferingContext;
@@ -580,6 +581,7 @@ class Purchases {
       'googleIsPersonalizedPrice': googleIsPersonalizedPrice,
       'signedDiscountTimestamp': signedDiscountTimestamp,
       'presentedOfferingContext': presentedOfferingContextJson,
+      'customerEmail': customerEmail,
     };
     if (package != null) {
       return await _invokeReturningPurchaseResult('purchasePackage', {

--- a/lib/web/purchases_flutter_web.dart
+++ b/lib/web/purchases_flutter_web.dart
@@ -242,6 +242,7 @@ class PurchasesFlutterPlugin {
     final options = {
       'packageIdentifier': packageIdentifier,
       'presentedOfferingContext': arguments['presentedOfferingContext'],
+      'customerEmail': arguments['customerEmail'],
     };
     return await _getMapFromInstanceMethod('purchasePackage', [options]);
   }


### PR DESCRIPTION
This uses the PurchaseParams class added in #1461 to add a new parameter used on web only that allows us to skip the email step when purchasing on web