### PR TITLE
Fix crash when calling new purchase w/ purchase params function

### DIFF
--- a/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
+++ b/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
@@ -344,8 +344,8 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
 presentedOfferingContext:(NSDictionary *)presentedOfferingContext
 signedDiscountTimestamp:(nullable NSString *)discountTimestamp
                  result:(FlutterResult)result {
-    [RCCommonFunctionality purchasePackage:packageIdentifier.mappingNSNullToNil
-                  presentedOfferingContext:presentedOfferingContext.mappingNSNullToNil
+    [RCCommonFunctionality purchasePackage:packageIdentifier
+                  presentedOfferingContext:presentedOfferingContext
                    signedDiscountTimestamp:discountTimestamp.mappingNSNullToNil
                            completionBlock:[self getResponseCompletionBlock:result]];
 }

--- a/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
+++ b/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
@@ -344,7 +344,6 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
 presentedOfferingContext:(NSDictionary *)presentedOfferingContext
 signedDiscountTimestamp:(nullable NSString *)discountTimestamp
                  result:(FlutterResult)result {
-
     [RCCommonFunctionality purchasePackage:packageIdentifier
                   presentedOfferingContext:presentedOfferingContext
                    signedDiscountTimestamp:discountTimestamp.mappingNSNullToNil

--- a/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
+++ b/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
@@ -345,7 +345,7 @@ presentedOfferingContext:(NSDictionary *)presentedOfferingContext
 signedDiscountTimestamp:(nullable NSString *)discountTimestamp
                  result:(FlutterResult)result {
     [RCCommonFunctionality purchasePackage:packageIdentifier
-                  presentedOfferingContext:presentedOfferingContext
+                  presentedOfferingContext:presentedOfferingContext.mappingNSNullToNil
                    signedDiscountTimestamp:discountTimestamp.mappingNSNullToNil
                            completionBlock:[self getResponseCompletionBlock:result]];
 }

--- a/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
+++ b/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
@@ -336,7 +336,7 @@ automaticDeviceIdentifierCollectionEnabled:(BOOL)automaticDeviceIdentifierCollec
 signedDiscountTimestamp:(nullable NSString *)discountTimestamp
                  result:(FlutterResult)result {
     [RCCommonFunctionality purchaseProduct:productIdentifier
-                   signedDiscountTimestamp:discountTimestamp
+                   signedDiscountTimestamp:discountTimestamp.mappingNSNullToNil
                            completionBlock:[self getResponseCompletionBlock:result]];
 }
 
@@ -344,7 +344,7 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
 presentedOfferingContext:(NSDictionary *)presentedOfferingContext
 signedDiscountTimestamp:(nullable NSString *)discountTimestamp
                  result:(FlutterResult)result {
-    [RCCommonFunctionality purchasePackage:packageIdentifier
+    [RCCommonFunctionality purchasePackage:packageIdentifier.mappingNSNullToNil
                   presentedOfferingContext:presentedOfferingContext.mappingNSNullToNil
                    signedDiscountTimestamp:discountTimestamp.mappingNSNullToNil
                            completionBlock:[self getResponseCompletionBlock:result]];

--- a/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
+++ b/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
@@ -338,9 +338,14 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
 presentedOfferingContext:(NSDictionary *)presentedOfferingContext
 signedDiscountTimestamp:(nullable NSString *)discountTimestamp
                  result:(FlutterResult)result {
+
+    // We can't send NSNull to the RCCommonFunctionality since it won't make it through the Objective-C/Swift bridging
+    // logic. Instead, this passes nil to RCCommonFunctionality if the value is NSNull.
+    NSString *sanitizedDiscountTimestamp = [discountTimestamp isKindOfClass:[NSNull class]] ? nil : discountTimestamp;
+
     [RCCommonFunctionality purchasePackage:packageIdentifier
                   presentedOfferingContext:presentedOfferingContext
-                   signedDiscountTimestamp:discountTimestamp
+                   signedDiscountTimestamp:sanitizedDiscountTimestamp
                            completionBlock:[self getResponseCompletionBlock:result]];
 }
 


### PR DESCRIPTION
Addresses https://github.com/RevenueCat/purchases-flutter/issues/1471 by passing `nil` to `RCCommonFunctionality.purchase` for `signedDiscountTimestamp` instead of `NSNull`, which appears to be causing issues when bridging to Swift. 

It accomplishes this by porting over the `mappingNSNullToNil` function from the React Native SDK.

### Explanation
The crash occurs between when `PurchasesFlutterPlugin.m` calls `RCCommonFunctionality`'s purchase function, so the issue appears to be with the Objective-C/Swift bridging. After narrowing it down, we found that passing `nil` instead of `NSNull` for the `signedDiscountTimestamp` parameter resolved the issue.

From https://www.andyibanez.com/posts/nil-null-mess-objective-c-and-swift/ :
> In Objective-C, you can send messages to nil, but when you are sending messages to a real object, the object needs to implement the method you want to call - in other words, you want the object to respond to a selector. If you send a message to an object and the object does not respond to it, you will crash with a message similar to “unrecognized selector sent to instance 0xb4df00d”.

The stacktrace for our crash shows: `reason: '-[NSNull length]: unrecognized selector sent to instance`, so it appears that for some reason, the objc/swift bridging appears to be attempting to call length() on NSNull. NSNull is a Foundation object, which inherits from NSObject, but doesn’t have a length() function, hence the crash.

Since messages can be sent to `nil`, the bridging code can call nil.length() and the app can continue executing without an issue, explaining why this PR works.

### Next Steps
While this PR addresses this issue in this one particular spot, we should audit other Obj-C/Swift boundaries throughout the hybrid SDKs to ensure that this issue isn't present anywhere else.
