### PR TITLE
Improved the Exception message if the MainActivity is not a subclass of FlutterFragmentActivity when displaying a PaywallView

### DIFF
--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/BasePaywallView.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/BasePaywallView.kt
@@ -1,0 +1,38 @@
+package com.revenuecat.purchases_ui_flutter.views
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import io.flutter.embedding.android.FlutterFragmentActivity
+import io.flutter.plugin.platform.PlatformView
+
+internal abstract class BasePaywallView(
+    context: Context
+) : PlatformView {
+    
+    init {
+        checkActivityType(context)
+    }
+    
+    private fun checkActivityType(context: Context) {
+        val activity = context.activity()
+        if (activity == null) {
+            return
+        }
+        
+        // Check if the MainActivity is a subclass of FlutterFragmentActivity, and if not throw an error.
+        val isFlutterFragmentActivity = FlutterFragmentActivity::class.java.isAssignableFrom(activity.javaClass)
+        if (!isFlutterFragmentActivity) {
+            val errorMessage = "Implementation Error: PaywallView requires the MainActivity to extend FlutterFragmentActivity in order for the paywall to be displayed correctly.\n" +
+                    "Please change your MainActivity to extend FlutterFragmentActivity instead. See https://rev.cat/flutter-paywall-installation for more information."
+            throw RuntimeException(errorMessage)
+        }
+    }
+
+    private tailrec fun Context.activity(): Activity? = when (this) {
+        is Activity -> this
+        is ContextWrapper -> baseContext.activity()
+        else -> null
+    }
+}
+

--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallFooterView.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallFooterView.kt
@@ -20,7 +20,7 @@ internal class PaywallFooterView(
     id: Int,
     messenger: BinaryMessenger,
     creationParams: Map<String?, Any?>
-) : PlatformView {
+) : BasePaywallView(context) {
 
     private val methodChannel: MethodChannel
 

--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallView.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallView.kt
@@ -16,7 +16,7 @@ internal class PaywallView(
     id: Int,
     messenger: BinaryMessenger,
     creationParams: Map<String?, Any?>
-) : PlatformView, MethodCallHandler {
+) : BasePaywallView(context), MethodCallHandler {
 
     private val methodChannel: MethodChannel
     private val nativePaywallView: NativePaywallView


### PR DESCRIPTION
Improved the Exception error message when trying to show a PaywallView when the MainActivity is not a subclass of FlutterFragmentActivity.

The original error that developers experienced was
```
E/flutter ( 8150): [ERROR:flutter/runtime/dart_vm_initializer.cc(40)] Unhandled Exception: PlatformException(error, java.lang.IllegalStateException: No OnBackPressedDispatcherOwner was provided via LocalOnBackPressedDispatcherOwner
```

Which wasn't really helpful and made it hard to understand what the problem was. This has  been changed to
```
E/flutter ( 8019): Please change your activity to extend FlutterFragmentActivity instead. See https://rev.cat/flutter-paywall-installation for more information.
```

Which should hopefully help developers resolve the issue. 