### PR TITLE
Expose RevenueCatUI layout direction opt-in

### DIFF
--- a/CHANGELOG-LATEST.md
+++ b/CHANGELOG-LATEST.md
@@ -1,4 +1,7 @@
 ## RevenueCat SDK
+### ✨ New Features
+* `RevenueCatUI` Paywalls and Customer Center can now opt in to matching right-to-left layout when overriding the preferred UI locale by setting `preferredUILocaleOverrideHonorsLayoutDirection` at configure time or `honorLayoutDirection` at runtime. The default remains false to preserve existing layout behavior.
+
 ### 🐞 Bugfixes
 * [EXTERNAL] Fix Wasm incompatibility in web error processing (#1684) contributed by @brunovsiqueira (#1722) via Toni Rico (@tonidero)
 ### 📦 Dependency Updates

--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -636,7 +636,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
             Purchases purchases = Purchases.getSharedInstance();
             Purchases.class
                     .getMethod("overridePreferredUILocale", String.class, boolean.class)
-                    .invoke(purchases, locale, true);
+                    .invoke(purchases, locale, honorLayoutDirection);
         } catch (Exception ignored) {
             CommonKt.overridePreferredLocale(locale);
         }

--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -428,7 +428,9 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
 
             if (preferredUILocaleOverrideHonorsLayoutDirection != null &&
                     preferredUILocaleOverrideHonorsLayoutDirection) {
-                overridePreferredUILocaleIfNeeded(preferredUILocaleOverride, true);
+                overridePreferredUILocaleIfNeeded(
+                        preferredUILocaleOverride,
+                        preferredUILocaleOverrideHonorsLayoutDirection);
             }
             setUpdatedCustomerInfoListener();
             result.success(null);

--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -125,11 +125,13 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                         .argument("automaticDeviceIdentifierCollectionEnabled");
                 Boolean diagnosticsEnabled = call.argument("diagnosticsEnabled");
                 String preferredUILocaleOverride = call.argument("preferredUILocaleOverride");
+                Boolean preferredUILocaleOverrideHonorsLayoutDirection =
+                        call.argument("preferredUILocaleOverrideHonorsLayoutDirection");
                 setupPurchases(apiKey, appUserId, purchasesAreCompletedBy, useAmazon,
                         shouldShowInAppMessagesAutomatically, verificationMode,
                         pendingTransactionsForPrepaidPlansEnabled,
                         automaticDeviceIdentifierCollectionEnabled, diagnosticsEnabled,
-                        preferredUILocaleOverride, result);
+                        preferredUILocaleOverride, preferredUILocaleOverrideHonorsLayoutDirection, result);
                 break;
             case "setAllowSharingStoreAccount":
                 Boolean allowSharing = call.argument("allowSharing");
@@ -213,7 +215,8 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 break;
             case "overridePreferredUILocale":
                 String locale = call.argument("locale");
-                overridePreferredUILocale(locale, result);
+                Boolean honorLayoutDirection = call.argument("honorLayoutDirection");
+                overridePreferredUILocale(locale, honorLayoutDirection, result);
                 break;
             case "getCustomerInfo":
                 getCustomerInfo(result);
@@ -400,6 +403,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
             @Nullable Boolean automaticDeviceIdentifierCollectionEnabled,
             @Nullable Boolean diagnosticsEnabled,
             @Nullable String preferredUILocaleOverride,
+            @Nullable Boolean preferredUILocaleOverrideHonorsLayoutDirection,
             final Result result) {
         if (this.applicationContext != null) {
             PlatformInfo platformInfo = new PlatformInfo(PLATFORM_NAME, PLUGIN_VERSION);
@@ -422,6 +426,10 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                     automaticDeviceIdentifierCollectionEnabled,
                     preferredUILocaleOverride);
 
+            if (preferredUILocaleOverrideHonorsLayoutDirection != null &&
+                    preferredUILocaleOverrideHonorsLayoutDirection) {
+                overridePreferredUILocaleIfNeeded(preferredUILocaleOverride, true);
+            }
             setUpdatedCustomerInfoListener();
             result.success(null);
         } else {
@@ -609,9 +617,29 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
         result.success(null);
     }
 
