### PR TITLE
Add promotional offer success callback to CustomerCenterView

### DIFF
--- a/api_tester/lib/api_tests/purchases_ui_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_ui_flutter_api_test.dart
@@ -30,7 +30,9 @@ class _PurchasesFlutterApiTest {
 
   void _checkPresentPaywallWithCustomVariables(Offering? offering) async {
     Future<PaywallResult> f1 = RevenueCatUI.presentPaywall(
-      customVariables: {'player_name': const CustomVariableValue.string('John')},
+      customVariables: {
+        'player_name': const CustomVariableValue.string('John')
+      },
     );
     Future<PaywallResult> f2 = RevenueCatUI.presentPaywall(
       offering: offering,
@@ -41,14 +43,18 @@ class _PurchasesFlutterApiTest {
     );
     Future<PaywallResult> f3 = RevenueCatUI.presentPaywallIfNeeded(
       "test",
-      customVariables: {'player_name': const CustomVariableValue.string('John')},
+      customVariables: {
+        'player_name': const CustomVariableValue.string('John')
+      },
     );
   }
 
   Widget _checkPaywallViewWithCustomVariables(Offering offering) {
     return PaywallView(
       offering: offering,
-      customVariables: {'player_name': const CustomVariableValue.string('John')},
+      customVariables: {
+        'player_name': const CustomVariableValue.string('John')
+      },
     );
   }
 
@@ -60,7 +66,8 @@ class _PurchasesFlutterApiTest {
     String value = stringValue.stringValue;
 
     // CustomVariableValue is a sealed class with only String subtype available
-    StringCustomVariableValue stringVariable = const StringCustomVariableValue('test');
+    StringCustomVariableValue stringVariable =
+        const StringCustomVariableValue('test');
     String directValue = stringVariable.value;
     String stringValueFromSubtype = stringVariable.stringValue;
   }
@@ -95,29 +102,22 @@ class _PurchasesFlutterApiTest {
   }
 
   Widget _checkPaywallViewWithListeners(
-      Offering offering,
-      bool displayCloseButton,
+    Offering offering,
+    bool displayCloseButton,
   ) {
     return Scaffold(
       body: Center(
         child: PaywallView(
           offering: offering,
           displayCloseButton: displayCloseButton,
-          onPurchaseStarted: (Package rcPackage) {
-          },
+          onPurchaseStarted: (Package rcPackage) {},
           onPurchaseCompleted:
-              (CustomerInfo customerInfo, StoreTransaction storeTransaction) {
-          },
-          onPurchaseCancelled: () {
-          },
-          onPurchaseError: (PurchasesError error) {
-          },
-          onRestoreCompleted: (CustomerInfo customerInfo) {
-          },
-          onRestoreError: (PurchasesError error) {
-          },
-          onDismiss: () {
-          },
+              (CustomerInfo customerInfo, StoreTransaction storeTransaction) {},
+          onPurchaseCancelled: () {},
+          onPurchaseError: (PurchasesError error) {},
+          onRestoreCompleted: (CustomerInfo customerInfo) {},
+          onRestoreError: (PurchasesError error) {},
+          onDismiss: () {},
         ),
       ),
     );
@@ -148,7 +148,7 @@ class _PurchasesFlutterApiTest {
   }
 
   Widget _checkOriginalTemplatePaywallFooterViewWithOffering(
-      Offering offering,
+    Offering offering,
   ) {
     return Scaffold(
       body: Center(
@@ -176,26 +176,19 @@ class _PurchasesFlutterApiTest {
   }
 
   Widget _checkOriginalTemplatePaywallFooterViewWithListeners(
-      Offering offering,
+    Offering offering,
   ) {
     return Scaffold(
       body: Center(
         child: OriginalTemplatePaywallFooterView(
-          onPurchaseStarted: (Package rcPackage) {
-          },
+          onPurchaseStarted: (Package rcPackage) {},
           onPurchaseCompleted:
-              (CustomerInfo customerInfo, StoreTransaction storeTransaction) {
-          },
-          onPurchaseCancelled: () {
-          },
-          onPurchaseError: (PurchasesError error) {
-          },
-          onRestoreCompleted: (CustomerInfo customerInfo) {
-          },
-          onRestoreError: (PurchasesError error) {
-          },
-          onDismiss: () {
-          },
+              (CustomerInfo customerInfo, StoreTransaction storeTransaction) {},
+          onPurchaseCancelled: () {},
+          onPurchaseError: (PurchasesError error) {},
+          onRestoreCompleted: (CustomerInfo customerInfo) {},
+          onRestoreError: (PurchasesError error) {},
+          onDismiss: () {},
           contentCreator: (double bottomPadding) {
             return Container();
           },
@@ -208,21 +201,14 @@ class _PurchasesFlutterApiTest {
     return Scaffold(
       body: Center(
         child: PaywallFooterView(
-          onPurchaseStarted: (Package rcPackage) {
-          },
+          onPurchaseStarted: (Package rcPackage) {},
           onPurchaseCompleted:
-              (CustomerInfo customerInfo, StoreTransaction storeTransaction) {
-          },
-          onPurchaseCancelled: () {
-          },
-          onPurchaseError: (PurchasesError error) {
-          },
-          onRestoreCompleted: (CustomerInfo customerInfo) {
-          },
-          onRestoreError: (PurchasesError error) {
-          },
-          onDismiss: () {
-          },
+              (CustomerInfo customerInfo, StoreTransaction storeTransaction) {},
+          onPurchaseCancelled: () {},
+          onPurchaseError: (PurchasesError error) {},
+          onRestoreCompleted: (CustomerInfo customerInfo) {},
+          onRestoreError: (PurchasesError error) {},
+          onDismiss: () {},
           contentCreator: (double bottomPadding) {
             return Container();
           },
@@ -267,8 +253,10 @@ class _PurchasesFlutterApiTest {
       onRefundRequestCompleted: (String productIdentifier, String status) {},
       onFeedbackSurveyCompleted: (String optionIdentifier) {},
       onManagementOptionSelected: (String optionIdentifier, String? url) {},
-      onCustomActionSelected: (String actionIdentifier, String? purchaseIdentifier) {},
-      onPromotionalOfferSuccess: () {},
+      onCustomActionSelected:
+          (String actionIdentifier, String? purchaseIdentifier) {},
+      onPromotionalOfferSucceeded: (CustomerInfo customerInfo,
+          StoreTransaction transaction, String offerId) {},
     );
   }
 
@@ -290,14 +278,16 @@ class _PurchasesFlutterApiTest {
           onRestoreFailed: (PurchasesError error) {},
           onShowingManageSubscriptions: () {},
           onRefundRequestStarted: (String productIdentifier) {},
-          onRefundRequestCompleted: (String productIdentifier, String status) {},
+          onRefundRequestCompleted:
+              (String productIdentifier, String status) {},
           onFeedbackSurveyCompleted: (String optionIdentifier) {},
           onManagementOptionSelected: (String optionIdentifier, String? url) {},
-          onCustomActionSelected: (String actionIdentifier, String? purchaseIdentifier) {},
-          onPromotionalOfferSuccess: () {},
+          onCustomActionSelected:
+              (String actionIdentifier, String? purchaseIdentifier) {},
+          onPromotionalOfferSucceeded: (CustomerInfo customerInfo,
+              StoreTransaction transaction, String offerId) {},
         ),
       ),
     );
   }
-
 }

--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/PurchasesUiFlutterPlugin.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/PurchasesUiFlutterPlugin.kt
@@ -268,6 +268,21 @@ class PurchasesUiFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware,
                     )
                 )
             }
+
+            override fun onPromotionalOfferSucceededWrapper(
+                customerInfo: Map<String, Any?>,
+                transaction: Map<String, Any?>,
+                offerId: String,
+            ) {
+                channel.invokeMethod(
+                    "onPromotionalOfferSucceeded",
+                    mapOf(
+                        "customerInfo" to customerInfo,
+                        "transaction" to transaction,
+                        "offerId" to offerId,
+                    ),
+                )
+            }
         }
     }
 

--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/CustomerCenterView.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/CustomerCenterView.kt
@@ -101,8 +101,19 @@ internal class CustomerCenterView(
                 )
             }
 
-            override fun onPromotionalOfferSuccessWrapper() {
-                methodChannel.invokeMethod("onPromotionalOfferSuccess", null)
+            override fun onPromotionalOfferSucceededWrapper(
+                customerInfo: Map<String, Any?>,
+                transaction: Map<String, Any?>,
+                offerId: String,
+            ) {
+                methodChannel.invokeMethod(
+                    "onPromotionalOfferSucceeded",
+                    mapOf(
+                        "customerInfo" to customerInfo,
+                        "transaction" to transaction,
+                        "offerId" to offerId,
+                    ),
+                )
             }
         }
     }

--- a/purchases_ui_flutter/ios/purchases_ui_flutter/Sources/purchases_ui_flutter/PurchasesUiCustomerCenterView.swift
+++ b/purchases_ui_flutter/ios/purchases_ui_flutter/Sources/purchases_ui_flutter/PurchasesUiCustomerCenterView.swift
@@ -188,7 +188,19 @@ extension PurchasesUiCustomerCenterView: CustomerCenterViewControllerDelegateWra
         )
     }
 
