### PR TITLE
Updated CircleCI macOS executor from m1 to m4 to avoid deprecation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,17 @@ orbs:
   flutter: circleci/flutter@2.1.0
   ruby: circleci/ruby@2.5.3
 
+executors:
+  macos-executor:
+    parameters:
+      xcode_version:
+        type: string
+        default: "15.4"
+    macos:
+      xcode: << parameters.xcode_version >>
+    resource_class: m4pro.medium
+    shell: /bin/bash --login -o pipefail
+
 parameters:
   action:
     type: enum
@@ -313,10 +324,8 @@ jobs:
 
   ios-integration-test-cocoapods:
     description: "Run integration tests for Flutter"
-    resource_class: macos.m1.medium.gen1
-    macos:
-      xcode: 15.4
-    shell: /bin/bash --login -o pipefail
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - install-correct-cocoapods
@@ -337,10 +346,8 @@ jobs:
 
   macos-integration-test-cocoapods:
     description: "Run integration tests for Flutter"
-    resource_class: macos.m1.medium.gen1
-    macos:
-      xcode: 15.4
-    shell: /bin/bash --login -o pipefail
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - install-correct-cocoapods
@@ -359,10 +366,8 @@ jobs:
 
   ios-integration-test-spm:
     description: "Run integration tests for Flutter"
-    resource_class: macos.m1.medium.gen1
-    macos:
-      xcode: 15.4
-    shell: /bin/bash --login -o pipefail
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - macos/preboot-simulator:
@@ -382,10 +387,8 @@ jobs:
 
   macos-integration-test-spm:
     description: "Run integration tests for Flutter"
-    resource_class: macos.m1.medium.gen1
-    macos:
-      xcode: 15.4
-    shell: /bin/bash --login -o pipefail
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - setup-flutter


### PR DESCRIPTION
The M1 executor will be deprecated soon, so I've updated the config to use the M4 executor instead, and centralized the config for easier updates down the road.