### PR TITLE
[V8] Prepare for next release

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ version '8.10.6'
 
 buildscript {
     ext.kotlin_version = '1.8.22'
-    ext.common_version = '14.3.0'
+    ext.common_version = '14.2.0'
     repositories {
         google()
         mavenCentral()

--- a/ios/purchases_flutter.podspec
+++ b/ios/purchases_flutter.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'PurchasesHybridCommon', '14.3.0'
+  s.dependency 'PurchasesHybridCommon', '14.2.0'
   s.ios.deployment_target = '13.0'
   s.swift_version         = '5.0'
 

--- a/macos/purchases_flutter.podspec
+++ b/macos/purchases_flutter.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files     = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'FlutterMacOS'
-  s.dependency 'PurchasesHybridCommon', '14.3.0'
+  s.dependency 'PurchasesHybridCommon', '14.2.0'
   s.platform = :osx, '10.12'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.0'

--- a/purchases_ui_flutter/android/build.gradle
+++ b/purchases_ui_flutter/android/build.gradle
@@ -3,7 +3,7 @@ version '8.10.6'
 
 buildscript {
     ext.kotlin_version = '1.9.20'
-    ext.common_version = '14.3.0'
+    ext.common_version = '14.2.0'
     repositories {
         google()
         mavenCentral()

--- a/purchases_ui_flutter/ios/purchases_ui_flutter.podspec
+++ b/purchases_ui_flutter/ios/purchases_ui_flutter.podspec
@@ -15,7 +15,7 @@ Flutter plugin that integrates RevenueCat Paywalls
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'PurchasesHybridCommonUI', '14.3.0'
+  s.dependency 'PurchasesHybridCommonUI', '14.2.0'
   s.platform = :ios, '11.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/purchases_ui_flutter/macos/purchases_ui_flutter.podspec
+++ b/purchases_ui_flutter/macos/purchases_ui_flutter.podspec
@@ -16,7 +16,7 @@ Flutter plugin that integrates RevenueCat Paywalls
   s.source           = { :path => '.' }
   s.source_files     = 'Classes/**/*'
   s.dependency 'FlutterMacOS'
-  s.dependency 'PurchasesHybridCommonUI', '14.3.0'
+  s.dependency 'PurchasesHybridCommonUI', '14.2.0'
 
   s.platform = :osx, '10.11'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }


### PR DESCRIPTION
This PR makes the changes needed for the next release of v8.

* Bump [fastlane-plugin-revenuecat_internal](https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal) from `05ef095 ` to `1593f78`. See full diff in <a href="https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal/compare/05ef0952ecb3b92398a0185a3f74019abd0c1d95...1593f78d0b9b24b48238337666183e3ba82f848e">compare view</a>.
* Pass current version in automatic bump.
* [CI] `bump` pipeline action won't trigger `deploy` workflow
* Fix dependencies declaration in Purchase Tester to fix failing CI jobs (iOS & macOS)