-    func customerCenterViewControllerDidSucceedWithPromotionalOffer(_ controller: CustomerCenterUIViewController) {
-        methodChannel.invokeMethod("onPromotionalOfferSuccess", arguments: nil)
+    func customerCenterViewController(
+        _ controller: CustomerCenterUIViewController,
+        didSucceedWithPromotionalOffer offerId: String,
+        customerInfoDictionary: [String: Any],
+        transactionDictionary: [String: Any]
+    ) {
+        methodChannel.invokeMethod(
+            "onPromotionalOfferSucceeded",
+            arguments: [
+                "customerInfo": customerInfoDictionary,
+                "transaction": transactionDictionary,
+                "offerId": offerId
+            ]
+        )
     }
 }

--- a/purchases_ui_flutter/ios/purchases_ui_flutter/Sources/purchases_ui_flutter/PurchasesUiFlutterPlugin.swift
+++ b/purchases_ui_flutter/ios/purchases_ui_flutter/Sources/purchases_ui_flutter/PurchasesUiFlutterPlugin.swift
@@ -343,5 +343,21 @@ final class CustomerCenterDelegateForwarder: NSObject, CustomerCenterViewControl
         ]
         methodChannel?.invokeMethod("onCustomActionSelected", arguments: args)
     }
+
+    func customerCenterViewController(
+        _ controller: CustomerCenterUIViewController,
+        didSucceedWithPromotionalOffer offerId: String,
+        customerInfoDictionary: [String: Any],
+        transactionDictionary: [String: Any]
+    ) {
+        methodChannel?.invokeMethod(
+            "onPromotionalOfferSucceeded",
+            arguments: [
+                "customerInfo": customerInfoDictionary,
+                "transaction": transactionDictionary,
+                "offerId": offerId
+            ]
+        )
+    }
 }
 #endif

