### PR TITLE
Add `diagnosticsEnabled` configuration option

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -122,11 +122,13 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                         .argument("pendingTransactionsForPrepaidPlansEnabled");
                 Boolean automaticDeviceIdentifierCollectionEnabled = call
                         .argument("automaticDeviceIdentifierCollectionEnabled");
+                Boolean diagnosticsEnabled = call.argument("diagnosticsEnabled");
                 String preferredUILocaleOverride = call.argument("preferredUILocaleOverride");
                 setupPurchases(apiKey, appUserId, purchasesAreCompletedBy, useAmazon,
                         shouldShowInAppMessagesAutomatically, verificationMode,
                         pendingTransactionsForPrepaidPlansEnabled,
-                        automaticDeviceIdentifierCollectionEnabled, preferredUILocaleOverride, result);
+                        automaticDeviceIdentifierCollectionEnabled, diagnosticsEnabled,
+                        preferredUILocaleOverride, result);
                 break;
             case "setAllowSharingStoreAccount":
                 Boolean allowSharing = call.argument("allowSharing");
@@ -383,6 +385,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
             @Nullable Boolean shouldShowInAppMessagesAutomatically, @Nullable String verificationMode,
             @Nullable Boolean pendingTransactionsForPrepaidPlansEnabled,
             @Nullable Boolean automaticDeviceIdentifierCollectionEnabled,
+            @Nullable Boolean diagnosticsEnabled,
             @Nullable String preferredUILocaleOverride,
             final Result result) {
         if (this.applicationContext != null) {
@@ -402,7 +405,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                     shouldShowInAppMessagesAutomatically,
                     verificationMode,
                     pendingTransactionsForPrepaidPlansEnabled,
-                    null,
+                    diagnosticsEnabled,
                     automaticDeviceIdentifierCollectionEnabled,
                     preferredUILocaleOverride);
 

--- a/api_tester/lib/api_tests/models/purchase_configuration_api_test.dart
+++ b/api_tester/lib/api_tests/models/purchase_configuration_api_test.dart
@@ -24,6 +24,7 @@ class _PurchaseConfigurationApiTest {
     configuration.store = Store.playStore;
     configuration.storeKitVersion = storeKitVersion;
     configuration.automaticDeviceIdentifierCollectionEnabled = true;
+    configuration.diagnosticsEnabled = true;
 
     // deprecated, but we still need to check that the API hasn't been removed.
     configuration.pendingTransactionsForPrepaidPlansEnabled = true;
@@ -49,5 +50,6 @@ class _PurchaseConfigurationApiTest {
     configuration.store = Store.playStore;
     configuration.storeKitVersion = storeKitVersion;
     configuration.automaticDeviceIdentifierCollectionEnabled = true;
+    configuration.diagnosticsEnabled = true;
   }
 }

--- a/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
+++ b/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
@@ -69,6 +69,11 @@ NSString *PurchasesLogHandlerEvent = @"Purchases-LogHandlerEvent";
         if (object != [NSNull null] && object != nil) {
             automaticDeviceIdentifierCollectionEnabled = [object boolValue];
         }
+        BOOL diagnosticsEnabled = NO;
+        object = arguments[@"diagnosticsEnabled"];
+        if (object != [NSNull null] && object != nil) {
+            diagnosticsEnabled = [object boolValue];
+        }
         [self setupPurchases:apiKey
                    appUserID:appUserID
      purchasesAreCompletedBy:purchasesAreCompletedBy
@@ -77,7 +82,8 @@ NSString *PurchasesLogHandlerEvent = @"Purchases-LogHandlerEvent";
 shouldShowInAppMessagesAutomatically: shouldShowInAppMessagesAutomatically
             verificationMode:verificationMode
 automaticDeviceIdentifierCollectionEnabled:automaticDeviceIdentifierCollectionEnabled
-      preferredUILocaleOverride:preferredUILocaleOverride
+          diagnosticsEnabled:diagnosticsEnabled
+   preferredUILocaleOverride:preferredUILocaleOverride
                       result:result];
     } else if ([@"setAllowSharingStoreAccount" isEqualToString:call.method]) {
         [self setAllowSharingStoreAccount:[arguments[@"allowSharing"] boolValue] result:result];
@@ -284,6 +290,7 @@ purchasesAreCompletedBy:(nullable NSString *)purchasesAreCompletedBy
 shouldShowInAppMessagesAutomatically:(BOOL)shouldShowInAppMessagesAutomatically
       verificationMode:(nullable NSString *)verificationMode
 automaticDeviceIdentifierCollectionEnabled:(BOOL)automaticDeviceIdentifierCollectionEnabled
+    diagnosticsEnabled:(BOOL)diagnosticsEnabled
  preferredUILocaleOverride:(nullable NSString *)preferredUILocaleOverride
                 result:(FlutterResult)result {
     if ([appUserID isKindOfClass:NSNull.class]) {
@@ -303,7 +310,7 @@ automaticDeviceIdentifierCollectionEnabled:(BOOL)automaticDeviceIdentifierCollec
                                             dangerousSettings:nil
                          shouldShowInAppMessagesAutomatically:shouldShowInAppMessagesAutomatically
                                              verificationMode:verificationMode
-                                           diagnosticsEnabled:NO
+                                           diagnosticsEnabled:diagnosticsEnabled
                    automaticDeviceIdentifierCollectionEnabled:automaticDeviceIdentifierCollectionEnabled
                                               preferredLocale:preferredUILocaleOverride.mappingNSNullToNil];
 

--- a/lib/models/purchases_configuration.dart
+++ b/lib/models/purchases_configuration.dart
@@ -74,6 +74,12 @@ class PurchasesConfiguration {
   ///
   /// Default is enabled.
   bool automaticDeviceIdentifierCollectionEnabled = true;
+
+  /// Enabling diagnostics will send some performance and debugging information from the SDK to our servers.
+  /// Examples of this information include response times, cache hits or error codes.
+  /// No personal identifiable information will be collected.
+  /// The default value is false.
+  bool diagnosticsEnabled = false;
 }
 
 /// A [PurchasesConfiguration] convenience object that

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -185,6 +185,7 @@ class Purchases {
             purchasesConfiguration.pendingTransactionsForPrepaidPlansEnabled,
         'automaticDeviceIdentifierCollectionEnabled':
             purchasesConfiguration.automaticDeviceIdentifierCollectionEnabled,
+        'diagnosticsEnabled': purchasesConfiguration.diagnosticsEnabled,
         'preferredUILocaleOverride':
             purchasesConfiguration.preferredUILocaleOverride,
       },

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -101,6 +101,7 @@ void main() {
             'entitlementVerificationMode': 'DISABLED',
             'pendingTransactionsForPrepaidPlansEnabled': false,
             'automaticDeviceIdentifierCollectionEnabled': true,
+            'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
           },
         ),
@@ -132,6 +133,7 @@ void main() {
             'entitlementVerificationMode': 'DISABLED',
             'pendingTransactionsForPrepaidPlansEnabled': false,
             'automaticDeviceIdentifierCollectionEnabled': true,
+            'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
           },
         ),
