### PR TITLE
Add presentedOfferingContext support to custom paywall impression events

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -384,9 +384,13 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
             case "getCachedVirtualCurrencies":
                 getCachedVirtualCurrencies(result);
                 break;
-            case "trackCustomPaywallImpression":
-                trackCustomPaywallImpression(call.arguments(), result);
+            case "trackCustomPaywallImpression": {
+                Map<String, Object> arguments = call.arguments();
+                trackCustomPaywallImpression(
+                        arguments != null ? arguments : new HashMap<>(),
+                        result);
                 break;
+            }
             case "trackAdDisplayed":
                 trackAdDisplayed(call.arguments(), result);
                 break;
@@ -883,14 +887,46 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
     }
 
     private void trackCustomPaywallImpression(Map<String, Object> arguments, final Result result) {
-        HashMap<String, Object> data = new HashMap<>();
-        for (Map.Entry<String, Object> entry : arguments.entrySet()) {
-            if (entry.getValue() != null) {
-                data.put(entry.getKey(), entry.getValue());
+        CommonKt.trackCustomPaywallImpression(mapWithoutNullValues(arguments));
+        result.success(null);
+    }
+
+    private static HashMap<String, Object> mapWithoutNullValues(@Nullable Map<String, Object> map) {
+        HashMap<String, Object> filteredMap = new HashMap<>();
+        if (map != null) {
+            for (Map.Entry<String, Object> entry : map.entrySet()) {
+                Object value = valueWithoutNullValues(entry.getValue());
+                if (value != null) {
+                    filteredMap.put(entry.getKey(), value);
+                }
             }
         }
-        CommonKt.trackCustomPaywallImpression(data);
-        result.success(null);
+        return filteredMap;
+    }
+
+    private static Object valueWithoutNullValues(@Nullable Object value) {
+        if (value instanceof Map) {
+            HashMap<String, Object> filteredMap = new HashMap<>();
+            Map<?, ?> originalMap = (Map<?, ?>) value;
+            for (Map.Entry<?, ?> entry : originalMap.entrySet()) {
+                Object filteredValue = valueWithoutNullValues(entry.getValue());
+                if (entry.getKey() instanceof String && filteredValue != null) {
+                    filteredMap.put((String) entry.getKey(), filteredValue);
+                }
+            }
+            return filteredMap;
+        }
+        if (value instanceof List) {
+            ArrayList<Object> filteredList = new ArrayList<>();
+            for (Object item : (List<?>) value) {
+                Object filteredItem = valueWithoutNullValues(item);
+                if (filteredItem != null) {
+                    filteredList.add(filteredItem);
+                }
+            }
+            return filteredList;
+        }
+        return value;
     }
 
     private void trackAdDisplayed(Map<String, Object> arguments, final Result result) {

--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -887,17 +887,17 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
     }
 
     private void trackCustomPaywallImpression(Map<String, Object> arguments, final Result result) {
-        CommonKt.trackCustomPaywallImpression(mapWithoutNullValues(arguments));
+        CommonKt.trackCustomPaywallImpression(stringKeyedMapWithoutNullValues(arguments));
         result.success(null);
     }
 
-    private static HashMap<String, Object> mapWithoutNullValues(@Nullable Map<String, Object> map) {
+    private static HashMap<String, Object> stringKeyedMapWithoutNullValues(@Nullable Map<?, ?> map) {
         HashMap<String, Object> filteredMap = new HashMap<>();
         if (map != null) {
-            for (Map.Entry<String, Object> entry : map.entrySet()) {
-                Object value = valueWithoutNullValues(entry.getValue());
-                if (value != null) {
-                    filteredMap.put(entry.getKey(), value);
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                Object filteredValue = valueWithoutNullValues(entry.getValue());
+                if (entry.getKey() instanceof String && filteredValue != null) {
+                    filteredMap.put((String) entry.getKey(), filteredValue);
                 }
             }
         }
@@ -906,15 +906,7 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
 
     private static Object valueWithoutNullValues(@Nullable Object value) {
         if (value instanceof Map) {
-            HashMap<String, Object> filteredMap = new HashMap<>();
-            Map<?, ?> originalMap = (Map<?, ?>) value;
-            for (Map.Entry<?, ?> entry : originalMap.entrySet()) {
-                Object filteredValue = valueWithoutNullValues(entry.getValue());
-                if (entry.getKey() instanceof String && filteredValue != null) {
-                    filteredMap.put((String) entry.getKey(), filteredValue);
-                }
-            }
-            return filteredMap;
+            return stringKeyedMapWithoutNullValues((Map<?, ?>) value);
         }
         if (value instanceof List) {
             ArrayList<Object> filteredList = new ArrayList<>();

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -795,6 +795,12 @@ class _PurchasesFlutterApiTest {
     CustomPaywallImpressionParams paramsWithOffering =
         CustomPaywallImpressionParams(offering: offering);
 
+    CustomPaywallImpressionParams paramsWithPaywallIdAndOffering =
+        CustomPaywallImpressionParams(
+      paywallId: 'test',
+      offering: offering,
+    );
+
     CustomPaywallImpressionParams paramsWithOfferingId =
         const CustomPaywallImpressionParams(offeringId: 'offering');
 

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -754,6 +754,15 @@ class _PurchasesFlutterApiTest {
     );
   }
 
+  void _checkTrackCustomPaywallImpressionWithOffering(Offering offering) {
+    Future<void> future = Purchases.trackCustomPaywallImpression(
+      params: CustomPaywallImpressionParams(
+        paywallId: 'my-paywall',
+        offering: offering,
+      ),
+    );
+  }
+
   void _checkTrackCustomPaywallImpressionWithBothParams() {
     Future<void> future = Purchases.trackCustomPaywallImpression(
       params: const CustomPaywallImpressionParams(
@@ -763,16 +772,20 @@ class _PurchasesFlutterApiTest {
     );
   }
 
-  void _checkCustomPaywallImpressionParams() {
+  void _checkCustomPaywallImpressionParams(Offering offering) {
     CustomPaywallImpressionParams params =
         const CustomPaywallImpressionParams();
     String? paywallId = params.paywallId;
+    Offering? optionalOffering = params.offering;
     String? offeringId = params.offeringId;
 
     CustomPaywallImpressionParams paramsWithId =
         const CustomPaywallImpressionParams(paywallId: 'test');
 
     CustomPaywallImpressionParams paramsWithOffering =
+        CustomPaywallImpressionParams(offering: offering);
+
+    CustomPaywallImpressionParams paramsWithOfferingId =
         const CustomPaywallImpressionParams(offeringId: 'offering');
 
     CustomPaywallImpressionParams paramsWithBoth =

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -742,6 +742,10 @@ class _PurchasesFlutterApiTest {
     Future<void> future = Purchases.trackCustomPaywallImpression();
   }
 
+  void _checkTrackCustomPaywallImpressionWithNullParams() {
+    Future<void> future = Purchases.trackCustomPaywallImpression(params: null);
+  }
+
   void _checkTrackCustomPaywallImpressionWithParams() {
     Future<void> future = Purchases.trackCustomPaywallImpression(
       params: const CustomPaywallImpressionParams(paywallId: 'my-paywall'),
@@ -781,6 +785,12 @@ class _PurchasesFlutterApiTest {
 
     CustomPaywallImpressionParams paramsWithId =
         const CustomPaywallImpressionParams(paywallId: 'test');
+
+    CustomPaywallImpressionParams paramsWithNullIds =
+        const CustomPaywallImpressionParams(
+      paywallId: null,
+      offeringId: null,
+    );
 
     CustomPaywallImpressionParams paramsWithOffering =
         CustomPaywallImpressionParams(offering: offering);

--- a/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
+++ b/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
@@ -280,7 +280,7 @@ automaticDeviceIdentifierCollectionEnabled:automaticDeviceIdentifierCollectionEn
     } else if ([@"getCachedVirtualCurrencies" isEqualToString:call.method]) {
         result([RCCommonFunctionality getCachedVirtualCurrencies]);
     } else if ([@"trackCustomPaywallImpression" isEqualToString:call.method]) {
-        [self trackCustomPaywallImpression:arguments result:result];
+        [self trackCustomPaywallImpression:arguments ?: @{} result:result];
     } else if ([@"trackAdDisplayed" isEqualToString:call.method]) {
         [self trackAdDisplayed:arguments result:result];
     } else if ([@"trackAdOpened" isEqualToString:call.method]) {
@@ -772,14 +772,7 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
 
 - (void)trackCustomPaywallImpression:(NSDictionary *)arguments result:(FlutterResult)result {
     if (@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)) {
-        NSMutableDictionary *data = [NSMutableDictionary dictionary];
-        for (NSString *key in arguments) {
-            id value = arguments[key];
-            if (value != nil && ![value isKindOfClass:[NSNull class]]) {
-                data[key] = value;
-            }
-        }
-        [RCCommonFunctionality trackCustomPaywallImpression:data];
+        [RCCommonFunctionality trackCustomPaywallImpression:[arguments mappingNSNullToNil]];
     } else {
         NSLog(@"[Purchases] Warning: tried to call trackCustomPaywallImpression, but it's only available on iOS 15.0 or greater.");
     }

--- a/lib/models/custom_paywall_impression_params.dart
+++ b/lib/models/custom_paywall_impression_params.dart
@@ -1,3 +1,5 @@
+import 'offering_wrapper.dart';
+
 /// Parameters for tracking a custom paywall impression.
 ///
 /// Use this class to provide additional context when tracking
@@ -6,12 +8,23 @@ class CustomPaywallImpressionParams {
   /// An optional identifier for the paywall being displayed.
   final String? paywallId;
 
+  /// The offering associated with the custom paywall.
+  ///
+  /// Pass the offering object so RevenueCat can track placement and targeting
+  /// context for placement-resolved offerings.
+  final Offering? offering;
+
   /// An optional identifier for the offering associated with the custom paywall.
-  /// If not provided, the SDK will use the current offering identifier from the
-  /// cache.
+  ///
+  /// Deprecated. Pass [offering] instead so RevenueCat can track placement and
+  /// targeting context.
+  @Deprecated('Use offering instead.')
   final String? offeringId;
 
-  /// Creates [CustomPaywallImpressionParams] with an optional [paywallId]
-  /// and [offeringId].
-  const CustomPaywallImpressionParams({this.paywallId, this.offeringId});
+  /// Creates [CustomPaywallImpressionParams] with optional context.
+  const CustomPaywallImpressionParams({
+    this.paywallId,
+    this.offering,
+    @Deprecated('Use offering instead.') this.offeringId,
+  });
 }

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -1447,19 +1447,45 @@ class Purchases {
   ///
   /// [params] Optional parameters for the impression. Include
   /// [CustomPaywallImpressionParams.paywallId] to identify which paywall was
-  /// shown, and [CustomPaywallImpressionParams.offeringId] to override the
-  /// offering. If [offeringId] is not provided, the SDK will use the current
-  /// offering identifier from the cache.
+  /// shown, and [CustomPaywallImpressionParams.offering] to identify the
+  /// offering and associated placement or targeting context.
+  /// [CustomPaywallImpressionParams.offeringId] is deprecated and only kept for
+  /// backwards compatibility. Pass [CustomPaywallImpressionParams.offering]
+  /// instead. If neither is provided, no offering data is sent and the native
+  /// SDK chooses the current offering.
   static Future<void> trackCustomPaywallImpression({
-    CustomPaywallImpressionParams? params,
+    CustomPaywallImpressionParams params =
+        const CustomPaywallImpressionParams(),
   }) =>
       _channel.invokeMethod(
         'trackCustomPaywallImpression',
-        {
-          'paywallId': params?.paywallId,
-          'offeringId': params?.offeringId,
-        },
+        _customPaywallImpressionData(params),
       );
+
+  static Map<String, dynamic> _customPaywallImpressionData(
+    CustomPaywallImpressionParams params,
+  ) {
+    final offering = params.offering;
+    final presentedOfferingContext =
+        offering != null && offering.availablePackages.isNotEmpty
+            ? offering.availablePackages.first.presentedOfferingContext
+            : null;
+    final paywallId = params.paywallId;
+    final offeringId = offering?.identifier ?? params.offeringId;
+    final data = <String, dynamic>{};
+
+    if (paywallId != null) {
+      data['paywallId'] = paywallId;
+    }
+    if (offeringId != null) {
+      data['offeringId'] = offeringId;
+    }
+    if (presentedOfferingContext != null) {
+      data['presentedOfferingContext'] = presentedOfferingContext.toJson();
+    }
+
+    return data;
+  }
 
   @experimental
   static final adTracker = PurchasesAdTracker._();

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -1454,8 +1454,7 @@ class Purchases {
   /// instead. If neither is provided, no offering data is sent and the native
   /// SDK chooses the current offering.
   static Future<void> trackCustomPaywallImpression({
-    CustomPaywallImpressionParams params =
-        const CustomPaywallImpressionParams(),
+    CustomPaywallImpressionParams? params,
   }) =>
       _channel.invokeMethod(
         'trackCustomPaywallImpression',
@@ -1463,15 +1462,15 @@ class Purchases {
       );
 
   static Map<String, dynamic> _customPaywallImpressionData(
-    CustomPaywallImpressionParams params,
+    CustomPaywallImpressionParams? params,
   ) {
-    final offering = params.offering;
+    final offering = params?.offering;
     final presentedOfferingContext =
         offering != null && offering.availablePackages.isNotEmpty
             ? offering.availablePackages.first.presentedOfferingContext
             : null;
-    final paywallId = params.paywallId;
-    final offeringId = offering?.identifier ?? params.offeringId;
+    final paywallId = params?.paywallId;
+    final offeringId = offering?.identifier ?? params?.offeringId;
     final data = <String, dynamic>{};
 
     if (paywallId != null) {

--- a/revenuecat_examples/purchase_tester/lib/src/custom_paywall_impression_testing_screen.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/custom_paywall_impression_testing_screen.dart
@@ -12,19 +12,39 @@ class CustomPaywallImpressionTestingScreen extends StatefulWidget {
 class _CustomPaywallImpressionTestingScreenState
     extends State<CustomPaywallImpressionTestingScreen> {
   final _paywallIdController = TextEditingController();
-  final _offeringIdController = TextEditingController();
   bool _loading = false;
   String? _status;
   String? _error;
+  String? _currentOfferingId;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadOfferings();
+  }
 
   @override
   void dispose() {
     _paywallIdController.dispose();
-    _offeringIdController.dispose();
     super.dispose();
   }
 
-  Future<void> _trackImpression() async {
+  String? get _paywallId {
+    final paywallId = _paywallIdController.text.trim();
+    return paywallId.isEmpty ? null : paywallId;
+  }
+
+  Future<Offerings> _loadOfferings() async {
+    final offerings = await Purchases.getOfferings();
+    if (mounted) {
+      setState(() {
+        _currentOfferingId = offerings.current?.identifier;
+      });
+    }
+    return offerings;
+  }
+
+  Future<void> _trackImpressionWithoutOffering() async {
     setState(() {
       _loading = true;
       _status = null;
@@ -32,23 +52,48 @@ class _CustomPaywallImpressionTestingScreenState
     });
 
     try {
-      final paywallId = _paywallIdController.text.trim();
-      final offeringId = _offeringIdController.text.trim();
+      final offerings = await _loadOfferings();
+      final currentOffering = offerings.current;
+      final paywallId = _paywallId;
 
-      if (paywallId.isEmpty && offeringId.isEmpty) {
+      if (currentOffering == null) {
+        setState(() {
+          _status =
+              'No current offering configured. The native SDK cannot infer an offering for this call.';
+        });
+        if (mounted) {
+          await showDialog<void>(
+            context: context,
+            builder: (context) => AlertDialog(
+              title: const Text('No current offering configured'),
+              content: const Text(
+                'The native SDK can only infer an offering when getOfferings().current is non-null. Use Track with Offering for this project.',
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('OK'),
+                ),
+              ],
+            ),
+          );
+        }
+        return;
+      }
+
+      if (paywallId == null) {
         await Purchases.trackCustomPaywallImpression();
       } else {
         await Purchases.trackCustomPaywallImpression(
           params: CustomPaywallImpressionParams(
-            paywallId: paywallId.isEmpty ? null : paywallId,
-            offeringId: offeringId.isEmpty ? null : offeringId,
+            paywallId: paywallId,
           ),
         );
       }
+
       setState(() {
-        _status =
-            'Tracked (paywallId: ${paywallId.isEmpty ? 'nil' : paywallId}, '
-            'offeringId: ${offeringId.isEmpty ? 'nil' : offeringId})';
+        _status = 'Tracked without offering (paywallId: ${paywallId ?? 'nil'}, '
+            'current offering: ${currentOffering.identifier})';
       });
     } catch (err) {
       setState(() {
@@ -58,6 +103,99 @@ class _CustomPaywallImpressionTestingScreenState
       setState(() {
         _loading = false;
       });
+    }
+  }
+
+  Future<void> _trackImpressionWithOffering(Offering offering) async {
+    setState(() {
+      _loading = true;
+      _status = null;
+      _error = null;
+    });
+
+    try {
+      final paywallId = _paywallId;
+
+      await Purchases.trackCustomPaywallImpression(
+        params: CustomPaywallImpressionParams(
+          paywallId: paywallId,
+          offering: offering,
+        ),
+      );
+
+      setState(() {
+        _status = 'Tracked with offering: ${offering.identifier} '
+            '(paywallId: ${paywallId ?? 'nil'})';
+      });
+    } catch (err) {
+      setState(() {
+        _error = err.toString();
+      });
+    } finally {
+      setState(() {
+        _loading = false;
+      });
+    }
+  }
+
+  Future<void> _showOfferingPicker() async {
+    setState(() {
+      _loading = true;
+      _status = 'Loading offerings...';
+      _error = null;
+    });
+
+    try {
+      final offerings = await _loadOfferings();
+      final offeringOptions = offerings.all.values.toList()
+        ..sort((a, b) => a.identifier.compareTo(b.identifier));
+
+      if (!mounted) {
+        return;
+      }
+
+      if (offeringOptions.isEmpty) {
+        setState(() {
+          _status = 'No offerings available';
+        });
+        return;
+      }
+
+      setState(() {
+        _loading = false;
+      });
+
+      final selectedOffering = await showDialog<Offering>(
+        context: context,
+        builder: (context) => SimpleDialog(
+          title: const Text('Select Offering'),
+          children: [
+            for (final offering in offeringOptions)
+              SimpleDialogOption(
+                onPressed: () => Navigator.of(context).pop(offering),
+                child: Text(offering.identifier),
+              ),
+          ],
+        ),
+      );
+
+      if (selectedOffering != null) {
+        await _trackImpressionWithOffering(selectedOffering);
+      } else if (mounted) {
+        setState(() {
+          _status = null;
+        });
+      }
+    } catch (err) {
+      setState(() {
+        _error = err.toString();
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _loading = false;
+        });
+      }
     }
   }
 
@@ -83,6 +221,12 @@ class _CustomPaywallImpressionTestingScreenState
               style: TextStyle(fontSize: 16, color: Colors.grey),
               textAlign: TextAlign.center,
             ),
+            const SizedBox(height: 8),
+            Text(
+              'Current offering: ${_currentOfferingId ?? 'nil'}',
+              style: const TextStyle(fontSize: 14, color: Colors.black54),
+              textAlign: TextAlign.center,
+            ),
             const SizedBox(height: 20),
             TextField(
               controller: _paywallIdController,
@@ -92,20 +236,18 @@ class _CustomPaywallImpressionTestingScreenState
                 border: OutlineInputBorder(),
               ),
             ),
-            const SizedBox(height: 12),
-            TextField(
-              controller: _offeringIdController,
-              decoration: const InputDecoration(
-                labelText: 'Offering ID',
-                hintText: 'Optional — leave empty for none',
-                border: OutlineInputBorder(),
-              ),
-            ),
             const SizedBox(height: 16),
             ElevatedButton(
-              onPressed: _loading ? null : _trackImpression,
+              onPressed: _loading ? null : _trackImpressionWithoutOffering,
               child: Text(
-                _loading ? 'Loading...' : 'Track Custom Paywall Impression',
+                _loading ? 'Loading...' : 'Track without Offering',
+              ),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: _loading ? null : _showOfferingPicker,
+              child: Text(
+                _loading ? 'Loading...' : 'Track with Offering',
               ),
             ),
             if (_status != null) ...[

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -2387,16 +2387,55 @@ void main() {
     expect(virtualCurrencies, isNull);
   });
 
+  const customPaywallPresentedOfferingContext = PresentedOfferingContext(
+    'my-offering',
+    'onboarding',
+    PresentedOfferingTargetingContext(7, 'rule_1'),
+  );
+  const customPaywallStoreProduct = StoreProduct(
+    'com.revenuecat.monthly',
+    'description',
+    'monthly (PurchasesSample)',
+    9.99,
+    '\$9.99',
+    'USD',
+  );
+  const customPaywallPackage = Package(
+    '\$rc_monthly',
+    PackageType.monthly,
+    customPaywallStoreProduct,
+    customPaywallPresentedOfferingContext,
+  );
+  const customPaywallOffering = Offering(
+    'my-offering',
+    'Custom paywall offering',
+    <String, Object>{},
+    <Package>[customPaywallPackage],
+  );
+  const customPaywallOfferingWithoutPackages = Offering(
+    'empty-offering',
+    'Custom paywall offering without packages',
+    <String, Object>{},
+    <Package>[],
+  );
+  const customPaywallPresentedOfferingContextJson = <String, dynamic>{
+    'offeringIdentifier': 'my-offering',
+    'placementIdentifier': 'onboarding',
+    'targetingContext': <String, dynamic>{
+      'revision': 7,
+      'ruleId': 'rule_1',
+    },
+  };
+
   test('trackCustomPaywallImpression works correctly with params', () async {
     await Purchases.trackCustomPaywallImpression(
-      params: CustomPaywallImpressionParams(paywallId: 'my-paywall'),
+      params: const CustomPaywallImpressionParams(paywallId: 'my-paywall'),
     );
     expect(log, <Matcher>[
       isMethodCall(
         'trackCustomPaywallImpression',
         arguments: {
           'paywallId': 'my-paywall',
-          'offeringId': null,
         },
       ),
     ]);
@@ -2408,25 +2447,37 @@ void main() {
     expect(log, <Matcher>[
       isMethodCall(
         'trackCustomPaywallImpression',
-        arguments: {
-          'paywallId': null,
-          'offeringId': null,
-        },
+        arguments: {},
       ),
     ]);
   });
 
-  test('trackCustomPaywallImpression works correctly with null paywallId',
+  test('trackCustomPaywallImpression does not send null ids',
       () async {
     await Purchases.trackCustomPaywallImpression(
-      params: CustomPaywallImpressionParams(),
+      params: const CustomPaywallImpressionParams(),
+    );
+    expect(log, <Matcher>[
+      isMethodCall(
+        'trackCustomPaywallImpression',
+        arguments: {},
+      ),
+    ]);
+  });
+
+  test('trackCustomPaywallImpression sends empty string ids', () async {
+    await Purchases.trackCustomPaywallImpression(
+      params: CustomPaywallImpressionParams(
+        paywallId: '',
+        offeringId: '',
+      ),
     );
     expect(log, <Matcher>[
       isMethodCall(
         'trackCustomPaywallImpression',
         arguments: {
-          'paywallId': null,
-          'offeringId': null,
+          'paywallId': '',
+          'offeringId': '',
         },
       ),
     ]);
@@ -2441,8 +2492,65 @@ void main() {
       isMethodCall(
         'trackCustomPaywallImpression',
         arguments: {
-          'paywallId': null,
           'offeringId': 'my-offering',
+        },
+      ),
+    ]);
+  });
+
+  test('trackCustomPaywallImpression derives context from offering', () async {
+    await Purchases.trackCustomPaywallImpression(
+      params: const CustomPaywallImpressionParams(
+        paywallId: 'my-paywall',
+        offering: customPaywallOffering,
+      ),
+    );
+    expect(log, <Matcher>[
+      isMethodCall(
+        'trackCustomPaywallImpression',
+        arguments: {
+          'paywallId': 'my-paywall',
+          'offeringId': 'my-offering',
+          'presentedOfferingContext': customPaywallPresentedOfferingContextJson,
+        },
+      ),
+    ]);
+  });
+
+  test('trackCustomPaywallImpression prefers offering over offeringId',
+      () async {
+    await Purchases.trackCustomPaywallImpression(
+      params: const CustomPaywallImpressionParams(
+        paywallId: 'my-paywall',
+        offering: customPaywallOffering,
+        offeringId: 'legacy-offering',
+      ),
+    );
+    expect(log, <Matcher>[
+      isMethodCall(
+        'trackCustomPaywallImpression',
+        arguments: {
+          'paywallId': 'my-paywall',
+          'offeringId': 'my-offering',
+          'presentedOfferingContext': customPaywallPresentedOfferingContextJson,
+        },
+      ),
+    ]);
+  });
+
+  test(
+      'trackCustomPaywallImpression sends offeringId for offering without packages',
+      () async {
+    await Purchases.trackCustomPaywallImpression(
+      params: const CustomPaywallImpressionParams(
+        offering: customPaywallOfferingWithoutPackages,
+      ),
+    );
+    expect(log, <Matcher>[
+      isMethodCall(
+        'trackCustomPaywallImpression',
+        arguments: {
+          'offeringId': 'empty-offering',
         },
       ),
     ]);
@@ -2451,7 +2559,7 @@ void main() {
   test('trackCustomPaywallImpression works correctly with both params',
       () async {
     await Purchases.trackCustomPaywallImpression(
-      params: CustomPaywallImpressionParams(
+      params: const CustomPaywallImpressionParams(
         paywallId: 'my-paywall',
         offeringId: 'my-offering',
       ),

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -2452,10 +2452,24 @@ void main() {
     ]);
   });
 
+  test('trackCustomPaywallImpression works correctly with null params',
+      () async {
+    await Purchases.trackCustomPaywallImpression(params: null);
+    expect(log, <Matcher>[
+      isMethodCall(
+        'trackCustomPaywallImpression',
+        arguments: {},
+      ),
+    ]);
+  });
+
   test('trackCustomPaywallImpression does not send null ids',
       () async {
     await Purchases.trackCustomPaywallImpression(
-      params: const CustomPaywallImpressionParams(),
+      params: const CustomPaywallImpressionParams(
+        paywallId: null,
+        offeringId: null,
+      ),
     );
     expect(log, <Matcher>[
       isMethodCall(


### PR DESCRIPTION
Based on PHC PR https://github.com/RevenueCat/purchases-hybrid-common/pull/1665.

## API

We will now send the `presentedOfferingContext` from the passed `Offering` along with the event. This PR adds the new API variant that takes an `Offering` instead of a plain string `offeringId`. The latter is now deprecated in favor of this new API variant. We will derive the `presentedOfferingContext` from this `Offering` and send it along with the request.

```
await Purchases.trackCustomPaywallImpression(
  params: CustomPaywallImpressionParams(paywallId: "", offering: offering),
)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only API extension with backward-compatible deprecation; no purchase, auth, or billing flow changes, though impression event shape changes may affect downstream analytics if callers relied on explicit null fields.
> 
> **Overview**
> **Custom paywall impression tracking** now accepts an `Offering` on `CustomPaywallImpressionParams` and forwards **placement/targeting** via `presentedOfferingContext` (taken from the offering’s first package when packages exist). String `offeringId` is **deprecated** but still supported; when both are set, the offering’s identifier wins.
> 
> `Purchases.trackCustomPaywallImpression` no longer always sends `paywallId`/`offeringId` as null—it builds a sparse map and only includes set fields. With no offering context, docs clarify that the native SDK picks the current offering.
> 
> **Android/iOS bridges** harden the channel path: null method arguments default to `{}`, and payloads strip null/`NSNull` values (Android recursively for nested maps/lists; iOS reuses `mappingNSNullToNil`).
> 
> Tests, API tester coverage, and the purchase_tester screen were updated to exercise tracking with/without an offering and the new payload shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c3e4c22dbf12a99b6ec592d37cf1cf31e3f1886. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->