### PR TITLE
Update Xcode versions to avoid CircleCI deprecation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -315,7 +315,7 @@ jobs:
     description: "Run integration tests for Flutter"
     resource_class: macos.m1.medium.gen1
     macos:
-      xcode: 15.2
+      xcode: 15.4
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
@@ -339,7 +339,7 @@ jobs:
     description: "Run integration tests for Flutter"
     resource_class: macos.m1.medium.gen1
     macos:
-      xcode: 15.2
+      xcode: 15.4
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
@@ -361,7 +361,7 @@ jobs:
     description: "Run integration tests for Flutter"
     resource_class: macos.m1.medium.gen1
     macos:
-      xcode: 15.2
+      xcode: 15.4
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
@@ -384,7 +384,7 @@ jobs:
     description: "Run integration tests for Flutter"
     resource_class: macos.m1.medium.gen1
     macos:
-      xcode: 15.2
+      xcode: 15.4
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout


### PR DESCRIPTION
## Summary
- Update ios-integration-test-cocoapods: Xcode 15.2 → 15.4
- Update macos-integration-test-cocoapods: Xcode 15.2 → 15.4
- Update ios-integration-test-spm: Xcode 15.2 → 15.4
- Update macos-integration-test-spm: Xcode 15.2 → 15.4

## Details
These changes address the CircleCI deprecation of EoL Xcode versions (13.4.1, 15.1.0, 15.2.0, 15.3.0, 16.0.0, 16.1.0) announced at https://circleci.com/changelog/deprecation-of-eol-xcode-versions/

The updated versions stay within the same major version where possible and use iOS simulator versions that are available in the respective Xcode VM images according to https://circleci.com/docs/guides/test/testing-ios/#supported-xcode-versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)