### PR TITLE
Fix custom variables not working on Android paywalls

### DIFF
--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallView.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallView.kt
@@ -69,7 +69,7 @@ internal class PaywallView(
                 methodChannel.invokeMethod("onRestoreError", error)
             }
         })
-        nativePaywallView.setOfferingId(offeringIdentifier, presentedOfferingContext)
+        // Custom variables must be set before setting the offering to ensure they're applied
         val customVariables = creationParams["customVariables"] as? Map<String, Any?>
         if (customVariables != null) {
             val convertedVariables = customVariables.mapNotNull { (key, value) ->
@@ -77,6 +77,7 @@ internal class PaywallView(
             }.toMap()
             nativePaywallView.setCustomVariables(convertedVariables)
         }
+        nativePaywallView.setOfferingId(offeringIdentifier, presentedOfferingContext)
     }
 
     // We currently don't have any communication in this channel from dart to native, so this can be empty.


### PR DESCRIPTION
## Summary
- Fix custom variables showing default values on Android while working correctly on iOS
- Set custom variables **before** calling `setOfferingId()` to match iOS behavior

## Root Cause
On Android, `setOfferingId()` was being called before `setCustomVariables()`. The paywall initializes when the offering is set, so custom variables configured afterwards are ignored.

On iOS, custom variables were correctly set first (with a comment: "Custom variables must be set before any other updates that might initialize the hosting controller").

## Changes
Moved the custom variables setup to execute before `setOfferingId()` in `PaywallView.kt`, matching the iOS implementation order.

Fixes #1646

## Test plan
- [ ] Build and run Android app with custom variables in paywall
- [ ] Verify custom variables display correctly instead of default values
- [ ] Verify iOS still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)