### PR TITLE
Fix OOM in android-integration-test-build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -315,7 +315,7 @@ jobs:
     description: "Build Android Flutter integration tests"
     docker:
       - image: ghcr.io/cirruslabs/flutter:stable
-    resource_class: large
+    resource_class: xlarge
     steps:
       - checkout
       - replace-api-key

--- a/revenuecat_examples/purchase_tester/android/gradle.properties
+++ b/revenuecat_examples/purchase_tester/android/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx4096M -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx8192M -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true


### PR DESCRIPTION
## What
- Bump the `android-integration-test-build` CI job from `large` (8GB) to `xlarge` (16GB) machine.
- Increase memory heap to 8GB

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and local Gradle tuning for the purchase_tester example only; no SDK, auth, or release behavior changes.
> 
> **Overview**
> Addresses **out-of-memory failures** in the `android-integration-test-build` CircleCI job by giving the build more host and JVM memory.
> 
> The job’s Docker executor **`resource_class` is raised from `large` to `xlarge`**, and **`purchase_tester` Android `org.gradle.jvmargs` heap is doubled from 4GB to 8GB** so `flutter build apk` and `./gradlew app:assembleAndroidTest` can complete reliably.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4815088038506c4186b8b01aca4551247521dbb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->