### PR TITLE
Fix iOS setPostHogUserID not working due to argument key typo

### DIFF
--- a/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
+++ b/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
@@ -189,7 +189,7 @@ automaticDeviceIdentifierCollectionEnabled:automaticDeviceIdentifierCollectionEn
         NSString *airshipChannelID = arguments[@"airshipChannelID"];
         [self setAirshipChannelID:airshipChannelID result:result];
     } else if ([@"setPostHogUserID" isEqualToString:call.method]) {
-        NSString *postHogUserID = arguments[@"postHogUserId"];
+        NSString *postHogUserID = arguments[@"postHogUserID"];
         [self setPostHogUserID:postHogUserID result:result];
     } else if ([@"setMediaSource" isEqualToString:call.method]) {
         NSString *mediaSource = arguments[@"mediaSource"];


### PR DESCRIPTION
## Summary
- Fixes `setPostHogUserID()` always setting an empty value on iOS
- The Dart side sends the argument with key `postHogUserID` (uppercase `ID`), but the iOS side was looking for `postHogUserId` (lowercase `Id`)
- Android works correctly since it uses the correct key

## Root Cause
```dart
// Dart sends:
_channel.invokeMethod('setPostHogUserID', {'postHogUserID': postHogUserID});
```

```objc
// iOS was expecting (wrong):
NSString *postHogUserID = arguments[@"postHogUserId"];  // lowercase 'd'

// Should be:
NSString *postHogUserID = arguments[@"postHogUserID"];  // uppercase 'D'
```

## Test plan
- [ ] Verify `Purchases.setPostHogUserID("test-id")` correctly sets the `$posthogUserId` subscriber attribute on iOS
- [ ] Verify the attribute value is non-empty in RevenueCat dashboard
- [ ] Verify Android still works correctly