### PR TITLE
ci: pin Ruby 3.2.0 for bump/release/hybrid-common jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -656,14 +656,12 @@ workflows:
         - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
         - equal: [ "release-train", << pipeline.schedule.name >> ]
     jobs:
-      - revenuecat/automatic-bump:
-          ruby_version: "3.2.0"
+      - revenuecat/automatic-bump
   manual-trigger-bump:
     when:
       equal: [ bump, << pipeline.parameters.action >> ]
     jobs:
-      - revenuecat/automatic-bump:
-          ruby_version: "3.2.0"
+      - revenuecat/automatic-bump
   update-error-codes:
     when:
       equal: [ update_error_codes, << pipeline.parameters.action >> ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ aliases:
 orbs:
   android: circleci/android@2.5.0
   swissknife: roopakv/swissknife@0.65.0
-  revenuecat: revenuecat/sdks-common-config@4.4.0
+  revenuecat: revenuecat/sdks-common-config@4.5.0
   macos: circleci/macos@2.3.2
   flutter: circleci/flutter@2.1.0
   ruby: circleci/ruby@2.5.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -510,7 +510,7 @@ jobs:
   update-hybrid-common-versions:
     description: "Creates a PR updating purchases-hybrid-common to latest release"
     docker:
-      - image: cimg/ruby:3.1.2
+      - image: cimg/ruby:3.2.0
     steps:
       - checkout
       - revenuecat/install-gem-unix-dependencies:
@@ -556,7 +556,7 @@ jobs:
   github_release:
     description: "Creates a github release with the current version"
     docker:
-      - image: cimg/ruby:3.1.2
+      - image: cimg/ruby:3.2.0
     steps:
       - checkout
       - revenuecat/install-gem-unix-dependencies:
@@ -656,12 +656,14 @@ workflows:
         - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
         - equal: [ "release-train", << pipeline.schedule.name >> ]
     jobs:
-      - revenuecat/automatic-bump
+      - revenuecat/automatic-bump:
+          ruby_version: "3.2.0"
   manual-trigger-bump:
     when:
       equal: [ bump, << pipeline.parameters.action >> ]
     jobs:
-      - revenuecat/automatic-bump
+      - revenuecat/automatic-bump:
+          ruby_version: "3.2.0"
   update-error-codes:
     when:
       equal: [ update_error_codes, << pipeline.parameters.action >> ]


### PR DESCRIPTION
### Motivation

The scheduled `update-hybrid-common-versions` job failed at `bundle install`. It runs on Ruby 3.1.2, but the locked gems require Ruby >= 3.2, so Bundler backtracks to `fastlane 0.0.1` / `nokogiri 1.6.8.1`, whose native extension fails to build (`net/ftp` was removed in Ruby 3.1).

### Summary

- Bump `update-hybrid-common-versions` and `github_release` job images to `cimg/ruby:3.2.0`.
- Bump the orb to `revenuecat/sdks-common-config@4.5.0`, whose `automatic-bump`/`danger` default to Ruby 3.2.0, so no per-usage `ruby_version` pin is needed.

### Notes

- Orb default bumped in sdks-circleci-orb#81 (released as v4.5.0).
- `update-error-codes` is unaffected (uses the `codegen` executor on Ruby 3.3).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI image and orb version changes only; no application runtime or release artifact logic is modified.
> 
> **Overview**
> Fixes failing **`bundle install`** on scheduled hybrid-common update and related release automation by aligning CircleCI Ruby with the locked gem set (requires **Ruby ≥ 3.2**).
> 
> **`update-hybrid-common-versions`** and **`github_release`** now use **`cimg/ruby:3.2.0`** instead of **3.1.2**. **`revenuecat/sdks-common-config`** is bumped **4.4.0 → 4.5.0** so **`revenuecat/automatic-bump`** picks up the orb’s default Ruby **3.2.0** without a per-job image override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24d7118d6a9735f5ede398009811aa218cc5e5d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->