### PR TITLE
[EXTERNAL] Fix Wasm incompatibility in web error processing (#1684) contributed by @brunovsiqueira

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,9 +153,6 @@ This release updates to Billing Library 8.3.0 with min SDK supported of Android 
 ### ✨ New Features
 * Add setAppstackAttributionParams API (#1671) via Rick (@rickvdl)
 
-### 🐞 Bugfixes
-* Fix Wasm incompatibility: replace `is JSObject` runtime check with `isA<JSObject>()` in web error processing (#1651)
-
 ## 9.13.2
 ## RevenueCat SDK
 ### 📦 Dependency Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,9 @@ This release updates to Billing Library 8.3.0 with min SDK supported of Android 
 ### ✨ New Features
 * Add setAppstackAttributionParams API (#1671) via Rick (@rickvdl)
 
+### 🐞 Bugfixes
+* Fix Wasm incompatibility: replace `is JSObject` runtime check with `isA<JSObject>()` in web error processing (#1651)
+
 ## 9.13.2
 ## RevenueCat SDK
 ### 📦 Dependency Updates

--- a/lib/web/purchases_flutter_web.dart
+++ b/lib/web/purchases_flutter_web.dart
@@ -453,7 +453,15 @@ class PurchasesFlutterPlugin {
   ];
 
   PlatformException _processError(dynamic error) {
-    final jsAny = error as JSAny?;
+    // Under dart2wasm, `error` may be a Dart exception or an opaque
+    // _JavaScriptError—neither is a subtype of JSAny, so the cast throws
+    // a TypeError. Catching it lets us fall through to the generic branch.
+    JSAny? jsAny;
+    try {
+      jsAny = error as JSAny?;
+    } on TypeError catch (e) {
+      debugPrint('Warning: error in _processError is not a JS interop type: $e');
+    }
     if (jsAny != null && jsAny.isA<JSObject>()) {
       final jsObject = jsAny as JSObject;
       if (jsObject.has('code')) {

--- a/lib/web/purchases_flutter_web.dart
+++ b/lib/web/purchases_flutter_web.dart
@@ -453,23 +453,26 @@ class PurchasesFlutterPlugin {
   ];
 
   PlatformException _processError(dynamic error) {
-    if (error is JSObject && error.has('code')) {
-      final errorMap = _convertJsRecordToMap(error);
-      final code = errorMap['code'];
-      final message = errorMap['message'];
-      final underlyingErrorMessage = errorMap['underlyingErrorMessage'];
-      final finalMessage = '$message. $underlyingErrorMessage';
-      return PlatformException(
-        code: '$code',
-        message: finalMessage,
-        details: errorMap,
-      );
-    } else {
-      return PlatformException(
-        code: _unknownErrorCode,
-        message: error.toString(),
-      );
+    final jsAny = error as JSAny?;
+    if (jsAny != null && jsAny.isA<JSObject>()) {
+      final jsObject = jsAny as JSObject;
+      if (jsObject.has('code')) {
+        final errorMap = _convertJsRecordToMap(jsObject);
+        final code = errorMap['code'];
+        final message = errorMap['message'];
+        final underlyingErrorMessage = errorMap['underlyingErrorMessage'];
+        final finalMessage = '$message. $underlyingErrorMessage';
+        return PlatformException(
+          code: '$code',
+          message: finalMessage,
+          details: errorMap,
+        );
+      }
     }
+    return PlatformException(
+      code: _unknownErrorCode,
+      message: error.toString(),
+    );
   }
 
   Map<String, dynamic> _convertJsRecordToMap(JSAny? jsRecord) {


### PR DESCRIPTION
Fixes #1651

## Description

The `_processError` method in `purchases_flutter_web.dart` uses `error is JSObject`, which triggers the
`invalid_runtime_check_with_js_interop_types` lint. The `is` operator on JS interop types is unreliable under Wasm compilation because JS interop types are erased differently between JS and Wasm targets.

This replaces the runtime check with the Wasm-safe `isA<JSObject>()` method from `dart:js_interop` (available since Dart 3.4, and the project requires Dart >=3.6.0).

- [x] A description about what and why you are contributing, even if it's trivial.
- [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.
- [x] If applicable, unit tests.

## Changes

**`lib/web/purchases_flutter_web.dart`**
- Cast `error` to `JSAny?` before checking
- Replace `error is JSObject` with `jsAny.isA<JSObject>()`
- Extract `jsObject` via `jsAny as JSObject` after the `isA` confirmation
- No new imports needed (`dart:js_interop` is already imported)
- Identical runtime behavior to the original code

**`CHANGELOG.md`**
- Added bugfix entry under 9.14.0

## Test plan

- [x] `dart format .` — clean
- [x] `flutter analyze lib` — passes with no issues (the `invalid_runtime_check_with_js_interop_types` warning is gone)
- [x] `flutter test` — all 134 tests pass
- [x] `cd revenuecat_examples/purchase_tester && flutter build web` — web build verification
- [x] `cd revenuecat_examples/purchase_tester && flutter build web --wasm` — Wasm build verification
- [ ] CI: `bundle exec fastlane run_api_tests` — no public API changes (requires CI environment)

## Why no new unit tests

`_processError` is a private method that uses `dart:js_interop` types requiring a web runtime. The repo has no web-platform test infrastructure (`flutter test --platform chrome`), and the change is a mechanical replacement of one pattern with its Wasm-safe equivalent. `flutter analyze` statically catches the lint if it regresses. Adding web test infra would be out of scope for this bugfix.

Contributed by @brunovsiqueira in #1684 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: localized change to web error handling that only affects how JS interop errors are detected/converted, with a safe fallback to the existing unknown-error path.
> 
> **Overview**
> Fixes web/Wasm incompatibility in `_processError` by avoiding `is JSObject` checks and instead attempting a `JSAny` cast and using `isA<JSObject>()` for JS interop type detection.
> 
> If the error isn’t a JS interop value (e.g., under `dart2wasm`), the code now catches the cast `TypeError`, logs a warning via `debugPrint`, and falls back to returning an `unknown` `PlatformException`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b05d3a957ce45e94b3fd93e89afd537944b9cd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->