### PR TITLE
Fixed offerings order in purchase tester app not being stable

### DIFF
--- a/revenuecat_examples/purchase_tester/lib/src/upsell.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/upsell.dart
@@ -81,8 +81,15 @@ class _UpsellScreenState extends State<UpsellScreen> {
   Widget _buildUpsell(BuildContext context) {
     final currentOfferingId = _offerings?.current?.identifier;
     // Sort offerings by identifier (key) for stable ordering, case-insensitive
+    // Put current/default offering first
     final sortedOfferings = _offerings!.all.entries.toList()
-      ..sort((a, b) => a.key.toLowerCase().compareTo(b.key.toLowerCase()));
+      ..sort((a, b) {
+        // Current offering always comes first
+        if (a.key == currentOfferingId) return -1;
+        if (b.key == currentOfferingId) return 1;
+        // Otherwise sort alphabetically
+        return a.key.toLowerCase().compareTo(b.key.toLowerCase());
+      });
     
     return ListView(children: [
       if (_customerInfo != null)


### PR DESCRIPTION
Makes it easier to find the same offering after relaunching during testing