### PR TITLE
chore: bump fastlane-plugin-revenuecat_internal to unblock hybrid bumps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: dab67655d71eaf08b40f74339e4bb17d16436c32
+  revision: 9b928b6ca92e965ecb7d63edb810e9343975f3de
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
       nokogiri


### PR DESCRIPTION
### Motivation
Hybrid version bumps crash in `update_hybrids_versions_file` with `undefined method 'captures' for nil:NilClass`, because the plugin looked up a removed `bc8` key in purchases-android's `libs.versions.toml`.

### Summary
- Bump the pinned `fastlane-plugin-revenuecat_internal` revision to `main` HEAD, which includes the fix (RevenueCat/fastlane-plugin-revenuecat_internal#145).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only change to internal Fastlane tooling; no SDK or app runtime code is modified.
> 
> **Overview**
> Pins **`fastlane-plugin-revenuecat_internal`** to a newer git revision in **`Gemfile.lock`** (`dab6765` → `9b928b6`). The plugin spec version stays **0.1.0**; only the upstream commit changes.
> 
> This pulls in the fix from RevenueCat/fastlane-plugin-revenuecat_internal#145 so hybrid version bumps no longer crash in **`update_hybrids_versions_file`** with `undefined method 'captures' for nil:NilClass` when the Android **`libs.versions.toml`** no longer has the **`bc8`** key the old plugin expected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7923b7970b0046dfad6059217ffb41adeed9b230. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->