### PR TITLE
Update sdks-common-config orb to 3.21.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ aliases:
 orbs:
   android: circleci/android@2.5.0
   swissknife: roopakv/swissknife@0.65.0
-  revenuecat: revenuecat/sdks-common-config@3.20.0
+  revenuecat: revenuecat/sdks-common-config@3.21.2
   macos: circleci/macos@2.3.2
   flutter: circleci/flutter@2.1.0
   ruby: circleci/ruby@2.5.3


### PR DESCRIPTION
### Motivation
Pull in [sdks-circleci-orb#69](https://github.com/RevenueCat/sdks-circleci-orb/pull/69), which fixes the `merge-release-pr` job failing after a successful merge.

### Description
Bump the CircleCI orb to `3.21.2`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency version bump with no application code changes; intended to fix a post-release pipeline failure.
> 
> **Overview**
> Bumps the **`revenuecat/sdks-common-config`** CircleCI orb from **3.20.0** to **3.21.2** in `.circleci/config.yml`.
> 
> This picks up the orb fix from [sdks-circleci-orb#69](https://github.com/RevenueCat/sdks-circleci-orb/pull/69) so the **`revenuecat/merge-release-pr`** step in the deploy workflow no longer fails after a release merge succeeds. All other jobs that use shared `revenuecat/*` commands inherit the new orb version unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 122726020b253ecdb2694f7a0e1ebcd185907e8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->