### PR TITLE
fix: Use correct directory for commit in PHC propagation

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -319,6 +319,8 @@ def update_web_hybrid_mappings_bundle(version:, commit_and_push:, expected_sha:)
   asset_path = File.join(get_root_folder, relative_path)
   download_url = web_hybrid_mappings_download_url(version)
 
+  previous_sha = File.exist?(asset_path) ? Digest::SHA256.hexdigest(File.binread(asset_path)) : nil
+
   UI.message("ℹ️  Downloading purchases-js-hybrid-mappings #{version} bundle from #{download_url}")
   Actions.sh("curl", "-fsSL", download_url, "-o", asset_path)
 
@@ -348,14 +350,11 @@ def update_web_hybrid_mappings_bundle(version:, commit_and_push:, expected_sha:)
 
   return unless commit_and_push
 
-  Dir.chdir(get_root_folder) do
-    status = Actions.sh("git", "status", "--porcelain", relative_path, log: false)
-    if status.strip.empty?
-      UI.message("ℹ️  Vendored purchases-js-hybrid-mappings bundle already up to date; nothing to commit")
-    else
-      commit_current_changes(commit_message: "Update vendored purchases-js-hybrid-mappings to #{version}")
-      push_to_git_remote
-    end
+  if actual_sha == previous_sha
+    UI.message("ℹ️  Vendored purchases-js-hybrid-mappings bundle already up to date; nothing to commit")
+  else
+    commit_current_changes(commit_message: "Update vendored purchases-js-hybrid-mappings to #{version}")
+    push_to_git_remote
   end
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -319,8 +319,6 @@ def update_web_hybrid_mappings_bundle(version:, commit_and_push:, expected_sha:)
   asset_path = File.join(get_root_folder, relative_path)
   download_url = web_hybrid_mappings_download_url(version)
 
-  previous_sha = File.exist?(asset_path) ? Digest::SHA256.hexdigest(File.binread(asset_path)) : nil
-
   UI.message("ℹ️  Downloading purchases-js-hybrid-mappings #{version} bundle from #{download_url}")
   Actions.sh("curl", "-fsSL", download_url, "-o", asset_path)
 
@@ -350,7 +348,8 @@ def update_web_hybrid_mappings_bundle(version:, commit_and_push:, expected_sha:)
 
   return unless commit_and_push
 
-  if actual_sha == previous_sha
+  status = Actions.sh("git", "-C", get_root_folder, "status", "--porcelain", relative_path, log: false)
+  if status.strip.empty?
     UI.message("ℹ️  Vendored purchases-js-hybrid-mappings bundle already up to date; nothing to commit")
   else
     commit_current_changes(commit_message: "Update vendored purchases-js-hybrid-mappings to #{version}")


### PR DESCRIPTION
`update_web_hybrid_mappings_bundle` called `commit_current_changes` (a fastlane action) inside a `Dir.chdir(get_root_folder)` block. fastlane's `Runner#execute_action` does its own `Dir.chdir("..")` before every action, expecting lane code to run with cwd = `fastlane/`. With the extra wrapper already at repo root, `..` overshoots to the repo's parent (no `.git`), so `git add -u` fails.

Fix: remove the `Dir.chdir` wrapper and use `git -C get_root_folder status --porcelain` for the change check, so git state (not just file bytes) determines whether to commit. `commit_current_changes`/`push_to_git_remote` now run at the normal lane cwd where fastlane's `..` resolves correctly.

Failure this caused: https://app.circleci.com/pipelines/github/RevenueCat/purchases-flutter/5937/workflows/1cbd3722-9e13-4ec4-8cd5-df09695efcf0/jobs/48407

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single fastlane helper change for release automation; no app runtime or SDK behavior affected.
> 
> **Overview**
> Fixes **CI failures** when `update_web_hybrid_mappings_bundle` tries to commit the vendored `purchases-js-hybrid-mappings` asset after a PHC bump.
> 
> The commit/push path no longer wraps `commit_current_changes` in `Dir.chdir(get_root_folder)`. That extra chdir stacked with fastlane’s per-action `Dir.chdir("..")` (from `fastlane/`), so git ran outside the repo and `git add` failed. **Uncommitted changes are detected** with `git -C get_root_folder status --porcelain` on the vendored path; commit and push run at the normal lane cwd where fastlane’s directory handling works.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f42a87cd034b5b2f92842bd2830bee6e724af71b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->