### PR TITLE
Add support for customer center view without `presentCustomerCenter` helper

### DIFF
--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/PurchasesUiFlutterPlugin.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/PurchasesUiFlutterPlugin.kt
@@ -10,6 +10,7 @@ import com.revenuecat.purchases.hybridcommon.ui.PaywallSource
 import com.revenuecat.purchases.hybridcommon.ui.PresentPaywallOptions
 import com.revenuecat.purchases.hybridcommon.ui.presentPaywallFromFragment
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.ShowCustomerCenter
+import com.revenuecat.purchases_ui_flutter.views.CustomerCenterViewFactory
 import com.revenuecat.purchases_ui_flutter.views.PaywallFooterViewFactory
 import com.revenuecat.purchases_ui_flutter.views.PaywallViewFactory
 import io.flutter.embedding.android.FlutterFragmentActivity
@@ -44,6 +45,10 @@ class PurchasesUiFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware,
         flutterPluginBinding.platformViewRegistry.registerViewFactory(
             "com.revenuecat.purchasesui/PaywallFooterView",
             PaywallFooterViewFactory(flutterPluginBinding.binaryMessenger)
+        )
+        flutterPluginBinding.platformViewRegistry.registerViewFactory(
+            "com.revenuecat.purchasesui/CustomerCenterView",
+            CustomerCenterViewFactory(flutterPluginBinding.binaryMessenger)
         )
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "purchases_ui_flutter")
         channel.setMethodCallHandler(this)

--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/CustomerCenterView.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/CustomerCenterView.kt
@@ -1,0 +1,47 @@
+package com.revenuecat.purchases_ui_flutter.views
+
+import android.content.Context
+import android.view.View
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler
+import io.flutter.plugin.platform.PlatformView
+import com.revenuecat.purchases.ui.revenuecatui.views.CustomerCenterView as NativeCustomerCenterView
+
+internal class CustomerCenterView(
+    context: Context,
+    id: Int,
+    messenger: BinaryMessenger,
+    creationParams: Map<String?, Any?>,
+) : PlatformView, MethodCallHandler {
+
+    private val methodChannel: MethodChannel
+    private val nativeCustomerCenterView: NativeCustomerCenterView
+
+    init {
+        methodChannel = MethodChannel(messenger, "com.revenuecat.purchasesui/CustomerCenterView/$id")
+        methodChannel.setMethodCallHandler(this)
+
+        nativeCustomerCenterView = NativeCustomerCenterView(context) {
+            methodChannel.invokeMethod("onDismiss", null)
+        }
+        nativeCustomerCenterView.applyCreationParams(creationParams)
+    }
+
+    override fun getView(): View = nativeCustomerCenterView
+
+    override fun dispose() {
+        methodChannel.setMethodCallHandler(null)
+    }
+
+    override fun onMethodCall(methodCall: MethodCall, result: MethodChannel.Result) {
+        result.notImplemented()
+    }
+}
+
+@Suppress("UNUSED_PARAMETER")
+private fun NativeCustomerCenterView.applyCreationParams(creationParams: Map<String?, Any?>) {
+    // Currently there are no Android specific configuration options.
+    // This extension is reserved for future parameters to keep init tidy.
+}

--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/CustomerCenterViewFactory.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/CustomerCenterViewFactory.kt
@@ -1,0 +1,18 @@
+package com.revenuecat.purchases_ui_flutter.views
+
+import android.content.Context
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.StandardMessageCodec
+import io.flutter.plugin.platform.PlatformView
+import io.flutter.plugin.platform.PlatformViewFactory
+
+internal class CustomerCenterViewFactory(
+    private val messenger: BinaryMessenger,
+) : PlatformViewFactory(StandardMessageCodec.INSTANCE) {
+
+    override fun create(context: Context, viewId: Int, args: Any?): PlatformView {
+        @Suppress("UNCHECKED_CAST")
+        val creationParams = args as? Map<String?, Any?>? ?: emptyMap()
+        return CustomerCenterView(context, viewId, messenger, creationParams)
+    }
+}

