### PR TITLE
Enable pod update retry for bump-phc branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ aliases:
         ignore: /.*/
       branches:
         only: /^bump-phc\/.*/
-  exclude-bump-phc-branches: &exclude-bump-phc-branches
+  not-bump-phc-branches: &not-bump-phc-branches
     filters:
       tags:
         ignore: /.*/
@@ -567,10 +567,10 @@ workflows:
       - dry-run-release: *release-branches
       - ios-integration-test-cocoapods:
           name: ios-integration-test-cocoapods
-          <<: *exclude-bump-phc-branches
+          <<: *not-bump-phc-branches
       - macos-integration-test-cocoapods:
           name: macos-integration-test-cocoapods
-          <<: *exclude-bump-phc-branches
+          <<: *not-bump-phc-branches
       - ios-integration-test-cocoapods:
           name: ios-integration-test-cocoapods-phc-bump
           enable_retry: true


### PR DESCRIPTION
## Summary

Fixes the pod update retry logic from #1618 to also apply to `bump-phc/*` branches.

### Problem
The retry logic was only enabled for `release/*` branches in the deploy workflow, but PHC bump PRs run on `bump-phc/*` branches using the test workflow where retry was not enabled.

### Changes
- Added `bump-phc-branches` alias to match `bump-phc/*` branches
- Added `exclude-bump-phc-branches` alias to exclude them from regular test runs
- Test workflow now runs CocoaPods integration tests:
  - **Without retry** on regular branches (fast fail)
  - **With retry** on `bump-phc/*` branches (handles propagation delays)

### Related
- Fixes CI failures on #1628
- Follow-up to #1618

🤖 Generated with [Claude Code](https://claude.ai/code)