### PR TITLE
Fix Wasm incompatibility in web error processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### ✨ New Features
 * Add setAppstackAttributionParams API (#1671) via Rick (@rickvdl)
 
+### 🐞 Bugfixes
+* Fix Wasm incompatibility: replace `is JSObject` runtime check with `isA<JSObject>()` in web error processing (#1651)
+
 ## 9.13.2
 ## RevenueCat SDK
 ### 📦 Dependency Updates

--- a/lib/web/purchases_flutter_web.dart
+++ b/lib/web/purchases_flutter_web.dart
@@ -453,23 +453,26 @@ class PurchasesFlutterPlugin {
   ];
 
   PlatformException _processError(dynamic error) {
-    if (error is JSObject && error.has('code')) {
-      final errorMap = _convertJsRecordToMap(error);
-      final code = errorMap['code'];
-      final message = errorMap['message'];
-      final underlyingErrorMessage = errorMap['underlyingErrorMessage'];
-      final finalMessage = '$message. $underlyingErrorMessage';
-      return PlatformException(
-        code: '$code',
-        message: finalMessage,
-        details: errorMap,
-      );
-    } else {
-      return PlatformException(
-        code: _unknownErrorCode,
-        message: error.toString(),
-      );
+    final jsAny = error as JSAny?;
+    if (jsAny != null && jsAny.isA<JSObject>()) {
+      final jsObject = jsAny as JSObject;
+      if (jsObject.has('code')) {
+        final errorMap = _convertJsRecordToMap(jsObject);
+        final code = errorMap['code'];
+        final message = errorMap['message'];
+        final underlyingErrorMessage = errorMap['underlyingErrorMessage'];
+        final finalMessage = '$message. $underlyingErrorMessage';
+        return PlatformException(
+          code: '$code',
+          message: finalMessage,
+          details: errorMap,
+        );
+      }
     }
+    return PlatformException(
+      code: _unknownErrorCode,
+      message: error.toString(),
+    );
   }
 
   Map<String, dynamic> _convertJsRecordToMap(JSAny? jsRecord) {


### PR DESCRIPTION
Fixes #1651

## Description

The `_processError` method in `purchases_flutter_web.dart` uses `error is JSObject`, which triggers the `invalid_runtime_check_with_js_interop_types` lint. The `is` operator on JS interop types is unreliable under Wasm compilation because JS interop types are erased differently between JS and Wasm targets.

This replaces the runtime check with the Wasm-safe `isA<JSObject>()` method from `dart:js_interop` (available since Dart 3.4, and the project requires Dart >=3.6.0).

- [x] A description about what and why you are contributing, even if it's trivial.
- [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.
- [x] If applicable, unit tests.

## Changes

**`lib/web/purchases_flutter_web.dart`**
- Cast `error` to `JSAny?` before checking
- Replace `error is JSObject` with `jsAny.isA<JSObject>()`
- Extract `jsObject` via `jsAny as JSObject` after the `isA` confirmation
- No new imports needed (`dart:js_interop` is already imported)
- Identical runtime behavior to the original code

**`CHANGELOG.md`**
- Added bugfix entry under 9.14.0

## Test plan

- [x] `dart format .` — clean
- [x] `flutter analyze lib` — passes with no issues (the `invalid_runtime_check_with_js_interop_types` warning is gone)
- [x] `flutter test` — all 134 tests pass
- [x] `cd revenuecat_examples/purchase_tester && flutter build web` — web build verification
- [x] `cd revenuecat_examples/purchase_tester && flutter build web --wasm` — Wasm build verification
- [ ] CI: `bundle exec fastlane run_api_tests` — no public API changes (requires CI environment)

## Why no new unit tests

`_processError` is a private method that uses `dart:js_interop` types requiring a web runtime. The repo has no web-platform test infrastructure (`flutter test --platform chrome`), and the change is a mechanical replacement of one pattern with its Wasm-safe equivalent. `flutter analyze` statically catches the lint if it regresses. Adding web test infra would be out of scope for this bugfix.