### PR TITLE
Replace unauthenticated SDKMAN install with SHA-pinned orb command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ aliases:
 orbs:
   android: circleci/android@2.5.0
   swissknife: roopakv/swissknife@0.65.0
-  revenuecat: revenuecat/sdks-common-config@3.16.0
+  revenuecat: revenuecat/sdks-common-config@3.20.0
   macos: circleci/macos@2.3.2
   flutter: circleci/flutter@2.1.0
   ruby: circleci/ruby@2.5.3
@@ -145,21 +145,9 @@ commands:
           command: xcrun simctl create '<< parameters.sim-name >>' com.apple.CoreSimulator.SimDeviceType.<< parameters.sim-device-type >> com.apple.CoreSimulator.SimRuntime.<< parameters.sim-device-runtime >>
 
   install-sdkman:
-    description: Install SDKMAN
-    parameters:
-      root:
-        type: string
-        default: /root
+    description: Install SDKMAN and set up Java environment
     steps:
-      - run:
-          name: Installing SDKMAN
-          command: |
-            if curl -s "https://get.sdkman.io?rcupdate=false" | bash; then
-              echo -e '\nsource "<< parameters.root >>/.sdkman/bin/sdkman-init.sh"' >> $BASH_ENV
-              source $BASH_ENV
-            else
-              echo "Error installing SDKMAN, continuing with default Java" >&2
-            fi
+      - revenuecat/install-sdkman
       - run:
           name: Setup Java environment
           command: |
@@ -343,8 +331,7 @@ jobs:
     steps:
       - checkout
       - replace-api-key
-      - install-sdkman:
-          root: /home/circleci
+      - install-sdkman
       - android/create-avd:
           avd-name: integration-tests
           system-image: system-images;android-33;google_apis;x86_64


### PR DESCRIPTION
Bumps `revenuecat/sdks-common-config` to `3.20.0` and replaces the local `install-sdkman` command (which used unauthenticated `curl https://get.sdkman.io | bash`) with the new `revenuecat/install-sdkman` orb command, which pins SDKMAN to a SHA256-verified GitHub release.

Mirrors the pattern from [sdks-circleci-orb#55](https://github.com/RevenueCat/sdks-circleci-orb/pull/55).

The prior soft-fail wrapper around the SDKMAN install ("continuing with default Java") is dropped — the orb command intentionally fails hard on a SHA-256 mismatch, which is the security guarantee. The downstream `sdk env install` Java setup is preserved as its own run-step at each invocation site, with its existing soft-fail kept intact. The local command's `root` parameter is also dropped: the orb command auto-resolves `SDKMAN_DIR` to `$HOME/.sdkman`, which matches both the previous default (`/root`) for docker-as-root executors and the explicit `/home/circleci` for the machine executor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI bootstrap for Java/SDKMAN across multiple jobs; failures could break builds/tests, but the change is scoped to pipeline configuration and improves supply-chain security.
> 
> **Overview**
> Upgrades the `revenuecat/sdks-common-config` CircleCI orb from `3.16.0` to `3.20.0`.
> 
> Replaces the custom `install-sdkman` implementation (previously `curl | bash` with a configurable `root`) with `revenuecat/install-sdkman`, and updates job invocations to use the simplified command while keeping the subsequent `sdk env install` Java setup step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30538a44ea72b566a7c30a4a162dfcf994945966. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->