### PR TITLE
Fix version of PHC in Swift Package manifest for mac

### DIFF
--- a/macos/purchases_flutter/Package.swift
+++ b/macos/purchases_flutter/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "purchases-flutter", targets: ["purchases_flutter"])
     ],
     dependencies: [
-        .package(url: "https://github.com/RevenueCat/purchases-hybrid-common.git", exact: "17.3.0")
+        .package(url: "https://github.com/RevenueCat/purchases-hybrid-common.git", exact: "17.21.2")
     ],
     targets: [
         .target(


### PR DESCRIPTION
The version of specified in `macos/purchases_flutter/Package.swift` was obsolete.

This PR updates it to match the PHC version everywhere in this repo