### PR TITLE
Add pod update with retry for CocoaPods propagation issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -552,8 +552,10 @@ workflows:
       - test
       - api_test
       - dry-run-release: *release-branches
-      - ios-integration-test-cocoapods
-      - macos-integration-test-cocoapods
+      - ios-integration-test-cocoapods:
+          name: ios-integration-test-cocoapods
+      - macos-integration-test-cocoapods:
+          name: macos-integration-test-cocoapods
       - ios-integration-test-spm
       - macos-integration-test-spm
       - android-integration-test-build
@@ -566,9 +568,11 @@ workflows:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - ios-integration-test-cocoapods:
+          name: ios-integration-test-cocoapods-release
           enable_retry: true
           <<: *release-branches
       - macos-integration-test-cocoapods:
+          name: macos-integration-test-cocoapods-release
           enable_retry: true
           <<: *release-branches
       - ios-integration-test-spm: *release-branches
@@ -577,8 +581,8 @@ workflows:
       - hold:
           type: approval
           requires:
-            - ios-integration-test-cocoapods
-            - macos-integration-test-cocoapods
+            - ios-integration-test-cocoapods-release
+            - macos-integration-test-cocoapods-release
             - ios-integration-test-spm
             - macos-integration-test-spm
             - android-integration-test


### PR DESCRIPTION
## Summary

Adds retry logic for `pod update` in iOS/macOS integration tests to handle CocoaPods CDN propagation delays during PHC bumps.

### Changes
- New `pod-update-with-retry` command with configurable retries (default: 5 retries, 5 min wait)
- Added `enable_retry` parameter to `ios-integration-test-cocoapods` and `macos-integration-test-cocoapods` jobs
- Retry is only enabled in `deploy` workflow (release branches) where PHC bumps run

### How it works
- On regular CI runs: `pod update --repo-update` runs once (no retry)
- On release branches (PHC bumps): retries up to 5 times with 5-minute waits for CocoaPods propagation

Closes https://github.com/RevenueCat/sdks-circleci-orb/pull/29

🤖 Generated with [Claude Code](https://claude.ai/code)