--- a/purchases_ui_flutter/ios/purchases_ui_flutter/Sources/purchases_ui_flutter/PurchasesUiCustomerCenterView.swift
+++ b/purchases_ui_flutter/ios/purchases_ui_flutter/Sources/purchases_ui_flutter/PurchasesUiCustomerCenterView.swift
@@ -1,0 +1,171 @@
+import Flutter
+import UIKit
+import PurchasesHybridCommonUI
+@_spi(Internal) import RevenueCatUI
+import RevenueCat
+
+final class PurchasesUiCustomerCenterViewFactory: NSObject, FlutterPlatformViewFactory {
+    private let messenger: FlutterBinaryMessenger
+
+    init(messenger: FlutterBinaryMessenger) {
+        self.messenger = messenger
+        super.init()
+    }
+
+    func create(
+        withFrame frame: CGRect,
+        viewIdentifier viewId: Int64,
+        arguments args: Any?
+    ) -> FlutterPlatformView {
+        if #available(iOS 15.0, *) {
+            return PurchasesUiCustomerCenterView(
+                frame: frame,
+                viewIdentifier: viewId,
+                arguments: args,
+                binaryMessenger: messenger
+            )
+        } else {
+            print("Error: attempted to present customer center on unsupported iOS version.")
+            return UnsupportedPlatformView()
+        }
+    }
+
+    func createArgsCodec() -> FlutterMessageCodec & NSObjectProtocol {
+        FlutterStandardMessageCodec.sharedInstance()
+    }
+}
+
+@available(iOS 15.0, *)
+final class PurchasesUiCustomerCenterView: NSObject, FlutterPlatformView {
+    private let methodChannel: FlutterMethodChannel
+    private let viewController: CustomerCenterUIViewController
+    private let wrapperView: ViewControllerWrapper<CustomerCenterUIViewController>
+
+    init(
+        frame: CGRect,
+        viewIdentifier viewId: Int64,
+        arguments args: Any?,
+        binaryMessenger messenger: FlutterBinaryMessenger
+    ) {
+        methodChannel = FlutterMethodChannel(
+            name: "com.revenuecat.purchasesui/CustomerCenterView/\(viewId)",
+            binaryMessenger: messenger
+        )
+
+        viewController = CustomerCenterUIViewController()
+        wrapperView = ViewControllerWrapper(viewController: viewController)
+
+        super.init()
+
+        setupMethodChannel()
+        configureViewController(arguments: args)
+    }
+
+    func view() -> UIView {
+        wrapperView
+    }
+
+    private func setupMethodChannel() {
+        methodChannel.setMethodCallHandler { _, result in
+            result(FlutterMethodNotImplemented)
+        }
+    }
+
+    private func configureViewController(arguments args: Any?) {
+        viewController.delegate = self
+
+        if let arguments = args as? [String: Any],
+           let shouldShowCloseButton = arguments["shouldShowCloseButton"] as? Bool {
+            viewController.shouldShowCloseButton = shouldShowCloseButton
+        }
+
+        viewController.onCloseHandler = { [weak self] in
+            self?.methodChannel.invokeMethod("onDismiss", arguments: nil)
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+extension PurchasesUiCustomerCenterView: CustomerCenterViewControllerDelegateWrapper {
+    func customerCenterViewControllerWasDismissed(_ controller: CustomerCenterUIViewController) {
+        methodChannel.invokeMethod("onDismiss", arguments: nil)
+    }
+
+    func customerCenterViewControllerDidStartRestore(_ controller: CustomerCenterUIViewController) {
+        methodChannel.invokeMethod("onRestoreStarted", arguments: nil)
+    }
+
+    func customerCenterViewController(
+        _ controller: CustomerCenterUIViewController,
+        didFinishRestoringWith customerInfoDictionary: [String : Any]
+    ) {
+        methodChannel.invokeMethod("onRestoreCompleted", arguments: customerInfoDictionary)
+    }
+
+    func customerCenterViewController(
+        _ controller: CustomerCenterUIViewController,
+        didFailRestoringWith errorDictionary: [String : Any]
+    ) {
+        methodChannel.invokeMethod("onRestoreFailed", arguments: errorDictionary)
+    }
+
+    func customerCenterViewControllerDidShowManageSubscriptions(_ controller: CustomerCenterUIViewController) {
+        methodChannel.invokeMethod("onShowingManageSubscriptions", arguments: nil)
+    }
+
+    func customerCenterViewController(
+        _ controller: CustomerCenterUIViewController,
+        didStartRefundRequestForProductWithID productID: String
+    ) {
+        methodChannel.invokeMethod("onRefundRequestStarted", arguments: productID)
+    }
+
+    func customerCenterViewController(
+        _ controller: CustomerCenterUIViewController,
+        didCompleteRefundRequestForProductWithID productId: String,
+        withStatus status: String
+    ) {
+        methodChannel.invokeMethod(
+            "onRefundRequestCompleted",
+            arguments: [
+                "productId": productId,
+                "status": status
+            ]
+        )
+    }
+
+    func customerCenterViewController(
+        _ controller: CustomerCenterUIViewController,
+        didSelectCustomerCenterManagementOption optionID: String,
+        withURL url: String?
+    ) {
+        methodChannel.invokeMethod(
+            "onManagementOptionSelected",
+            arguments: [
+                "optionId": optionID,
+                "url": url as Any
+            ]
+        )
+    }
+
+    func customerCenterViewController(
+        _ controller: CustomerCenterUIViewController,
+        didCompleteFeedbackSurveyWithOptionID optionID: String
+    ) {
+        methodChannel.invokeMethod("onFeedbackSurveyCompleted", arguments: optionID)
+    }
+
+    func customerCenterViewController(
+        _ controller: CustomerCenterUIViewController,
+        didSelectCustomAction actionID: String,
+        withPurchaseIdentifier purchaseIdentifier: String?
+    ) {
+        methodChannel.invokeMethod(
+            "onCustomActionSelected",
+            arguments: [
+                "actionId": actionID,
+                "purchaseIdentifier": purchaseIdentifier as Any
+            ]
+        )
+    }
+}

--- a/purchases_ui_flutter/ios/purchases_ui_flutter/Sources/purchases_ui_flutter/PurchasesUiFlutterPlugin.swift
+++ b/purchases_ui_flutter/ios/purchases_ui_flutter/Sources/purchases_ui_flutter/PurchasesUiFlutterPlugin.swift
@@ -19,9 +19,11 @@ public class PurchasesUiFlutterPlugin: NSObject, FlutterPlugin {
         let messenger = registrar.messenger()
         let factory = PurchasesUiPaywallViewFactory(messenger: messenger)
         let footerFactory = PurchasesUiPaywallFooterViewFactory(messenger: messenger)
+        let customerCenterFactory = PurchasesUiCustomerCenterViewFactory(messenger: messenger)
 
         registrar.register(factory, withId: "com.revenuecat.purchasesui/PaywallView")
         registrar.register(footerFactory, withId: "com.revenuecat.purchasesui/PaywallFooterView")
+        registrar.register(customerCenterFactory, withId: "com.revenuecat.purchasesui/CustomerCenterView")
 
 #endif
         let channel = FlutterMethodChannel(name: "purchases_ui_flutter", binaryMessenger: messenger)

--- a/purchases_ui_flutter/lib/purchases_ui_flutter.dart
+++ b/purchases_ui_flutter/lib/purchases_ui_flutter.dart
@@ -6,6 +6,7 @@ import 'paywall_result.dart';
 export 'paywall_result.dart';
 export 'views/paywall_footer_view.dart';
 export 'views/paywall_view.dart';
+export 'views/customer_center_view.dart';
 
 class RevenueCatUI {
   static const _methodChannel = MethodChannel('purchases_ui_flutter');

--- a/purchases_ui_flutter/lib/views/customer_center_view.dart
+++ b/purchases_ui_flutter/lib/views/customer_center_view.dart
@@ -1,0 +1,107 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+
+import 'customer_center_view_method_handler.dart';
+
+class CustomerCenterView extends StatelessWidget {
+  const CustomerCenterView({
+    super.key,
+    this.shouldShowCloseButton = true,
+    this.onDismiss,
+    this.onRestoreStarted,
+    this.onRestoreCompleted,
+    this.onRestoreFailed,
+    this.onShowingManageSubscriptions,
+    this.onRefundRequestStarted,
+    this.onRefundRequestCompleted,
+    this.onFeedbackSurveyCompleted,
+    this.onManagementOptionSelected,
+    this.onCustomActionSelected,
+  });
+
+  final bool shouldShowCloseButton;
+
+  final CustomerCenterDismissCallback? onDismiss;
+  final CustomerCenterRestoreStartedCallback? onRestoreStarted;
+  final CustomerCenterRestoreCompletedCallback? onRestoreCompleted;
+  final CustomerCenterRestoreFailedCallback? onRestoreFailed;
+  final CustomerCenterManageSubscriptionsCallback? onShowingManageSubscriptions;
+  final CustomerCenterRefundRequestStartedCallback? onRefundRequestStarted;
+  final CustomerCenterRefundRequestCompletedCallback? onRefundRequestCompleted;
+  final CustomerCenterFeedbackSurveyCompletedCallback? onFeedbackSurveyCompleted;
+  final CustomerCenterManagementOptionSelectedCallback? onManagementOptionSelected;
+  final CustomerCenterCustomActionSelectedCallback? onCustomActionSelected;
+
+  static const String _viewType = 'com.revenuecat.purchasesui/CustomerCenterView';
+
+  @override
+  Widget build(BuildContext context) {
+    final creationParams = <String, dynamic>{
+      'shouldShowCloseButton': shouldShowCloseButton,
+    };
+
+    return Platform.isAndroid
+        ? _buildAndroidPlatformViewLink(creationParams)
+        : _buildUiKitView(creationParams);
+  }
+
+  UiKitView _buildUiKitView(Map<String, dynamic> creationParams) => UiKitView(
+        viewType: _viewType,
+        layoutDirection: TextDirection.ltr,
+        creationParams: creationParams,
+        creationParamsCodec: const StandardMessageCodec(),
+        onPlatformViewCreated: _buildListenerChannel,
+      );
+
+  PlatformViewLink _buildAndroidPlatformViewLink(
+    Map<String, dynamic> creationParams,
+  ) =>
+      PlatformViewLink(
+        viewType: _viewType,
+        surfaceFactory: (context, controller) => AndroidViewSurface(
+          controller: controller as AndroidViewController,
+          gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
+          hitTestBehavior: PlatformViewHitTestBehavior.opaque,
+        ),
+        onCreatePlatformView: (params) =>
+            PlatformViewsService.initSurfaceAndroidView(
+          id: params.id,
+          viewType: _viewType,
+          layoutDirection: TextDirection.ltr,
+          creationParams: creationParams,
+          creationParamsCodec: const StandardMessageCodec(),
+          onFocus: () {
+            params.onFocusChanged(true);
+          },
+        )
+              ..addOnPlatformViewCreatedListener(
+                params.onPlatformViewCreated,
+              )
+              ..addOnPlatformViewCreatedListener(
+                _buildListenerChannel,
+              )
+              ..create(),
+      );
+
+  void _buildListenerChannel(int id) {
+    final handler = CustomerCenterViewMethodHandler(
+      onDismiss: onDismiss,
+      onRestoreStarted: onRestoreStarted,
+      onRestoreCompleted: onRestoreCompleted,
+      onRestoreFailed: onRestoreFailed,
+      onShowingManageSubscriptions: onShowingManageSubscriptions,
+      onRefundRequestStarted: onRefundRequestStarted,
+      onRefundRequestCompleted: onRefundRequestCompleted,
+      onFeedbackSurveyCompleted: onFeedbackSurveyCompleted,
+      onManagementOptionSelected: onManagementOptionSelected,
+      onCustomActionSelected: onCustomActionSelected,
+    );
+    MethodChannel('com.revenuecat.purchasesui/CustomerCenterView/$id')
+        .setMethodCallHandler(handler.handleMethodCall);
+  }
+}

--- a/purchases_ui_flutter/lib/views/customer_center_view_method_handler.dart
+++ b/purchases_ui_flutter/lib/views/customer_center_view_method_handler.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/services.dart';
+import 'package:purchases_flutter/models/customer_info_wrapper.dart';
+import 'package:purchases_flutter/models/purchases_error.dart';
+
+typedef CustomerCenterDismissCallback = void Function();
+typedef CustomerCenterRestoreStartedCallback = void Function();
+typedef CustomerCenterRestoreCompletedCallback = void Function(CustomerInfo customerInfo);
+typedef CustomerCenterRestoreFailedCallback = void Function(PurchasesError error);
+typedef CustomerCenterManageSubscriptionsCallback = void Function();
+typedef CustomerCenterRefundRequestStartedCallback = void Function(String productIdentifier);
+typedef CustomerCenterRefundRequestCompletedCallback = void Function(String productIdentifier, String status);
+typedef CustomerCenterFeedbackSurveyCompletedCallback = void Function(String optionIdentifier);
+typedef CustomerCenterManagementOptionSelectedCallback = void Function(String optionIdentifier, String? url);
+typedef CustomerCenterCustomActionSelectedCallback = void Function(String actionIdentifier, String? purchaseIdentifier);
+
+class CustomerCenterViewMethodHandler {
+  final CustomerCenterDismissCallback? onDismiss;
+  final CustomerCenterRestoreStartedCallback? onRestoreStarted;
+  final CustomerCenterRestoreCompletedCallback? onRestoreCompleted;
+  final CustomerCenterRestoreFailedCallback? onRestoreFailed;
+  final CustomerCenterManageSubscriptionsCallback? onShowingManageSubscriptions;
+  final CustomerCenterRefundRequestStartedCallback? onRefundRequestStarted;
+  final CustomerCenterRefundRequestCompletedCallback? onRefundRequestCompleted;
+  final CustomerCenterFeedbackSurveyCompletedCallback? onFeedbackSurveyCompleted;
+  final CustomerCenterManagementOptionSelectedCallback? onManagementOptionSelected;
+  final CustomerCenterCustomActionSelectedCallback? onCustomActionSelected;
+
+  const CustomerCenterViewMethodHandler({
+    this.onDismiss,
+    this.onRestoreStarted,
+    this.onRestoreCompleted,
+    this.onRestoreFailed,
+    this.onShowingManageSubscriptions,
+    this.onRefundRequestStarted,
+    this.onRefundRequestCompleted,
+    this.onFeedbackSurveyCompleted,
+    this.onManagementOptionSelected,
+    this.onCustomActionSelected,
+  });
+
+  Future<void> handleMethodCall(MethodCall call) async {
+    switch (call.method) {
+      case 'onDismiss':
+        onDismiss?.call();
+        break;
+      case 'onRestoreStarted':
+        onRestoreStarted?.call();
+        break;
+      case 'onRestoreCompleted':
+        _handleRestoreCompleted(call.arguments);
+        break;
+      case 'onRestoreFailed':
+        _handleRestoreFailed(call.arguments);
+        break;
+      case 'onShowingManageSubscriptions':
+        onShowingManageSubscriptions?.call();
+        break;
+      case 'onRefundRequestStarted':
+        _handleRefundRequestStarted(call.arguments);
+        break;
+      case 'onRefundRequestCompleted':
+        _handleRefundRequestCompleted(call.arguments);
+        break;
+      case 'onFeedbackSurveyCompleted':
+        _handleFeedbackSurveyCompleted(call.arguments);
+        break;
+      case 'onManagementOptionSelected':
+        _handleManagementOptionSelected(call.arguments);
+        break;
+      case 'onCustomActionSelected':
+        _handleCustomActionSelected(call.arguments);
+        break;
+      default:
+        break;
+    }
+  }
+
+  void _handleRestoreCompleted(dynamic arguments) {
+    if (onRestoreCompleted == null) {
+      return;
+    }
+    if (arguments is Map) {
+      final customerInfo = CustomerInfo.fromJson(Map<String, dynamic>.from(arguments));
+      onRestoreCompleted?.call(customerInfo);
+    }
+  }
+
+  void _handleRestoreFailed(dynamic arguments) {
+    if (onRestoreFailed == null) {
+      return;
+    }
+    if (arguments is Map) {
+      final error = PurchasesError.fromJson(Map<String, dynamic>.from(arguments));
+      onRestoreFailed?.call(error);
+    }
+  }
+
+  void _handleRefundRequestStarted(dynamic arguments) {
+    if (onRefundRequestStarted == null) {
+      return;
+    }
+    if (arguments is String) {
+      onRefundRequestStarted?.call(arguments);
+    }
+  }
+
+  void _handleRefundRequestCompleted(dynamic arguments) {
+    if (onRefundRequestCompleted == null) {
+      return;
+    }
+    if (arguments is Map) {
+      final data = Map<String, dynamic>.from(arguments);
+      final productIdentifier = data['productId'] as String?;
+      final status = data['status'] as String?;
+      if (productIdentifier != null && status != null) {
+        onRefundRequestCompleted?.call(productIdentifier, status);
+      }
+    }
+  }
+
+  void _handleFeedbackSurveyCompleted(dynamic arguments) {
+    if (onFeedbackSurveyCompleted == null) {
+      return;
+    }
+    if (arguments is String) {
+      onFeedbackSurveyCompleted?.call(arguments);
+    }
+  }
+
+  void _handleManagementOptionSelected(dynamic arguments) {
+    if (onManagementOptionSelected == null) {
+      return;
+    }
+    if (arguments is Map) {
+      final data = Map<String, dynamic>.from(arguments);
+      final optionIdentifier = data['optionId'] as String?;
+      final url = data['url'] as String?;
+      if (optionIdentifier != null) {
+        onManagementOptionSelected?.call(optionIdentifier, url);
+      }
+    }
+  }
+
+  void _handleCustomActionSelected(dynamic arguments) {
+    if (onCustomActionSelected == null) {
+      return;
+    }
+    if (arguments is Map) {
+      final data = Map<String, dynamic>.from(arguments);
+      final actionId = data['actionId'] as String?;
+      final purchaseIdentifier = data['purchaseIdentifier'] as String?;
+      if (actionId != null) {
+        onCustomActionSelected?.call(actionId, purchaseIdentifier);
+      }
+    }
+  }
+}

--- a/revenuecat_examples/purchase_tester/lib/main.dart
+++ b/revenuecat_examples/purchase_tester/lib/main.dart
@@ -17,14 +17,14 @@ void main() async {
   } else if (Platform.isIOS || Platform.isMacOS) {
     StoreConfig(
       store: Store.appStore,
-      apiKey: appleApiKey,
+      apiKey: "appl_KFpRDwauDyfIGIETKyVymslMcjX",
     );
   } else if (Platform.isAndroid) {
     // Run the app passing --dart-define=AMAZON=true
     const useAmazon = bool.fromEnvironment("amazon");
     StoreConfig(
       store: useAmazon ? Store.amazon : Store.playStore,
-      apiKey: useAmazon ? amazonApiKey : googleApiKey,
+      apiKey: useAmazon ? amazonApiKey : "goog_cRtaFpfwfcQYPXkIEqFUkVszUfN",
     );
   }
   WidgetsFlutterBinding.ensureInitialized();

--- a/revenuecat_examples/purchase_tester/lib/src/customer_center_view_screen.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/customer_center_view_screen.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:purchases_ui_flutter/purchases_ui_flutter.dart';
+
+class CustomerCenterViewModalScreen extends StatelessWidget {
+  const CustomerCenterViewModalScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        top: false,
+        child: MediaQuery.removePadding(
+          context: context,
+          removeTop: true,
+          child: CustomerCenterView(
+            onDismiss: () {
+              if (Navigator.of(context).canPop()) {
+                Navigator.of(context).pop();
+              }
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/revenuecat_examples/purchase_tester/lib/src/customer_center_view_screen.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/customer_center_view_screen.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:purchases_ui_flutter/purchases_ui_flutter.dart';
 
@@ -14,9 +15,37 @@ class CustomerCenterViewModalScreen extends StatelessWidget {
           removeTop: true,
           child: CustomerCenterView(
             onDismiss: () {
+              debugPrint('[CustomerCenter] Dismissed');
               if (Navigator.of(context).canPop()) {
                 Navigator.of(context).pop();
               }
+            },
+            onRestoreStarted: () {
+              debugPrint('[CustomerCenter] Restore started');
+            },
+            onRestoreCompleted: (customerInfo) {
+              debugPrint('[CustomerCenter] Restore completed: $customerInfo');
+            },
+            onRestoreFailed: (error) {
+              debugPrint('[CustomerCenter] Restore failed: $error');
+            },
+            onShowingManageSubscriptions: () {
+              debugPrint('[CustomerCenter] Showing manage subscriptions');
+            },
+            onRefundRequestStarted: (productIdentifier) {
+              debugPrint('[CustomerCenter] Refund request started for product: $productIdentifier');
+            },
+            onRefundRequestCompleted: (productIdentifier, status) {
+              debugPrint('[CustomerCenter] Refund request completed for product $productIdentifier with status $status');
+            },
+            onFeedbackSurveyCompleted: (optionIdentifier) {
+              debugPrint('[CustomerCenter] Feedback survey completed with option: $optionIdentifier');
+            },
+            onManagementOptionSelected: (optionIdentifier, url) {
+              debugPrint('[CustomerCenter] Management option selected: $optionIdentifier (url: ${url ?? 'none'})');
+            },
+            onCustomActionSelected: (actionIdentifier, purchaseIdentifier) {
+              debugPrint('[CustomerCenter] Custom action selected: $actionIdentifier (purchase: ${purchaseIdentifier ?? 'none'})');
             },
           ),
         ),

--- a/revenuecat_examples/purchase_tester/lib/src/upsell.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/upsell.dart
@@ -9,6 +9,7 @@ import 'package:purchases_ui_flutter/purchases_ui_flutter.dart';
 
 import 'cats.dart';
 import 'constant.dart';
+import 'customer_center_view_screen.dart';
 import 'initial.dart';
 import 'paywall.dart';
 import 'winback_testing_screen.dart';
@@ -134,7 +135,7 @@ class _UpsellScreenState extends State<UpsellScreen> {
                       Navigator.push(
                           context,
                           MaterialPageRoute(
-                            builder: (context) => WinbackTestingScreen(),
+                            builder: (context) => const WinbackTestingScreen(),
                           ));
                     },
                     child: const Text("Go to Win-Back Offer Testing Screen"),
@@ -170,6 +171,18 @@ class _UpsellScreenState extends State<UpsellScreen> {
                 padding: const EdgeInsets.all(8.0),
                 child: Column(children: [
                   const Text("Customer Center"),
+                  ElevatedButton(
+                    onPressed: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => const CustomerCenterViewModalScreen(),
+                        ),
+                      );
+                    },
+                    child: const Text("Open Customer Center (Close Button)"),
+                  ),
+                  const SizedBox(height: 12),
                   ElevatedButton(
                     onPressed: () async {
                       await RevenueCatUI.presentCustomerCenter();


### PR DESCRIPTION
## Motivation

This PR adds a variant to address https://github.com/RevenueCat/purchases-flutter/issues/1297

Following existing patterns, this PR adds the necessary code to display `CustomerCenterView` without using the helper.

- Register the Customer Center platform view on both iOS and Android
- Adjust the purchase tester sample

| Header | Header |
|--------|--------|
| <img width="697" height="1056" alt="Screenshot 2025-09-22 at 12 44 04" src="https://github.com/user-attachments/assets/696e6d20-f6d8-4dc6-9841-80e91e7e23cb" /> | <img width="544" height="1036" alt="Screenshot 2025-09-22 at 12 44 16" src="https://github.com/user-attachments/assets/ad7470a6-80ca-4b56-82e0-c4aeb8fa715d" /> |
