### PR TITLE
Use mise for Java in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ aliases:
 orbs:
   android: circleci/android@2.5.0
   swissknife: roopakv/swissknife@0.65.0
-  revenuecat: revenuecat/sdks-common-config@4.1.0
+  revenuecat: revenuecat/sdks-common-config@4.2.0
   macos: circleci/macos@2.3.2
   flutter: circleci/flutter@2.1.0
   ruby: circleci/ruby@2.5.3
@@ -147,17 +147,11 @@ commands:
           name: Create simulator
           command: xcrun simctl create '<< parameters.sim-name >>' com.apple.CoreSimulator.SimDeviceType.<< parameters.sim-device-type >> com.apple.CoreSimulator.SimRuntime.<< parameters.sim-device-runtime >>
 
-  install-sdkman:
-    description: Install SDKMAN and set up Java environment
+  install-mise-tools:
+    description: Install mise tools from mise.toml (Java, etc.)
     steps:
-      - revenuecat/install-sdkman
-      - run:
-          name: Setup Java environment
-          command: |
-            if ! sdk env install; then
-              echo "Error installing Java SDK through SDKMAN, continuing with default Java" >&2
-            fi
-  
+      - revenuecat/install-mise-tools
+
   install-correct-cocoapods:
     description: Install correct cocoapods version
     steps:
@@ -301,7 +295,7 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout
-      - install-sdkman
+      - install-mise-tools
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - flutter-get-dependencies:
@@ -330,7 +324,7 @@ jobs:
     steps:
       - checkout
       - replace-api-key
-      - install-sdkman
+      - install-mise-tools
       - run:
           working_directory: revenuecat_examples/purchase_tester/android
           command: |
@@ -346,7 +340,7 @@ jobs:
     steps:
       - checkout
       - replace-api-key
-      - install-sdkman
+      - install-mise-tools
       - android/create-avd:
           avd-name: integration-tests
           system-image: system-images;android-33;google_apis;x86_64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,11 +147,6 @@ commands:
           name: Create simulator
           command: xcrun simctl create '<< parameters.sim-name >>' com.apple.CoreSimulator.SimDeviceType.<< parameters.sim-device-type >> com.apple.CoreSimulator.SimRuntime.<< parameters.sim-device-runtime >>
 
-  install-mise-tools:
-    description: Install mise tools from mise.toml (Java, etc.)
-    steps:
-      - revenuecat/install-mise-tools
-
   install-correct-cocoapods:
     description: Install correct cocoapods version
     steps:
@@ -295,7 +290,7 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout
-      - install-mise-tools
+      - revenuecat/install-mise-tools
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - flutter-get-dependencies:
@@ -324,7 +319,7 @@ jobs:
     steps:
       - checkout
       - replace-api-key
-      - install-mise-tools
+      - revenuecat/install-mise-tools
       - run:
           working_directory: revenuecat_examples/purchase_tester/android
           command: |
@@ -340,7 +335,7 @@ jobs:
     steps:
       - checkout
       - replace-api-key
-      - install-mise-tools
+      - revenuecat/install-mise-tools
       - android/create-avd:
           avd-name: integration-tests
           system-image: system-images;android-33;google_apis;x86_64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ aliases:
 orbs:
   android: circleci/android@2.5.0
   swissknife: roopakv/swissknife@0.65.0
-  revenuecat: revenuecat/sdks-common-config@4.2.0
+  revenuecat: revenuecat/sdks-common-config@4.3.0
   macos: circleci/macos@2.3.2
   flutter: circleci/flutter@2.1.0
   ruby: circleci/ruby@2.5.3

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,6 @@
+# Deprecated: CI and local Java versions are managed in mise.toml.
+# This file is kept for reference only; do not add new SDKMAN pins here.
+#
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
 java=17.0.6-librca

--- a/mise.lock
+++ b/mise.lock
@@ -4,6 +4,54 @@
 version = "3.44.2"
 backend = "http:flutter"
 
