### PR TITLE
Remove test API key from test app constants

### DIFF
--- a/revenuecat_examples/purchase_tester/lib/src/constant.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/constant.dart
@@ -1,5 +1,5 @@
 //TO DO: add the Apple API key for your app from the RevenueCat dashboard: https://app.revenuecat.com
-const appleApiKey = 'appl_SYkbbYptqjDadVkQeBUtXxVxCcw';
+const appleApiKey = 'appl_api_key';
 
 //TO DO: add the Google API key for your app from the RevenueCat dashboard: https://app.revenuecat.com
 const googleApiKey = 'googl_api_key';


### PR DESCRIPTION
The example app's `constant.dart` was committed with a test API key. This PR restores the placeholder.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only replaces a hardcoded test Apple API key in the example app with the generic placeholder, with no functional logic changes beyond requiring local configuration for Apple testing.
> 
> **Overview**
> Removes a committed RevenueCat Apple API key from the `purchase_tester` example by restoring the `appleApiKey` placeholder value in `constant.dart`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 989e22928bc5ef325ab998f1b6f063d7d39f7771. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->