### PR TITLE
Implemented additional APIs for getting the price per period as formatted string or double value

### DIFF
--- a/api_tester/lib/api_tests/models/store_product_wrapper_api_test.dart
+++ b/api_tester/lib/api_tests/models/store_product_wrapper_api_test.dart
@@ -19,7 +19,13 @@ class _StoreProductApiTest {
       List<StoreProductDiscount>? discounts,
       ProductCategory? productCategory,
       String? subscriptionPeriod,
-      PresentedOfferingContext? presentedOfferingContext) {
+      PresentedOfferingContext? presentedOfferingContext,
+      double? pricePerWeek,
+      double? pricePerMonth,
+      double? pricePerYear,
+      String? pricePerWeekString,
+      String? pricePerMonthString,
+      String? pricePerYearString) {
     StoreProduct product = StoreProduct(
         identifier, description, title, price, priceString, currencyCode);
     product = StoreProduct(
@@ -28,7 +34,13 @@ class _StoreProductApiTest {
         discounts: discounts,
         productCategory: productCategory,
         subscriptionPeriod: subscriptionPeriod,
-        presentedOfferingContext: presentedOfferingContext);
+        presentedOfferingContext: presentedOfferingContext,
+        pricePerWeek: pricePerWeek,
+        pricePerMonth: pricePerMonth,
+        pricePerYear: pricePerYear,
+        pricePerWeekString: pricePerWeekString,
+        pricePerMonthString: pricePerMonthString,
+        pricePerYearString: pricePerYearString);
   }
 
   void _checkProperties(StoreProduct product) {
@@ -47,5 +59,11 @@ class _StoreProductApiTest {
     String? presentedOfferingIdentifier = product.presentedOfferingIdentifier;
     PresentedOfferingContext? presentedOfferingContext =
         product.presentedOfferingContext;
+    double? pricePerWeek = product.pricePerWeek;
+    double? pricePerMonth = product.pricePerMonth;
+    double? pricePerYear = product.pricePerYear;
+    String? pricePerWeekString = product.pricePerWeekString;
+    String? pricePerMonthString = product.pricePerMonthString;
+    String? pricePerYearString = product.pricePerYearString;
   }
 }

--- a/lib/models/store_product_wrapper.dart
+++ b/lib/models/store_product_wrapper.dart
@@ -52,6 +52,30 @@ class StoreProduct extends Equatable {
   /// Note: Not available for Amazon.
   final String? subscriptionPeriod;
 
+  /// Price per week in the local currency.
+  /// Null for non-subscription products.
+  final double? pricePerWeek;
+
+  /// Price per month in the local currency.
+  /// Null for non-subscription products.
+  final double? pricePerMonth;
+
+  /// Price per year in the local currency.
+  /// Null for non-subscription products.
+  final double? pricePerYear;
+
+  /// Formatted price per week, including its currency sign.
+  /// Null for non-subscription products.
+  final String? pricePerWeekString;
+
+  /// Formatted price per month, including its currency sign.
+  /// Null for non-subscription products.
+  final String? pricePerMonthString;
+
+  /// Formatted price per year, including its currency sign.
+  /// Null for non-subscription products.
+  final String? pricePerYearString;
+
   const StoreProduct(
     this.identifier,
     this.description,
@@ -66,6 +90,12 @@ class StoreProduct extends Equatable {
     this.subscriptionOptions,
     this.presentedOfferingContext,
     this.subscriptionPeriod,
+    this.pricePerWeek,
+    this.pricePerMonth,
+    this.pricePerYear,
+    this.pricePerWeekString,
+    this.pricePerMonthString,
+    this.pricePerYearString,
   });
 
   factory StoreProduct.fromJson(Map<String, dynamic> json) => StoreProduct(
@@ -82,6 +112,12 @@ class StoreProduct extends Equatable {
       subscriptionOptions: json['subscriptionOptions'] != null ? (json['subscriptionOptions'] as List).map((e) => SubscriptionOption.fromJson(Map<String, dynamic>.from(e))).toList() : null,
       presentedOfferingContext: json['presentedOfferingContext'] != null ? PresentedOfferingContext.fromJson(Map<String, dynamic>.from(json['presentedOfferingContext'])) : null,
       subscriptionPeriod: json['subscriptionPeriod'] as String?,
+      pricePerWeek: json['pricePerWeek'] != null ? (json['pricePerWeek'] as num).toDouble() : null,
+      pricePerMonth: json['pricePerMonth'] != null ? (json['pricePerMonth'] as num).toDouble() : null,
+      pricePerYear: json['pricePerYear'] != null ? (json['pricePerYear'] as num).toDouble() : null,
+      pricePerWeekString: json['pricePerWeekString'] as String?,
+      pricePerMonthString: json['pricePerMonthString'] as String?,
+      pricePerYearString: json['pricePerYearString'] as String?,
     );
 
   @override
@@ -99,6 +135,12 @@ class StoreProduct extends Equatable {
     subscriptionOptions,
     presentedOfferingContext,
     subscriptionPeriod,
+    pricePerWeek,
+    pricePerMonth,
+    pricePerYear,
+    pricePerWeekString,
+    pricePerMonthString,
+    pricePerYearString,
   ];
 }
 

--- a/test/models/store_product_wrapper_test.dart
+++ b/test/models/store_product_wrapper_test.dart
@@ -62,6 +62,12 @@ void main() {
         'subscriptionOptions': null,
         'presentedOfferingContext': null,
         'subscriptionPeriod': 'P1M',
+        'pricePerWeek': 0.69,
+        'pricePerMonth': 2.99,
+        'pricePerYear': 35.88,
+        'pricePerWeekString': '\$0.69',
+        'pricePerMonthString': '\$2.99',
+        'pricePerYearString': '\$35.88',
       };
       final info = StoreProduct.fromJson(json);
       const expected = StoreProduct(
@@ -95,6 +101,12 @@ void main() {
         subscriptionOptions: null,
         presentedOfferingContext: null,
         subscriptionPeriod: 'P1M',
+        pricePerWeek: 0.69,
+        pricePerMonth: 2.99,
+        pricePerYear: 35.88,
+        pricePerWeekString: '\$0.69',
+        pricePerMonthString: '\$2.99',
+        pricePerYearString: '\$35.88',
       );
       expect(info, equals(expected));
     });


### PR DESCRIPTION
Depends on https://github.com/RevenueCat/purchases-hybrid-common/pull/1447 for consistency across platforms.

- Adds the `pricePerWeek`, `pricePerMonth` and `pricePerYear` APIs for getting a double value of the price.
- Adds the `pricePerWeekString`, `pricePerMonthString` and `pricePerYearString` for getting a formatted string of the price.
