### PR TITLE
Expose `SubscriptionInfo` and `CustomerInfo.subscriptionsByProductIdentifier`

### DIFF
--- a/api_tester/lib/api_tests/models/customer_info_wrapper_api_test.dart
+++ b/api_tester/lib/api_tests/models/customer_info_wrapper_api_test.dart
@@ -20,7 +20,8 @@ class _CustomerInfoApiTest {
       String? latestExpirationDate,
       String? originalPurchaseDate,
       String? originalApplicationVersion,
-      String? managementURL) {
+      String? managementURL,
+      Map<String, SubscriptionInfo> subscriptionsByProductIdentifier) {
     CustomerInfo customerInfo = CustomerInfo(
         entitlements,
         allPurchaseDates,
@@ -44,7 +45,8 @@ class _CustomerInfoApiTest {
         latestExpirationDate: latestExpirationDate,
         originalPurchaseDate: originalPurchaseDate,
         originalApplicationVersion: originalApplicationVersion,
-        managementURL: managementURL);
+        managementURL: managementURL,
+        subscriptionsByProductIdentifier: subscriptionsByProductIdentifier);
   }
 
   void _checkProperties(CustomerInfo customerInfo) {
@@ -64,5 +66,7 @@ class _CustomerInfoApiTest {
     String? originalApplicationVersion =
         customerInfo.originalApplicationVersion;
     String? managementURL = customerInfo.managementURL;
+    Map<String, SubscriptionInfo> subscriptionsByProductIdentifier =
+        customerInfo.subscriptionsByProductIdentifier;
   }
 }

--- a/api_tester/lib/api_tests/models/subscription_info_wrapper_api_test.dart
+++ b/api_tester/lib/api_tests/models/subscription_info_wrapper_api_test.dart
@@ -1,0 +1,71 @@
+import 'package:purchases_flutter/object_wrappers.dart';
+
+// ignore_for_file: unused_element
+// ignore_for_file: unused_local_variable
+class _SubscriptionInfoApiTest {
+  void _checkFromJsonFactory(Map<String, dynamic> json) {
+    SubscriptionInfo info = SubscriptionInfo.fromJson(json);
+  }
+
+  void _checkConstructor(
+      String productIdentifier,
+      String purchaseDate,
+      bool isSandbox,
+      bool isActive,
+      bool willRenew,
+      String? originalPurchaseDate,
+      String? expiresDate,
+      Store store,
+      String? unsubscribeDetectedAt,
+      String? billingIssuesDetectedAt,
+      String? gracePeriodExpiresDate,
+      OwnershipType ownershipType,
+      PeriodType periodType,
+      String? refundedAt,
+      String? storeTransactionId,
+      String? autoResumeDate,
+      String? displayName,
+      String? managementURL,
+      String? productPlanIdentifier) {
+    SubscriptionInfo info = SubscriptionInfo(
+        productIdentifier, purchaseDate, isSandbox, isActive, willRenew);
+    info = SubscriptionInfo(
+        productIdentifier, purchaseDate, isSandbox, isActive, willRenew,
+        originalPurchaseDate: originalPurchaseDate,
+        expiresDate: expiresDate,
+        store: store,
+        unsubscribeDetectedAt: unsubscribeDetectedAt,
+        billingIssuesDetectedAt: billingIssuesDetectedAt,
+        gracePeriodExpiresDate: gracePeriodExpiresDate,
+        ownershipType: ownershipType,
+        periodType: periodType,
+        refundedAt: refundedAt,
+        storeTransactionId: storeTransactionId,
+        autoResumeDate: autoResumeDate,
+        displayName: displayName,
+        managementURL: managementURL,
+        productPlanIdentifier: productPlanIdentifier);
+  }
+
+  void _checkProperties(SubscriptionInfo info) {
+    String productIdentifier = info.productIdentifier;
+    String purchaseDate = info.purchaseDate;
+    bool isSandbox = info.isSandbox;
+    bool isActive = info.isActive;
+    bool willRenew = info.willRenew;
+    String? originalPurchaseDate = info.originalPurchaseDate;
+    String? expiresDate = info.expiresDate;
+    Store store = info.store;
+    String? unsubscribeDetectedAt = info.unsubscribeDetectedAt;
+    String? billingIssuesDetectedAt = info.billingIssuesDetectedAt;
+    String? gracePeriodExpiresDate = info.gracePeriodExpiresDate;
+    OwnershipType ownershipType = info.ownershipType;
+    PeriodType periodType = info.periodType;
+    String? refundedAt = info.refundedAt;
+    String? storeTransactionId = info.storeTransactionId;
+    String? autoResumeDate = info.autoResumeDate;
+    String? displayName = info.displayName;
+    String? managementURL = info.managementURL;
+    String? productPlanIdentifier = info.productPlanIdentifier;
+  }
+}

