### PR TITLE
Fix CocoaPods retry job names breaking GitHub required checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,7 +233,7 @@ commands:
           working_directory: << parameters.working_directory >>
           command: |
             enable_retry=false
-            if [[ "$CIRCLE_BRANCH" == bump-phc/* ]] || [[ "$CIRCLE_BRANCH" == release/* ]]; then
+            if [[ "$CIRCLE_BRANCH" == bump-phc/* ]]; then
               enable_retry=true
             fi
 


### PR DESCRIPTION
## Summary

- Fixes CocoaPods integration test jobs reporting different names on `bump-phc/*` branches, which broke GitHub required checks.
- Instead of duplicating jobs with branch filters (introduced in #1629), the `pod-update-with-retry` command now auto-detects `bump-phc/*` branches at runtime and enables retry accordingly.
- Removes the now-unused `bump-phc-branches` / `not-bump-phc-branches` aliases and the `enable_retry` parameter from jobs and command.
- Removes unnecessary retry for `release/*` branches, since they don't run right after a new PHC version is published.

## Related

- Simplifies the approach from #1629
- Original retry mechanism added in #1618