-    private void overridePreferredUILocale(@Nullable String locale, final Result result) {
-        CommonKt.overridePreferredLocale(locale);
+    private void overridePreferredUILocale(
+            @Nullable String locale,
+            @Nullable Boolean honorLayoutDirection,
+            final Result result
+    ) {
+        overridePreferredUILocaleIfNeeded(locale, honorLayoutDirection != null && honorLayoutDirection);
         result.success(null);
+    }
+
+    private void overridePreferredUILocaleIfNeeded(@Nullable String locale, boolean honorLayoutDirection) {
+        if (!honorLayoutDirection) {
+            CommonKt.overridePreferredLocale(locale);
+            return;
+        }
+
+        try {
+            Purchases purchases = Purchases.getSharedInstance();
+            Purchases.class
+                    .getMethod("overridePreferredUILocale", String.class, boolean.class)
+                    .invoke(purchases, locale, true);
+        } catch (Exception ignored) {
+            CommonKt.overridePreferredLocale(locale);
+        }
     }
 
     private void getCustomerInfo(final Result result) {

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -182,6 +182,10 @@ class _PurchasesFlutterApiTest {
   void _checkOverridePreferredUILocale() async {
     String locale = "en-US";
     Future<void> future = Purchases.overridePreferredUILocale(locale);
+    Future<void> futureWithLayoutDirection = Purchases.overridePreferredUILocale(
+      locale,
+      honorLayoutDirection: true,
+    );
   }
 
   void _checkLogIn() async {

--- a/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
+++ b/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
@@ -331,7 +331,7 @@ preferredUILocaleOverrideHonorsLayoutDirection:(BOOL)preferredUILocaleOverrideHo
 
     if (preferredUILocaleOverrideHonorsLayoutDirection) {
         [self overridePreferredUILocale:preferredUILocaleOverride
-                   honorLayoutDirection:YES];
+                   honorLayoutDirection:preferredUILocaleOverrideHonorsLayoutDirection];
     }
 
     result(nil);

--- a/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
+++ b/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
@@ -64,6 +64,11 @@ NSString *PurchasesLogHandlerEvent = @"Purchases-LogHandlerEvent";
         NSString * _Nullable userDefaultsSuiteName = arguments[@"userDefaultsSuiteName"];
         NSString *storeKitVersion = arguments[@"storeKitVersion"];
         NSString * _Nullable preferredUILocaleOverride = arguments[@"preferredUILocaleOverride"];
+        BOOL preferredUILocaleOverrideHonorsLayoutDirection = NO;
+        object = arguments[@"preferredUILocaleOverrideHonorsLayoutDirection"];
+        if (object != [NSNull null] && object != nil) {
+            preferredUILocaleOverrideHonorsLayoutDirection = [object boolValue];
+        }
         BOOL automaticDeviceIdentifierCollectionEnabled = YES;
         object = arguments[@"automaticDeviceIdentifierCollectionEnabled"];
         if (object != [NSNull null] && object != nil) {
@@ -84,6 +89,7 @@ shouldShowInAppMessagesAutomatically: shouldShowInAppMessagesAutomatically
 automaticDeviceIdentifierCollectionEnabled:automaticDeviceIdentifierCollectionEnabled
           diagnosticsEnabled:diagnosticsEnabled
    preferredUILocaleOverride:preferredUILocaleOverride
+preferredUILocaleOverrideHonorsLayoutDirection:preferredUILocaleOverrideHonorsLayoutDirection
                       result:result];
     } else if ([@"setAllowSharingStoreAccount" isEqualToString:call.method]) {
         [self setAllowSharingStoreAccount:[arguments[@"allowSharing"] boolValue] result:result];
@@ -126,7 +132,9 @@ automaticDeviceIdentifierCollectionEnabled:automaticDeviceIdentifierCollectionEn
     } else if ([@"setProxyURLString" isEqualToString:call.method]) {
         [self setProxyURLString:arguments[@"proxyURLString"] result:result];
     } else if ([@"overridePreferredUILocale" isEqualToString:call.method]) {
-        [self overridePreferredUILocale:arguments[@"locale"] result:result];
+        [self overridePreferredUILocale:arguments[@"locale"]
+                   honorLayoutDirection:[arguments[@"honorLayoutDirection"] boolValue]
+                                 result:result];
     } else if ([@"getCustomerInfo" isEqualToString:call.method]) {
         [self getCustomerInfoWithResult:result];
     } else if ([@"syncPurchases" isEqualToString:call.method]) {
@@ -296,6 +304,7 @@ shouldShowInAppMessagesAutomatically:(BOOL)shouldShowInAppMessagesAutomatically
 automaticDeviceIdentifierCollectionEnabled:(BOOL)automaticDeviceIdentifierCollectionEnabled
     diagnosticsEnabled:(BOOL)diagnosticsEnabled
  preferredUILocaleOverride:(nullable NSString *)preferredUILocaleOverride
+preferredUILocaleOverrideHonorsLayoutDirection:(BOOL)preferredUILocaleOverrideHonorsLayoutDirection
                 result:(FlutterResult)result {
     if ([appUserID isKindOfClass:NSNull.class]) {
         appUserID = nil;
@@ -319,6 +328,11 @@ automaticDeviceIdentifierCollectionEnabled:(BOOL)automaticDeviceIdentifierCollec
                                               preferredLocale:preferredUILocaleOverride.mappingNSNullToNil];
 
     purchases.delegate = self;
+
+    if (preferredUILocaleOverrideHonorsLayoutDirection) {
+        [self overridePreferredUILocale:preferredUILocaleOverride
+                   honorLayoutDirection:YES];
+    }
 
     result(nil);
 }
@@ -439,9 +453,41 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
 }
 
 - (void)overridePreferredUILocale:(nullable NSString *)locale
+             honorLayoutDirection:(BOOL)honorLayoutDirection
                            result:(FlutterResult)result {
-    [RCCommonFunctionality overridePreferredLocale:locale.mappingNSNullToNil];
+    [self overridePreferredUILocale:locale
+               honorLayoutDirection:honorLayoutDirection];
     result(nil);
+}
+
+- (void)overridePreferredUILocale:(nullable NSString *)locale
+             honorLayoutDirection:(BOOL)honorLayoutDirection {
+    if (!honorLayoutDirection) {
+        [RCCommonFunctionality overridePreferredLocale:locale.mappingNSNullToNil];
+        return;
+    }
+
+    if (!RCPurchases.isConfigured) {
+        [RCCommonFunctionality overridePreferredLocale:locale.mappingNSNullToNil];
+        return;
+    }
+
+    RCPurchases *purchases = RCPurchases.sharedPurchases;
+    SEL selector = NSSelectorFromString(@"overridePreferredUILocale:honorLayoutDirection:");
+    if (![purchases respondsToSelector:selector]) {
+        [RCCommonFunctionality overridePreferredLocale:locale.mappingNSNullToNil];
+        return;
+    }
+
+    NSMethodSignature *signature = [purchases methodSignatureForSelector:selector];
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+    NSString *localeArgument = locale.mappingNSNullToNil;
+    BOOL honorLayoutDirectionArgument = YES;
+    invocation.target = purchases;
+    invocation.selector = selector;
+    [invocation setArgument:&localeArgument atIndex:2];
+    [invocation setArgument:&honorLayoutDirectionArgument atIndex:3];
+    [invocation invoke];
 }
 
 - (void)setSimulatesAskToBuyInSandbox:(BOOL)enabled

--- a/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
+++ b/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
@@ -482,7 +482,7 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
     NSMethodSignature *signature = [purchases methodSignatureForSelector:selector];
     NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
     NSString *localeArgument = locale.mappingNSNullToNil;
-    BOOL honorLayoutDirectionArgument = YES;
+    BOOL honorLayoutDirectionArgument = honorLayoutDirection;
     invocation.target = purchases;
     invocation.selector = selector;
     [invocation setArgument:&localeArgument atIndex:2];

--- a/lib/models/purchases_configuration.dart
+++ b/lib/models/purchases_configuration.dart
@@ -13,6 +13,12 @@ class PurchasesConfiguration {
   /// Both "es-ES" and "es_ES" formats are supported.
   String? preferredUILocaleOverride;
 
+  /// Whether RevenueCat UI components should also derive layout direction
+  /// from [preferredUILocaleOverride].
+  ///
+  /// Defaults to false to preserve existing layout behavior.
+  bool preferredUILocaleOverrideHonorsLayoutDirection = false;
+
   /// An optional unique id for identifying the user.
   String? appUserID;
 

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -188,6 +188,8 @@ class Purchases {
         'diagnosticsEnabled': purchasesConfiguration.diagnosticsEnabled,
         'preferredUILocaleOverride':
             purchasesConfiguration.preferredUILocaleOverride,
+        'preferredUILocaleOverrideHonorsLayoutDirection':
+            purchasesConfiguration.preferredUILocaleOverrideHonorsLayoutDirection,
       },
     );
   }
@@ -200,11 +202,17 @@ class Purchases {
   /// Pass null to revert to the system default.
   ///
   /// [locale] The locale identifier (e.g., "de-DE", "es_ES") or null to use the system default.
-  static Future<void> overridePreferredUILocale(String? locale) =>
+  /// [honorLayoutDirection] Whether RevenueCat UI components should also derive layout direction
+  /// from [locale]. Defaults to false to preserve existing layout behavior.
+  static Future<void> overridePreferredUILocale(
+    String? locale, {
+    bool honorLayoutDirection = false,
+  }) =>
       _channel.invokeMethod(
         'overridePreferredUILocale',
         {
           'locale': locale,
+          'honorLayoutDirection': honorLayoutDirection,
         },
       );
 

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -103,6 +103,7 @@ void main() {
             'automaticDeviceIdentifierCollectionEnabled': true,
             'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
+            'preferredUILocaleOverrideHonorsLayoutDirection': false,
           },
         ),
       ],
