### PR TITLE
Add web SDK to release automations

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -58,12 +58,14 @@ lane :bump do |options|
     automatic_release: options[:automatic_release],
     hybrid_common_version: phc_version,
     versions_file_path: versions_path,
-    is_prerelease: options[:is_prerelease]
+    is_prerelease: options[:is_prerelease],
+    include_purchases_js: true
   )
   update_hybrids_versions_file(
     versions_file_path: versions_path,
     new_sdk_version: current_version_number,
-    hybrid_common_version: phc_version
+    hybrid_common_version: phc_version,
+    include_purchases_js: true
   )
   commit_current_changes(commit_message: 'Update VERSIONS.md')
   push_to_git_remote(set_upstream: true)


### PR DESCRIPTION
We added extra automations to add the purchases-js version to the CHANGELOG.md and VERSIONS.md files. This enables them for this repo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts release automation parameters to include an additional SDK when generating/updating changelog and versions metadata.
> 
> **Overview**
> Release automation now opts into including the `purchases-js` web SDK when running the `bump` lane.
> 
> This passes `include_purchases_js: true` through to `bump_version_update_changelog_create_pr` and `update_hybrids_versions_file`, so `CHANGELOG.md`/`VERSIONS.md` updates can incorporate the web SDK version during version bumps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48cd608f6391dc238c091efefebedaf1c9e15fed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->