--- a/purchases_ui_flutter/lib/purchases_ui_flutter.dart
+++ b/purchases_ui_flutter/lib/purchases_ui_flutter.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:purchases_flutter/models/customer_info_wrapper.dart';
 import 'package:purchases_flutter/models/offering_wrapper.dart';
 import 'package:purchases_flutter/models/purchases_error.dart';
+import 'package:purchases_flutter/models/store_transaction.dart';
 
 import 'custom_variable_value.dart';
 import 'paywall_result.dart';
@@ -35,8 +36,8 @@ class RevenueCatUI {
       _customerCenterOnManagementOptionSelected;
   static CustomerCenterCustomActionSelected?
       _customerCenterOnCustomActionSelected;
-  static CustomerCenterPromotionalOfferSuccess?
-      _customerCenterOnPromotionalOfferSuccess;
+  static CustomerCenterPromotionalOfferSucceeded?
+      _customerCenterOnPromotionalOfferSucceeded;
   static bool _methodChannelHandlerSet = false;
 
   /// Presents the paywall as an activity on android or a modal in iOS.
@@ -102,7 +103,7 @@ class RevenueCatUI {
     CustomerCenterFeedbackSurveyCompleted? onFeedbackSurveyCompleted,
     CustomerCenterManagementOptionSelected? onManagementOptionSelected,
     CustomerCenterCustomActionSelected? onCustomActionSelected,
-    CustomerCenterPromotionalOfferSuccess? onPromotionalOfferSuccess,
+    CustomerCenterPromotionalOfferSucceeded? onPromotionalOfferSucceeded,
   }) async {
     _setMethodChannelHandlerIfNeeded();
     final hasCallbacks = onRestoreStarted != null ||
@@ -114,7 +115,7 @@ class RevenueCatUI {
         onFeedbackSurveyCompleted != null ||
         onManagementOptionSelected != null ||
         onCustomActionSelected != null ||
-        onPromotionalOfferSuccess != null;
+        onPromotionalOfferSucceeded != null;
 
     await _clearCustomerCenterCallbacks();
 
@@ -129,7 +130,7 @@ class RevenueCatUI {
         onFeedbackSurveyCompleted: onFeedbackSurveyCompleted,
         onManagementOptionSelected: onManagementOptionSelected,
         onCustomActionSelected: onCustomActionSelected,
-        onPromotionalOfferSuccess: onPromotionalOfferSuccess,
+        onPromotionalOfferSucceeded: onPromotionalOfferSucceeded,
       );
     }
     await _methodChannel.invokeMethod('presentCustomerCenter');
@@ -177,7 +178,7 @@ class RevenueCatUI {
     CustomerCenterFeedbackSurveyCompleted? onFeedbackSurveyCompleted,
     CustomerCenterManagementOptionSelected? onManagementOptionSelected,
     CustomerCenterCustomActionSelected? onCustomActionSelected,
-    CustomerCenterPromotionalOfferSuccess? onPromotionalOfferSuccess,
+    CustomerCenterPromotionalOfferSucceeded? onPromotionalOfferSucceeded,
   }) async {
     _setMethodChannelHandlerIfNeeded();
     _customerCenterOnRestoreStarted = onRestoreStarted;
@@ -189,7 +190,7 @@ class RevenueCatUI {
     _customerCenterOnFeedbackSurveyCompleted = onFeedbackSurveyCompleted;
     _customerCenterOnManagementOptionSelected = onManagementOptionSelected;
     _customerCenterOnCustomActionSelected = onCustomActionSelected;
-    _customerCenterOnPromotionalOfferSuccess = onPromotionalOfferSuccess;
+    _customerCenterOnPromotionalOfferSucceeded = onPromotionalOfferSucceeded;
     await _methodChannel.invokeMethod('setCustomerCenterCallbacks');
   }
 
@@ -204,7 +205,7 @@ class RevenueCatUI {
     _customerCenterOnFeedbackSurveyCompleted = null;
     _customerCenterOnManagementOptionSelected = null;
     _customerCenterOnCustomActionSelected = null;
-    _customerCenterOnPromotionalOfferSuccess = null;
+    _customerCenterOnPromotionalOfferSucceeded = null;
     await _methodChannel.invokeMethod('clearCustomerCenterCallbacks');
   }
 
@@ -379,8 +380,43 @@ class RevenueCatUI {
           purchaseIdentifier as String?,
         );
         break;
-      case 'onPromotionalOfferSuccess':
-        _customerCenterOnPromotionalOfferSuccess?.call();
+      case 'onPromotionalOfferSucceeded':
+        final rawArguments = call.arguments;
+        if (rawArguments is! Map) {
+          debugPrint(
+            'RevenueCatUI: Error - onPromotionalOfferSucceeded called with invalid arguments: $rawArguments',
+          );
+          return;
+        }
+        final arguments = Map<String, dynamic>.from(rawArguments);
+        final customerInfoMap = arguments['customerInfo'];
+        final transactionMap = arguments['transaction'];
+        final offerId = arguments['offerId'];
+        if (customerInfoMap is! Map ||
+            transactionMap is! Map ||
+            offerId is! String) {
+          debugPrint(
+            'RevenueCatUI: Error - onPromotionalOfferSucceeded called with missing or invalid data',
+          );
+          return;
+        }
+        try {
+          final customerInfo = CustomerInfo.fromJson(
+            Map<String, dynamic>.from(customerInfoMap),
+          );
+          final transaction = StoreTransaction.fromJson(
+            Map<String, dynamic>.from(transactionMap),
+          );
+          _customerCenterOnPromotionalOfferSucceeded?.call(
+            customerInfo,
+            transaction,
+            offerId,
+          );
+        } catch (e) {
+          debugPrint(
+            'RevenueCatUI: Error parsing onPromotionalOfferSucceeded data: $e',
+          );
+        }
         break;
     }
   }