@@ -135,6 +136,7 @@ void main() {
             'automaticDeviceIdentifierCollectionEnabled': true,
             'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
+            'preferredUILocaleOverrideHonorsLayoutDirection': false,
           },
         ),
       ],
@@ -165,6 +167,7 @@ void main() {
             'automaticDeviceIdentifierCollectionEnabled': true,
             'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
+            'preferredUILocaleOverrideHonorsLayoutDirection': false,
           },
         ),
       ],
@@ -198,6 +201,7 @@ void main() {
             'automaticDeviceIdentifierCollectionEnabled': true,
             'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
+            'preferredUILocaleOverrideHonorsLayoutDirection': false,
           },
         ),
       ],
@@ -1657,6 +1661,7 @@ void main() {
             'automaticDeviceIdentifierCollectionEnabled': true,
             'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
+            'preferredUILocaleOverrideHonorsLayoutDirection': false,
           },
         ),
       ],
@@ -1688,6 +1693,7 @@ void main() {
             'automaticDeviceIdentifierCollectionEnabled': true,
             'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
+            'preferredUILocaleOverrideHonorsLayoutDirection': false,
           },
         ),
       ],
@@ -1720,6 +1726,7 @@ void main() {
             'automaticDeviceIdentifierCollectionEnabled': true,
             'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
+            'preferredUILocaleOverrideHonorsLayoutDirection': false,
           },
         ),
       ],