@@ -161,6 +163,7 @@ void main() {
             'entitlementVerificationMode': 'DISABLED',
             'pendingTransactionsForPrepaidPlansEnabled': false,
             'automaticDeviceIdentifierCollectionEnabled': true,
+            'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
           },
         ),
@@ -193,6 +196,7 @@ void main() {
             'entitlementVerificationMode': 'DISABLED',
             'pendingTransactionsForPrepaidPlansEnabled': false,
             'automaticDeviceIdentifierCollectionEnabled': true,
+            'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
           },
         ),
@@ -1651,6 +1655,7 @@ void main() {
             'entitlementVerificationMode': 'DISABLED',
             'pendingTransactionsForPrepaidPlansEnabled': false,
             'automaticDeviceIdentifierCollectionEnabled': true,
+            'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
           },
         ),
@@ -1681,6 +1686,7 @@ void main() {
             'entitlementVerificationMode': 'DISABLED',
             'pendingTransactionsForPrepaidPlansEnabled': true,
             'automaticDeviceIdentifierCollectionEnabled': true,
+            'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
           },
         ),
@@ -1712,6 +1718,7 @@ void main() {
             'entitlementVerificationMode': 'DISABLED',
             'pendingTransactionsForPrepaidPlansEnabled': false,
             'automaticDeviceIdentifierCollectionEnabled': true,
+            'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
           },
         ),
@@ -1744,6 +1751,7 @@ void main() {
             'entitlementVerificationMode': 'DISABLED',
             'pendingTransactionsForPrepaidPlansEnabled': false,
             'automaticDeviceIdentifierCollectionEnabled': true,
+            'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
           },
         ),
@@ -1773,6 +1781,7 @@ void main() {
             'entitlementVerificationMode': 'DISABLED',
             'pendingTransactionsForPrepaidPlansEnabled': false,
             'automaticDeviceIdentifierCollectionEnabled': false,
+            'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
           },
         ),
@@ -1802,7 +1811,38 @@ void main() {
             'entitlementVerificationMode': 'DISABLED',
             'pendingTransactionsForPrepaidPlansEnabled': false,
             'automaticDeviceIdentifierCollectionEnabled': true,
+            'diagnosticsEnabled': false,
             'preferredUILocaleOverride': 'de_DE',
+          },
+        ),
+      ],
+    );
+  });
+
+  test('configure with diagnosticsEnabled', () async {
+    await Purchases.configure(
+      PurchasesConfiguration('api_key')
+        ..appUserID = 'cesar'
+        ..diagnosticsEnabled = true,
+    );
+    expect(
+      log,
+      <Matcher>[
+        isMethodCall(
+          'setupPurchases',
+          arguments: <String, dynamic>{
+            'apiKey': 'api_key',
+            'appUserId': 'cesar',
+            'purchasesAreCompletedBy': 'REVENUECAT',
+            'userDefaultsSuiteName': null,
+            'storeKitVersion': 'DEFAULT',
+            'useAmazon': false,
+            'shouldShowInAppMessagesAutomatically': true,
+            'entitlementVerificationMode': 'DISABLED',
+            'pendingTransactionsForPrepaidPlansEnabled': false,
+            'automaticDeviceIdentifierCollectionEnabled': true,
+            'diagnosticsEnabled': true,
+            'preferredUILocaleOverride': null,
           },
         ),
       ],


### PR DESCRIPTION
This adds support for diagnostics in our Flutter SDK, where it wasn't still available.