--- a/purchases_ui_flutter/lib/views/customer_center_view.dart
+++ b/purchases_ui_flutter/lib/views/customer_center_view.dart
@@ -26,7 +26,7 @@ class CustomerCenterView extends StatelessWidget {
     this.onFeedbackSurveyCompleted,
     this.onManagementOptionSelected,
     this.onCustomActionSelected,
-    this.onPromotionalOfferSuccess,
+    this.onPromotionalOfferSucceeded,
   });
 
   /// Whether to show a close button in the customer center.
@@ -49,8 +49,9 @@ class CustomerCenterView extends StatelessWidget {
   final CustomerCenterManagementOptionSelected? onManagementOptionSelected;
   final CustomerCenterCustomActionSelected? onCustomActionSelected;
 
-  /// Called when a promotional offer is successfully redeemed.
-  final CustomerCenterPromotionalOfferSuccess? onPromotionalOfferSuccess;
+  /// Called when a promotional offer purchase completes successfully,
+  /// providing the resulting customer info, transaction, and the promotional offer identifier.
+  final CustomerCenterPromotionalOfferSucceeded? onPromotionalOfferSucceeded;
 
   static const String _viewType =
       'com.revenuecat.purchasesui/CustomerCenterView';
@@ -112,7 +113,7 @@ class CustomerCenterView extends StatelessWidget {
       onFeedbackSurveyCompleted: onFeedbackSurveyCompleted,
       onManagementOptionSelected: onManagementOptionSelected,
       onCustomActionSelected: onCustomActionSelected,
-      onPromotionalOfferSuccess: onPromotionalOfferSuccess,
+      onPromotionalOfferSucceeded: onPromotionalOfferSucceeded,
     );
     MethodChannel(
       'com.revenuecat.purchasesui/CustomerCenterView/$id',

--- a/purchases_ui_flutter/lib/views/customer_center_view_method_handler.dart
+++ b/purchases_ui_flutter/lib/views/customer_center_view_method_handler.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/services.dart';
 import 'package:purchases_flutter/models/customer_info_wrapper.dart';
 import 'package:purchases_flutter/models/purchases_error.dart';
+import 'package:purchases_flutter/models/store_transaction.dart';
 
 /// Called when the customer center is dismissed by the user.
 typedef CustomerCenterOnDismiss = void Function();
@@ -55,8 +56,13 @@ typedef CustomerCenterManagementOptionSelected = void Function(
 typedef CustomerCenterCustomActionSelected = void Function(
     String actionIdentifier, String? purchaseIdentifier);
 
-/// Called when a promotional offer is successfully redeemed in the Customer Center.
-typedef CustomerCenterPromotionalOfferSuccess = void Function();
+/// Called when a promotional offer purchase completes successfully in the Customer Center,
+/// providing the resulting customer info, transaction, and the promotional offer identifier.
+typedef CustomerCenterPromotionalOfferSucceeded = void Function(
+  CustomerInfo customerInfo,
+  StoreTransaction transaction,
+  String offerId,
+);
 
 class CustomerCenterViewMethodHandler {
   final CustomerCenterOnDismiss? onDismiss;
@@ -69,7 +75,7 @@ class CustomerCenterViewMethodHandler {
   final CustomerCenterFeedbackSurveyCompleted? onFeedbackSurveyCompleted;
   final CustomerCenterManagementOptionSelected? onManagementOptionSelected;
   final CustomerCenterCustomActionSelected? onCustomActionSelected;
-  final CustomerCenterPromotionalOfferSuccess? onPromotionalOfferSuccess;
+  final CustomerCenterPromotionalOfferSucceeded? onPromotionalOfferSucceeded;
 
   const CustomerCenterViewMethodHandler({
     this.onDismiss,
@@ -82,7 +88,7 @@ class CustomerCenterViewMethodHandler {
     this.onFeedbackSurveyCompleted,
     this.onManagementOptionSelected,
     this.onCustomActionSelected,
-    this.onPromotionalOfferSuccess,
+    this.onPromotionalOfferSucceeded,
   });
 
   Future<void> handleMethodCall(MethodCall call) async {
@@ -117,8 +123,8 @@ class CustomerCenterViewMethodHandler {
       case 'onCustomActionSelected':
         _handleCustomActionSelected(call.arguments);
         break;
-      case 'onPromotionalOfferSuccess':
-        onPromotionalOfferSuccess?.call();
+      case 'onPromotionalOfferSucceeded':
+        _handlePromotionalOfferSucceeded(call.arguments);
         break;
       default:
         break;
@@ -213,6 +219,29 @@ class CustomerCenterViewMethodHandler {
       final purchaseIdentifier = data['purchaseIdentifier'] as String?;
       if (actionId != null) {
         onCustomActionSelected?.call(actionId, purchaseIdentifier);
+      }
+    }
+  }
+
+  void _handlePromotionalOfferSucceeded(dynamic arguments) {
+    if (onPromotionalOfferSucceeded == null) {
+      return;
+    }
+    if (arguments is Map) {
+      final data = Map<String, dynamic>.from(arguments);
+      final customerInfoMap = data['customerInfo'] as Map?;
+      final transactionMap = data['transaction'] as Map?;
+      final offerId = data['offerId'] as String?;
+      if (customerInfoMap != null &&
+          transactionMap != null &&
+          offerId != null) {
+        final customerInfo = CustomerInfo.fromJson(
+          Map<String, dynamic>.from(customerInfoMap),
+        );
+        final transaction = StoreTransaction.fromJson(
+          Map<String, dynamic>.from(transactionMap),
+        );
+        onPromotionalOfferSucceeded?.call(customerInfo, transaction, offerId);
       }
     }
   }

--- a/purchases_ui_flutter/test/purchases_ui_flutter_test.dart
+++ b/purchases_ui_flutter/test/purchases_ui_flutter_test.dart
@@ -7,6 +7,8 @@ import 'package:purchases_flutter/models/package_wrapper.dart';
 import 'package:purchases_flutter/models/presented_offering_context_wrapper.dart';
 import 'package:purchases_flutter/models/presented_offering_targeting_context_wrapper.dart';
 import 'package:purchases_flutter/models/store_product_wrapper.dart';
+import 'package:purchases_flutter/models/customer_info_wrapper.dart';
+import 'package:purchases_flutter/models/store_transaction.dart';
 import 'package:purchases_ui_flutter/purchases_ui_flutter.dart';
 import 'package:purchases_ui_flutter/views/customer_center_view_method_handler.dart';
 
@@ -658,19 +660,51 @@ void main() {
       },
     );
 
-    test('onPromotionalOfferSuccess fires callback', () async {
-      var callbackCalled = false;
+    test('onPromotionalOfferSucceeded fires callback with data', () async {
+      CustomerInfo? receivedCustomerInfo;
+      StoreTransaction? receivedTransaction;
+      String? receivedOfferId;
 
       await RevenueCatUI.presentCustomerCenter(
-        onPromotionalOfferSuccess: () {
-          callbackCalled = true;
+        onPromotionalOfferSucceeded: (customerInfo, transaction, offerId) {
+          receivedCustomerInfo = customerInfo;
+          receivedTransaction = transaction;
+          receivedOfferId = offerId;
         },
       );
 
       log.clear();
 
-      await invokeCustomerCenterMethod('onPromotionalOfferSuccess', null);
-      expect(callbackCalled, true);
+      await invokeCustomerCenterMethod('onPromotionalOfferSucceeded', {
+        'customerInfo': {
+          'originalAppUserId': 'test_user',
+          'entitlements': {
+            'all': {},
+            'active': {},
+            'verification': 'NOT_REQUESTED',
+          },
+          'activeSubscriptions': [],
+          'latestExpirationDate': null,
+          'allExpirationDates': {},
+          'allPurchasedProductIdentifiers': [],
+          'firstSeen': '2024-01-01T00:00:00Z',
+          'requestDate': '2024-01-01T00:00:00Z',
+          'allPurchaseDates': {},
+          'originalApplicationVersion': null,
+          'nonSubscriptionTransactions': [],
+        },
+        'transaction': {
+          'transactionIdentifier': 'txn_123',
+          'productIdentifier': 'com.test.product',
+          'purchaseDate': '2024-01-01T00:00:00Z',
+        },
+        'offerId': 'promo_offer_1',
+      });
+      expect(receivedCustomerInfo, isNotNull);
+      expect(receivedTransaction, isNotNull);
+      expect(receivedTransaction!.transactionIdentifier, 'txn_123');
+      expect(receivedTransaction!.productIdentifier, 'com.test.product');
+      expect(receivedOfferId, 'promo_offer_1');
     });
   });
 }


### PR DESCRIPTION
## Summary
- Adds `onPromotionalOfferSuccess` callback to `CustomerCenterView` and `presentCustomerCenter`, allowing apps to be notified when a promotional retention offer is successfully redeemed in the Customer Center.
- iOS-only for now — Android native SDK does not yet expose this callback in `CustomerCenterListener`.
- Includes unit test and API tester coverage.

**Depends on:** https://github.com/RevenueCat/purchases-hybrid-common/pull/1527

Addresses https://linear.app/revenuecat/issue/ONCALL-1649