### PR TITLE
Verify vendored web bundle against sha256 from purchases-hybrid-common

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,9 @@ parameters:
   automatic:
     type: boolean
     default: false
+  js_mappings_sha:
+    type: string
+    default: ''
 
 commands:
 
@@ -532,6 +535,7 @@ jobs:
             bundle exec fastlane update_hybrid_common \
             version:<< pipeline.parameters.version >> \
             open_pr:true \
+            js_mappings_sha:<< pipeline.parameters.js_mappings_sha >> \
             automatic_release:<< pipeline.parameters.automatic >>
 
   make-release:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -203,8 +203,14 @@ lane :update_hybrid_common do |options|
   # same-origin in strict CSP environments. Keep that vendored file in sync with
   # the version bumped above. When a PR was opened, bump_phc_version already
   # created/checked out the bump branch, so this is committed and pushed there to
-  # ship in the same PR.
-  update_web_hybrid_mappings_bundle(version: new_version_number, commit_and_push: open_pr)
+  # ship in the same PR. When triggered by purchases-hybrid-common, expected_sha
+  # is the sha256 of the bundle PHC just built and published, used to verify the
+  # downloaded copy.
+  update_web_hybrid_mappings_bundle(
+    version: new_version_number,
+    commit_and_push: open_pr,
+    expected_sha: options[:js_mappings_sha]
+  )
 end
 
 desc "Run maestro E2E tests on iOS"
@@ -303,7 +309,12 @@ end
 # asset. The npm package is versioned in lockstep with purchases-hybrid-common.
 # When `commit_and_push` is true, commits the updated asset to the current
 # branch (the bump branch created by bump_phc_version) and pushes it.
-def update_web_hybrid_mappings_bundle(version:, commit_and_push:)
+# When `expected_sha` is provided (the sha256 purchases-hybrid-common computed
+# for the bundle it built and published), the downloaded copy is verified
+# against it before being committed.
+def update_web_hybrid_mappings_bundle(version:, commit_and_push:, expected_sha: nil)
+  require 'digest'
+
   relative_path = web_hybrid_mappings_relative_path
   asset_path = File.join(get_root_folder, relative_path)
   download_url = web_hybrid_mappings_download_url(version)
@@ -313,6 +324,23 @@ def update_web_hybrid_mappings_bundle(version:, commit_and_push:)
 
   unless File.exist?(asset_path) && File.size(asset_path) > 0
     UI.user_error!("Downloaded purchases-js-hybrid-mappings bundle is empty or missing at #{asset_path}")
+  end
+
+  expected_sha = expected_sha.to_s.strip
+  if expected_sha.empty?
+    UI.message("ℹ️  No expected sha256 provided; skipping integrity verification of the downloaded bundle")
+  else
+    actual_sha = Digest::SHA256.hexdigest(File.binread(asset_path))
+    if actual_sha == expected_sha
+      UI.success("✅ Downloaded purchases-js-hybrid-mappings bundle matches the expected sha256 (#{actual_sha})")
+    else
+      UI.user_error!(
+        "Downloaded purchases-js-hybrid-mappings@#{version} bundle does not match the expected sha256.\n" \
+        "  expected sha256: #{expected_sha}\n" \
+        "  actual   sha256: #{actual_sha}\n" \
+        "The bundle published to npm/CDN does not match the artifact purchases-hybrid-common built."
+      )
+    end
   end
 
   return unless commit_and_push

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -328,19 +328,22 @@ def update_web_hybrid_mappings_bundle(version:, commit_and_push:, expected_sha:)
 
   expected_sha = expected_sha.to_s.strip
   if expected_sha.empty?
-    UI.message("ℹ️  No expected sha256 provided; skipping integrity verification of the downloaded bundle")
+    UI.user_error!(
+      "No expected sha256 provided for the purchases-js-hybrid-mappings bundle. It must be supplied " \
+      "(js_mappings_sha) by the purchases-hybrid-common bump trigger so the downloaded copy can be verified."
+    )
+  end
+
+  actual_sha = Digest::SHA256.hexdigest(File.binread(asset_path))
+  if actual_sha == expected_sha
+    UI.success("✅ Downloaded purchases-js-hybrid-mappings bundle matches the expected sha256 (#{actual_sha})")
   else
-    actual_sha = Digest::SHA256.hexdigest(File.binread(asset_path))
-    if actual_sha == expected_sha
-      UI.success("✅ Downloaded purchases-js-hybrid-mappings bundle matches the expected sha256 (#{actual_sha})")
-    else
-      UI.user_error!(
-        "Downloaded purchases-js-hybrid-mappings@#{version} bundle does not match the expected sha256.\n" \
-        "  expected sha256: #{expected_sha}\n" \
-        "  actual   sha256: #{actual_sha}\n" \
-        "The bundle published to npm/CDN does not match the artifact purchases-hybrid-common built."
-      )
-    end
+    UI.user_error!(
+      "Downloaded purchases-js-hybrid-mappings@#{version} bundle does not match the expected sha256.\n" \
+      "  expected sha256: #{expected_sha}\n" \
+      "  actual   sha256: #{actual_sha}\n" \
+      "The bundle published to npm/CDN does not match the artifact purchases-hybrid-common built."
+    )
   end
 
   return unless commit_and_push

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -312,7 +312,7 @@ end
 # When `expected_sha` is provided (the sha256 purchases-hybrid-common computed
 # for the bundle it built and published), the downloaded copy is verified
 # against it before being committed.
-def update_web_hybrid_mappings_bundle(version:, commit_and_push:, expected_sha: nil)
+def update_web_hybrid_mappings_bundle(version:, commit_and_push:, expected_sha:)
   require 'digest'
 
   relative_path = web_hybrid_mappings_relative_path


### PR DESCRIPTION
### Motivation

#1785 vendors the `purchases-js-hybrid-mappings` UMD bundle, downloaded from the CDN at bump time. This adds an integrity check so we confirm the downloaded copy matches the artifact purchases-hybrid-common actually built and published, addressing the supply-chain concern raised in review.

### Summary

- Declare a `js_mappings_sha` pipeline parameter (sent by purchases-hybrid-common's bump trigger).
- Verify the downloaded bundle's sha256 against it before committing; fail the bump on mismatch or if `js_mappings_sha` is empty.

### Notes

- RevenueCat/purchases-hybrid-common#1690 implements sending the `js_mappings_sha` parameter in the bump trigger.
- This parameter declaration must reach `main` before PHC starts sending it, otherwise the trigger fails with a 400 on the undeclared parameter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the automated PHC upgrade/release path and makes bumps fail without a matching sha or missing `js_mappings_sha`; low runtime risk but coordination with purchases-hybrid-common is required.
> 
> **Overview**
> Adds a **supply-chain integrity check** when the hybrid-common bump flow downloads and vendors the `purchases-js-hybrid-mappings` UMD bundle for Flutter web.
> 
> CircleCI declares a new **`js_mappings_sha`** pipeline parameter and forwards it into `fastlane update_hybrid_common`. That lane passes the value as **`expected_sha`** to `update_web_hybrid_mappings_bundle`, which now **requires** a non-empty expected SHA256, hashes the CDN download, and **fails the bump** if it does not match the artifact purchases-hybrid-common built and published.
> 
> **Note:** `main` must accept this parameter before PHC starts sending `js_mappings_sha`, or triggered pipelines will error on an undeclared parameter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90311118ec64d563030b8f7f2ec44ac2d1327ec3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->