+[tools.flutter."platforms.linux-x64"]
+checksum = "sha256:b0de1d19754688ec6769c9a067db3b0594479d3d767f971bfecfc132904c8d5e"
+url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.44.2-stable.tar.xz"
+
+[tools.flutter."platforms.linux-x64-musl"]
+checksum = "sha256:b0de1d19754688ec6769c9a067db3b0594479d3d767f971bfecfc132904c8d5e"
+url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.44.2-stable.tar.xz"
+
+[tools.flutter."platforms.macos-arm64"]
+checksum = "sha256:57fbfdc7032678ab30ad577872bbfc4114a25d3cba94fbfa14a050ec61381a23"
+url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_arm64_3.44.2-stable.zip"
+
+[tools.flutter."platforms.macos-x64"]
+checksum = "sha256:024d4e941ceb7c09fd9036e025c71bb8ce7e90eb2956fa8041a3260169aa2478"
+url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_3.44.2-stable.zip"
+
+[tools.flutter."platforms.windows-x64"]
+checksum = "sha256:d79ae99807ba744b843e54f048308c629061456fdc7b0753251fb96eb5346a0e"
+url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/windows/flutter_windows_3.44.2-stable.zip"
+
 [[tools.java]]
 version = "liberica-17.0.6+10"
 backend = "core:java"
+
+[tools.java."platforms.linux-arm64"]
+checksum = "sha1:3f35ee9fac9ab87b163333bc6c7802753730a680"
+url = "https://github.com/bell-sw/Liberica/releases/download/17.0.6%2B10/bellsoft-jdk17.0.6%2B10-linux-aarch64.tar.gz"
+
+[tools.java."platforms.linux-arm64-musl"]
+checksum = "sha1:95edb1e0015eac796053923234c12b665cd6b287"
+url = "https://github.com/bell-sw/Liberica/releases/download/17.0.6%2B10/bellsoft-jdk17.0.6%2B10-linux-aarch64-musl.tar.gz"
+
+[tools.java."platforms.linux-x64"]
+checksum = "sha1:3921ead0629aa003b3ec3afad7557bbea397fb1e"
+url = "https://github.com/bell-sw/Liberica/releases/download/17.0.6%2B10/bellsoft-jdk17.0.6%2B10-linux-amd64.tar.gz"
+
+[tools.java."platforms.linux-x64-musl"]
+checksum = "sha1:9c4f64693f71ca3c88c1321173887b1facda75e2"
+url = "https://github.com/bell-sw/Liberica/releases/download/17.0.6%2B10/bellsoft-jdk17.0.6%2B10-linux-x64-musl.tar.gz"
+
+[tools.java."platforms.macos-arm64"]
+checksum = "sha1:2af64f6f557c6cbf96cac7022eba2c9779a6be7a"
+url = "https://github.com/bell-sw/Liberica/releases/download/17.0.6%2B10/bellsoft-jdk17.0.6%2B10-macos-aarch64.tar.gz"
+
+[tools.java."platforms.macos-x64"]
+checksum = "sha1:e78e899e7a6449751c5431d53a9cb9ed001da90d"
+url = "https://github.com/bell-sw/Liberica/releases/download/17.0.6%2B10/bellsoft-jdk17.0.6%2B10-macos-amd64.tar.gz"
+
+[tools.java."platforms.windows-x64"]
+checksum = "sha1:04397d865b19e2d4b8102f4070b6c7a946846d6a"
+url = "https://github.com/bell-sw/Liberica/releases/download/17.0.6%2B10/bellsoft-jdk17.0.6%2B10-windows-amd64.zip"


### PR DESCRIPTION
Replaces the custom `install-sdkman` CI command with `revenuecat/install-mise-tools` from the updated `revenuecat/sdks-common-config@4.3.0` orb. 

The `.sdkmanrc` file is retained for reference but marked as deprecated. Platform-specific checksums and download URLs have been added to `mise.lock.`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only toolchain wiring with no application, auth, or runtime behavior changes; main risk is transient build failures if mise/orb installs misconfigure Java on affected jobs.
> 
> **Overview**
> CircleCI now installs **Java (and related tooling) via mise** instead of the removed in-repo **`install-sdkman`** helper, using **`revenuecat/install-mise-tools`** from **`revenuecat/sdks-common-config@4.3.0`** (up from 4.1.0).
> 
> That orb step replaces **`install-sdkman`** on **`api_test`**, **`android-integration-test-build`**, and **`android-integration-test`**. **`.sdkmanrc`** is marked deprecated in favor of **`mise.toml`**, and **`mise.lock`** gains per-platform checksums and download URLs for **Flutter** and **Liberica Java** so CI installs are pinned and reproducible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 104648d2961d28a93daf3b439a14ffb1f653019a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->