@@ -1753,6 +1760,7 @@ void main() {
             'automaticDeviceIdentifierCollectionEnabled': true,
             'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
+            'preferredUILocaleOverrideHonorsLayoutDirection': false,
           },
         ),
       ],
@@ -1783,6 +1791,7 @@ void main() {
             'automaticDeviceIdentifierCollectionEnabled': false,
             'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
+            'preferredUILocaleOverrideHonorsLayoutDirection': false,
           },
         ),
       ],
@@ -1813,6 +1822,39 @@ void main() {
             'automaticDeviceIdentifierCollectionEnabled': true,
             'diagnosticsEnabled': false,
             'preferredUILocaleOverride': 'de_DE',
+            'preferredUILocaleOverrideHonorsLayoutDirection': false,
+          },
+        ),
+      ],
+    );
+  });
+
+  test('configure with preferredUILocaleOverrideHonorsLayoutDirection', () async {
+    await Purchases.configure(
+      PurchasesConfiguration('api_key')
+        ..appUserID = 'cesar'
+        ..preferredUILocaleOverride = 'ar_SA'
+        ..preferredUILocaleOverrideHonorsLayoutDirection = true,
+    );
+    expect(
+      log,
+      <Matcher>[
+        isMethodCall(
+          'setupPurchases',
+          arguments: <String, dynamic>{
+            'apiKey': 'api_key',
+            'appUserId': 'cesar',
+            'purchasesAreCompletedBy': 'REVENUECAT',
+            'userDefaultsSuiteName': null,
+            'storeKitVersion': 'DEFAULT',
+            'useAmazon': false,
+            'shouldShowInAppMessagesAutomatically': true,
+            'entitlementVerificationMode': 'DISABLED',
+            'pendingTransactionsForPrepaidPlansEnabled': false,
+            'automaticDeviceIdentifierCollectionEnabled': true,
+            'diagnosticsEnabled': false,
+            'preferredUILocaleOverride': 'ar_SA',
+            'preferredUILocaleOverrideHonorsLayoutDirection': true,
           },
         ),
       ],
@@ -1843,6 +1885,7 @@ void main() {
             'automaticDeviceIdentifierCollectionEnabled': true,
             'diagnosticsEnabled': true,
             'preferredUILocaleOverride': null,
+            'preferredUILocaleOverrideHonorsLayoutDirection': false,
           },
         ),
       ],
@@ -1858,6 +1901,26 @@ void main() {
           'overridePreferredUILocale',
           arguments: <String, dynamic>{
             'locale': 'es-ES',
+            'honorLayoutDirection': false,
+          },
+        ),
+      ],
+    );
+  });
+
+  test('overridePreferredUILocale with honorLayoutDirection', () async {
+    await Purchases.overridePreferredUILocale(
+      'he',
+      honorLayoutDirection: true,
+    );
+    expect(
+      log,
+      <Matcher>[
+        isMethodCall(
+          'overridePreferredUILocale',
+          arguments: <String, dynamic>{
+            'locale': 'he',
+            'honorLayoutDirection': true,
           },
         ),
       ],
@@ -1873,6 +1936,7 @@ void main() {
           'overridePreferredUILocale',
           arguments: <String, dynamic>{
             'locale': null,
+            'honorLayoutDirection': false,
           },
         ),
       ],


### PR DESCRIPTION
## Summary
- add preferredUILocaleOverrideHonorsLayoutDirection to Flutter configuration, defaulting false
- add honorLayoutDirection to overridePreferredUILocale runtime API, defaulting false
- bridge the flag to native SDKs with backward-compatible fallbacks
- add tests, API tester usage, and changelog entry

## Tests
- flutter test test/purchases_flutter_test.dart

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new configuration and runtime flags that alter how RevenueCat UI derives layout direction, plus native bridging via reflection/selector invocation that could behave differently across SDK versions.
> 
> **Overview**
> Adds an opt-in to have RevenueCat UI components match right-to-left layout direction when overriding the preferred UI locale.
> 
> Flutter API now supports `preferredUILocaleOverrideHonorsLayoutDirection` on `PurchasesConfiguration` (sent during `configure`) and an `honorLayoutDirection` option on `Purchases.overridePreferredUILocale`; Android/iOS bridge these to the native SDK using backward-compatible fallbacks when the newer native methods aren’t available. Updates API tester usage, unit tests, and the changelog entry accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 938889e788327e63e5943889287de6b717b81dd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->