--- a/api_tester/lib/api_tests_import.dart
+++ b/api_tester/lib/api_tests_import.dart
@@ -27,6 +27,7 @@ import 'package:api_tester/api_tests/models/store_product_discount_api_test.dart
 import 'package:api_tester/api_tests/models/store_product_wrapper_api_test.dart';
 import 'package:api_tester/api_tests/models/store_transaction_api_test.dart';
 import 'package:api_tester/api_tests/models/storefront_api_test.dart';
+import 'package:api_tester/api_tests/models/subscription_info_wrapper_api_test.dart';
 import 'package:api_tester/api_tests/models/subscription_option_wrapper_api_test.dart';
 import 'package:api_tester/api_tests/models/virtual_currencies_api_test.dart';
 import 'package:api_tester/api_tests/models/virtual_currency_api_test.dart';

--- a/lib/models/customer_info_wrapper.dart
+++ b/lib/models/customer_info_wrapper.dart
@@ -2,6 +2,7 @@ import 'package:equatable/equatable.dart';
 
 import 'entitlement_infos_wrapper.dart';
 import 'store_transaction.dart';
+import 'subscription_info_wrapper.dart';
 
 /// Class containing all information regarding the customer
 class CustomerInfo extends Equatable {
@@ -55,6 +56,10 @@ class CustomerInfo extends Equatable {
   /// If there are multiple for different platforms, it will point to the device store.
   final String? managementURL;
 
+  /// Map of product identifiers to their subscription info, for both
+  /// subscriptions and non-subscriptions.
+  final Map<String, SubscriptionInfo> subscriptionsByProductIdentifier;
+
   const CustomerInfo(
     this.entitlements,
     this.allPurchaseDates,
@@ -69,6 +74,7 @@ class CustomerInfo extends Equatable {
     this.originalPurchaseDate,
     this.originalApplicationVersion,
     this.managementURL,
+    this.subscriptionsByProductIdentifier = const {},
   });
 
   factory CustomerInfo.fromJson(Map<String, dynamic> json) => CustomerInfo(
@@ -85,6 +91,9 @@ class CustomerInfo extends Equatable {
       originalPurchaseDate: json['originalPurchaseDate'] as String?,
       originalApplicationVersion: json['originalApplicationVersion'] as String?,
       managementURL: json['managementURL'] as String?,
+      subscriptionsByProductIdentifier: Map<String, dynamic>.from(json['subscriptionsByProductIdentifier'] ?? {}).map(
+        (key, value) => MapEntry(key, SubscriptionInfo.fromJson(Map<String, dynamic>.from(value))),
+      ),
     );
 
   @override
@@ -102,5 +111,6 @@ class CustomerInfo extends Equatable {
     originalPurchaseDate,
     originalApplicationVersion,
     managementURL,
+    subscriptionsByProductIdentifier,
   ];
 }

--- a/lib/models/entitlement_info_wrapper.dart
+++ b/lib/models/entitlement_info_wrapper.dart
@@ -151,31 +151,3 @@ class EntitlementInfo extends Equatable {
     verification,
   ];
 }
-
-OwnershipType ownershipTypeFromJson(dynamic value) {
-  switch (value) {
-    case 'PURCHASED':
-      return OwnershipType.purchased;
-    case 'FAMILY_SHARED':
-      return OwnershipType.familyShared;
-    case 'UNKNOWN':
-      return OwnershipType.unknown;
-    default:
-      return OwnershipType.unknown;
-  }
-}
-
-PeriodType periodTypeFromJson(dynamic value) {
-  switch (value) {
-    case 'INTRO':
-      return PeriodType.intro;
-    case 'NORMAL':
-      return PeriodType.normal;
-    case 'TRIAL':
-      return PeriodType.trial;
-    case 'PREPAID':
-      return PeriodType.prepaid;
-    default:
-      return PeriodType.unknown;
-  }
-}

--- a/lib/models/entitlement_info_wrapper.dart
+++ b/lib/models/entitlement_info_wrapper.dart
@@ -122,9 +122,9 @@ class EntitlementInfo extends Equatable {
       json['originalPurchaseDate'] as String,
       json['productIdentifier'] as String,
       json['isSandbox'] as bool,
-      ownershipType: _ownershipTypeFromJson(json['ownershipType']),
+      ownershipType: ownershipTypeFromJson(json['ownershipType']),
       store: storeFromJson(json['store']),
-      periodType: _periodTypeFromJson(json['periodType']),
+      periodType: periodTypeFromJson(json['periodType']),
       expirationDate: json['expirationDate'] as String?,
       unsubscribeDetectedAt: json['unsubscribeDetectedAt'] as String?,
       billingIssueDetectedAt: json['billingIssueDetectedAt'] as String?,
@@ -152,7 +152,7 @@ class EntitlementInfo extends Equatable {
   ];
 }
 
-OwnershipType _ownershipTypeFromJson(dynamic value) {
+OwnershipType ownershipTypeFromJson(dynamic value) {
   switch (value) {
     case 'PURCHASED':
       return OwnershipType.purchased;
@@ -165,7 +165,7 @@ OwnershipType _ownershipTypeFromJson(dynamic value) {
   }
 }
 
-PeriodType _periodTypeFromJson(dynamic value) {
+PeriodType periodTypeFromJson(dynamic value) {
   switch (value) {
     case 'INTRO':
       return PeriodType.intro;

--- a/lib/models/map_helpers.dart
+++ b/lib/models/map_helpers.dart
@@ -1,7 +1,36 @@
+import 'entitlement_info_wrapper.dart';
 import 'period_unit.dart';
 import 'product_category.dart';
 import 'store.dart';
 import 'verification_result.dart';
+
+OwnershipType ownershipTypeFromJson(dynamic value) {
+  switch (value) {
+    case 'PURCHASED':
+      return OwnershipType.purchased;
+    case 'FAMILY_SHARED':
+      return OwnershipType.familyShared;
+    case 'UNKNOWN':
+      return OwnershipType.unknown;
+    default:
+      return OwnershipType.unknown;
+  }
+}
+
+PeriodType periodTypeFromJson(dynamic value) {
+  switch (value) {
+    case 'INTRO':
+      return PeriodType.intro;
+    case 'NORMAL':
+      return PeriodType.normal;
+    case 'TRIAL':
+      return PeriodType.trial;
+    case 'PREPAID':
+      return PeriodType.prepaid;
+    default:
+      return PeriodType.unknown;
+  }
+}
 
 VerificationResult verificationResultFromJson(dynamic value) {
   switch (value) {

--- a/lib/models/subscription_info_wrapper.dart
+++ b/lib/models/subscription_info_wrapper.dart
@@ -1,0 +1,141 @@
+import 'package:equatable/equatable.dart';
+
+import 'entitlement_info_wrapper.dart';
+import 'map_helpers.dart';
+import 'store.dart';
+
+/// Subscription purchase of a customer, keyed by product identifier in
+/// [CustomerInfo.subscriptionsByProductIdentifier].
+class SubscriptionInfo extends Equatable {
+  /// The product identifier.
+  final String productIdentifier;
+
+  /// Date when the last subscription period started.
+  final String purchaseDate;
+
+  /// Whether or not the purchase was made in sandbox mode.
+  final bool isSandbox;
+
+  /// Whether the subscription is currently active.
+  final bool isActive;
+
+  /// Whether the subscription will renew at the next billing period.
+  final bool willRenew;
+
+  /// Date when this subscription first started. Can be null for non-subscriptions.
+  final String? originalPurchaseDate;
+
+  /// Date when the subscription expires/expired. Can be null for non-subscriptions.
+  final String? expiresDate;
+
+  /// Store where the subscription was purchased.
+  final Store store;
+
+  /// Date when RevenueCat detected that auto-renewal was turned off for this
+  /// subscription. Note the subscription may still be active, check the
+  /// [expiresDate] attribute.
+  final String? unsubscribeDetectedAt;
+
+  /// Date when RevenueCat detected any billing issues with this subscription.
+  /// If and when the billing issue gets resolved, this field is set to null.
+  /// Note the subscription may still be active, check the [expiresDate] attribute.
+  final String? billingIssuesDetectedAt;
+
+  /// Date when any grace period for this subscription expires/expired.
+  /// Null if the customer has never been in a grace period.
+  final String? gracePeriodExpiresDate;
+
+  /// How the customer received access to this subscription.
+  final OwnershipType ownershipType;
+
+  /// Type of the current subscription period.
+  final PeriodType periodType;
+
+  /// Date when RevenueCat detected a refund of this subscription.
+  final String? refundedAt;
+
+  /// The transaction id in the store of the subscription.
+  final String? storeTransactionId;
+
+  /// The date the paused subscription will automatically resume.
+  /// Only set for Google Play subscriptions that have been paused; null otherwise.
+  final String? autoResumeDate;
+
+  /// The display name of the subscription as configured in the RevenueCat dashboard.
+  final String? displayName;
+
+  /// The URL to manage this subscription in the store. Can be null.
+  final String? managementURL;
+
+  /// The base plan identifier that unlocked this subscription (Google Play base
+  /// plans and Apple purchases with non-upfront billing plans). Null otherwise.
+  final String? productPlanIdentifier;
+
+  const SubscriptionInfo(
+    this.productIdentifier,
+    this.purchaseDate,
+    this.isSandbox,
+    this.isActive,
+    this.willRenew, {
+    this.originalPurchaseDate,
+    this.expiresDate,
+    this.store = Store.unknownStore,
+    this.unsubscribeDetectedAt,
+    this.billingIssuesDetectedAt,
+    this.gracePeriodExpiresDate,
+    this.ownershipType = OwnershipType.unknown,
+    this.periodType = PeriodType.unknown,
+    this.refundedAt,
+    this.storeTransactionId,
+    this.autoResumeDate,
+    this.displayName,
+    this.managementURL,
+    this.productPlanIdentifier,
+  });
+
+  factory SubscriptionInfo.fromJson(Map<String, dynamic> json) =>
+    SubscriptionInfo(
+      json['productIdentifier'] as String,
+      json['purchaseDate'] as String,
+      json['isSandbox'] as bool,
+      json['isActive'] as bool,
+      json['willRenew'] as bool,
+      originalPurchaseDate: json['originalPurchaseDate'] as String?,
+      expiresDate: json['expiresDate'] as String?,
+      store: storeFromJson(json['store']),
+      unsubscribeDetectedAt: json['unsubscribeDetectedAt'] as String?,
+      billingIssuesDetectedAt: json['billingIssuesDetectedAt'] as String?,
+      gracePeriodExpiresDate: json['gracePeriodExpiresDate'] as String?,
+      ownershipType: ownershipTypeFromJson(json['ownershipType']),
+      periodType: periodTypeFromJson(json['periodType']),
+      refundedAt: json['refundedAt'] as String?,
+      storeTransactionId: json['storeTransactionId'] as String?,
+      autoResumeDate: json['autoResumeDate'] as String?,
+      displayName: json['displayName'] as String?,
+      managementURL: json['managementURL'] as String?,
+      productPlanIdentifier: json['productPlanIdentifier'] as String?,
+    );
+
+  @override
+  List<Object?> get props => [
+    productIdentifier,
+    purchaseDate,
+    isSandbox,
+    isActive,
+    willRenew,
+    originalPurchaseDate,
+    expiresDate,
+    store,
+    unsubscribeDetectedAt,
+    billingIssuesDetectedAt,
+    gracePeriodExpiresDate,
+    ownershipType,
+    periodType,
+    refundedAt,
+    storeTransactionId,
+    autoResumeDate,
+    displayName,
+    managementURL,
+    productPlanIdentifier,
+  ];
+}

--- a/lib/object_wrappers.dart
+++ b/lib/object_wrappers.dart
@@ -38,6 +38,7 @@ export 'models/store_product_wrapper.dart';
 export 'models/store_transaction.dart';
 export 'models/storefront.dart';
 export 'models/storekit_version.dart';
+export 'models/subscription_info_wrapper.dart';
 export 'models/subscription_option_wrapper.dart';
 export 'models/upgrade_info.dart';
 export 'models/verification_result.dart';

--- a/revenuecat_examples/purchase_tester/lib/main.dart
+++ b/revenuecat_examples/purchase_tester/lib/main.dart
@@ -36,11 +36,19 @@ void main() async {
 Future<void> _configureSDK() async {
   await Purchases.setLogLevel(LogLevel.debug);
 
+  if (proxyUrl.isNotEmpty) {
+    await Purchases.setProxyURL(proxyUrl);
+  }
+
   PurchasesConfiguration configuration;
   if (StoreConfig.isForAmazonAppstore()) {
     configuration = AmazonConfiguration(StoreConfig.instance.apiKey);
   } else {
     configuration = PurchasesConfiguration(StoreConfig.instance.apiKey);
+  }
+
+  if (testAppUserId.isNotEmpty) {
+    configuration.appUserID = testAppUserId;
   }
 
   configuration.entitlementVerificationMode =

--- a/revenuecat_examples/purchase_tester/lib/src/constant.dart
+++ b/revenuecat_examples/purchase_tester/lib/src/constant.dart
@@ -12,6 +12,15 @@ const webApiKey = 'web_api_key';
 
 const entitlementKey = 'pro';
 
+// Optional: route SDK traffic to a local backend (e.g. a local khepri at http://localhost:8000).
+// Leave empty to use the production RevenueCat backend. Set the host that the device can reach:
+// Android emulators reach the host machine at 10.0.2.2, not localhost.
+const proxyUrl = '';
+
+// Optional: log in as a specific app user id at configure time (e.g. a seeded backend user).
+// Leave empty to stay anonymous.
+const testAppUserId = '';
+
 // Set this to true to configure the SDK with purchasesAreCompletedBy: myApp.
 // When enabled, PaywallView will use SamplePurchaseLogic (in paywall.dart)
 // to handle purchases and restores instead of the default RevenueCat flow.

--- a/test/models/customer_info_wrapper_test.dart
+++ b/test/models/customer_info_wrapper_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:purchases_flutter/models/customer_info_wrapper.dart';
 import 'package:purchases_flutter/models/entitlement_infos_wrapper.dart';
+import 'package:purchases_flutter/models/store.dart';
 import 'package:purchases_flutter/models/store_transaction.dart';
 import 'package:purchases_flutter/models/verification_result.dart';
 
@@ -35,6 +36,7 @@ void main() {
         '2024-01-01T00:00:00Z',
       );
       expect(info, equals(expected));
+      expect(info.subscriptionsByProductIdentifier, isEmpty);
     });
 
     test('parses all fields with values', () {
@@ -82,5 +84,42 @@ void main() {
       );
       expect(info, equals(expected));
     });
+
+    test('parses subscriptionsByProductIdentifier', () {
+      final json = {
+        'entitlements': {
+          'all': {},
+          'active': {},
+          'verification': 'NOT_REQUESTED',
+        },
+        'allPurchaseDates': {},
+        'activeSubscriptions': ['sku1'],
+        'allPurchasedProductIdentifiers': ['sku1'],
+        'nonSubscriptionTransactions': [],
+        'firstSeen': '2024-01-01T00:00:00Z',
+        'originalAppUserId': 'user_123',
+        'allExpirationDates': {},
+        'requestDate': '2024-01-01T00:00:00Z',
+        'subscriptionsByProductIdentifier': {
+          'sku1': {
+            'productIdentifier': 'sku1',
+            'purchaseDate': '2024-01-01T00:00:00Z',
+            'isSandbox': false,
+            'isActive': true,
+            'willRenew': false,
+            'store': 'PLAY_STORE',
+            'autoResumeDate': '2024-03-01T00:00:00Z',
+            'productPlanIdentifier': 'monthly-plan',
+          }
+        },
+      };
+      final info = CustomerInfo.fromJson(json);
+      expect(info.subscriptionsByProductIdentifier.keys, ['sku1']);
+      final subscription = info.subscriptionsByProductIdentifier['sku1']!;
+      expect(subscription.productIdentifier, 'sku1');
+      expect(subscription.store, Store.playStore);
+      expect(subscription.autoResumeDate, '2024-03-01T00:00:00Z');
+      expect(subscription.productPlanIdentifier, 'monthly-plan');
+    });
   });
-} 
+}

--- a/test/models/subscription_info_wrapper_test.dart
+++ b/test/models/subscription_info_wrapper_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:purchases_flutter/models/entitlement_info_wrapper.dart';
+import 'package:purchases_flutter/models/store.dart';
+import 'package:purchases_flutter/models/subscription_info_wrapper.dart';
+
+void main() {
+  group('SubscriptionInfo.fromJson', () {
+    test('parses required fields and applies defaults', () {
+      final json = {
+        'productIdentifier': 'sku1',
+        'purchaseDate': '2024-01-01T00:00:00Z',
+        'isSandbox': false,
+        'isActive': true,
+        'willRenew': true,
+      };
+      final info = SubscriptionInfo.fromJson(json);
+      const expected = SubscriptionInfo(
+        'sku1',
+        '2024-01-01T00:00:00Z',
+        false,
+        true,
+        true,
+      );
+      expect(info, equals(expected));
+      expect(info.store, Store.unknownStore);
+      expect(info.periodType, PeriodType.unknown);
+      expect(info.ownershipType, OwnershipType.unknown);
+      expect(info.autoResumeDate, isNull);
+      expect(info.displayName, isNull);
+      expect(info.managementURL, isNull);
+      expect(info.productPlanIdentifier, isNull);
+    });
+
+    test('parses all fields including autoResumeDate and productPlanIdentifier',
+        () {
+      final json = {
+        'productIdentifier': 'sku1',
+        'purchaseDate': '2024-01-01T00:00:00Z',
+        'isSandbox': true,
+        'isActive': false,
+        'willRenew': false,
+        'originalPurchaseDate': '2023-12-01T00:00:00Z',
+        'expiresDate': '2024-02-01T00:00:00Z',
+        'store': 'PLAY_STORE',
+        'unsubscribeDetectedAt': '2024-01-15T00:00:00Z',
+        'billingIssuesDetectedAt': '2024-01-16T00:00:00Z',
+        'gracePeriodExpiresDate': '2024-01-20T00:00:00Z',
+        'ownershipType': 'PURCHASED',
+        'periodType': 'NORMAL',
+        'refundedAt': '2024-01-18T00:00:00Z',
+        'storeTransactionId': 'gpa.123',
+        'autoResumeDate': '2024-03-01T00:00:00Z',
+        'displayName': 'Premium',
+        'managementURL': 'https://play.google.com/store/account/subscriptions',
+        'productPlanIdentifier': 'monthly-plan',
+      };
+      final info = SubscriptionInfo.fromJson(json);
+      expect(info.store, Store.playStore);
+      expect(info.periodType, PeriodType.normal);
+      expect(info.ownershipType, OwnershipType.purchased);
+      expect(info.willRenew, false);
+      expect(info.storeTransactionId, 'gpa.123');
+      expect(info.autoResumeDate, '2024-03-01T00:00:00Z');
+      expect(info.displayName, 'Premium');
+      expect(info.managementURL,
+          'https://play.google.com/store/account/subscriptions');
+      expect(info.productPlanIdentifier, 'monthly-plan');
+    });
+  });
+}


### PR DESCRIPTION
`SubscriptionInfo` is a new model representing a subscription purchase, keyed by product identifier. It mirrors the `SubscriptionInfo` type already present in other hybrid SDKs, including `autoResumeDate`.

Additionally, added for testing but I thought it would be good to leave it: the `purchase_tester` example now has a configurable `proxyUrl` and `testAppuserId` in `constant.dart`.

Closes SDK-4383

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new public API surface on CustomerInfo that apps may depend on; parsing mistakes could misrepresent subscription state, though defaults preserve backward compatibility when the field is absent.
> 
> **Overview**
> Adds a public **`SubscriptionInfo`** model (renewal state, store, billing/grace dates, plan IDs, per-subscription management URL, etc.) and wires it into **`CustomerInfo`** via **`subscriptionsByProductIdentifier`**, parsed from the native payload with an empty-map default when the key is missing.
> 
> **`ownershipTypeFromJson`** and **`periodTypeFromJson`** are now library-visible so **`SubscriptionInfo.fromJson`** can reuse the same enum mapping as entitlements. The type is exported from **`object_wrappers.dart`**, with api_tester compile checks and unit tests for JSON parsing.
> 
> The purchase_tester example gains optional **`proxyUrl`** and **`testAppUserId`** constants for pointing the SDK at a local backend or a fixed user during manual testing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56aaa683534ecd9319816d8423996aee66be23da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
