### PR TITLE
Bump sdks-common-config orb to 4.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ aliases:
 orbs:
   android: circleci/android@2.5.0
   swissknife: roopakv/swissknife@0.65.0
-  revenuecat: revenuecat/sdks-common-config@4.0.0
+  revenuecat: revenuecat/sdks-common-config@4.1.0
   macos: circleci/macos@2.3.2
   flutter: circleci/flutter@2.1.0
   ruby: circleci/ruby@2.5.3


### PR DESCRIPTION
Bump common config orb to 4.1.0 to include error codes reminder

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency version bump in CI config only; no application or runtime code changes, though orb updates can subtly change pipeline steps.
> 
> **Overview**
> Bumps the shared **`revenuecat/sdks-common-config`** CircleCI orb from **4.0.0** to **4.1.0** in `.circleci/config.yml`.
> 
> All existing jobs that use `revenuecat/*` steps (Danger, gem installs, release/tag flows, `update-error-codes`, Maestro, etc.) will pick up whatever behavior changed in the orb—per the PR intent, that includes an **error codes reminder** in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd9807c23167c68ae4372e4e0092a31a17c9309a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->