### PR TITLE
Add onWebCheckoutOpened and onUrlOpened to the paywall listener

### DIFF
--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallView.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallView.kt
@@ -72,6 +72,10 @@ internal class PaywallView(
             override fun onRestoreError(error: Map<String, Any?>) {
                 methodChannel.invokeMethod("onRestoreError", error)
             }
+
+            override fun onWebCheckoutOpened() {
+                methodChannel.invokeMethod("onWebCheckoutOpened", null)
+            }
         })
         // Custom variables must be set before setting the offering to ensure they're applied
         val customVariables = creationParams["customVariables"] as? Map<String, Any?>

--- a/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallView.kt
+++ b/purchases_ui_flutter/android/src/main/kotlin/com/revenuecat/purchases_ui_flutter/views/PaywallView.kt
@@ -76,6 +76,10 @@ internal class PaywallView(
             override fun onWebCheckoutOpened() {
                 methodChannel.invokeMethod("onWebCheckoutOpened", null)
             }
+
+            override fun onUrlOpened(url: String) {
+                methodChannel.invokeMethod("onUrlOpened", mapOf("url" to url))
+            }
         })
         // Custom variables must be set before setting the offering to ensure they're applied
         val customVariables = creationParams["customVariables"] as? Map<String, Any?>

--- a/purchases_ui_flutter/ios/purchases_ui_flutter/Sources/purchases_ui_flutter/PurchasesUiPaywallView.swift
+++ b/purchases_ui_flutter/ios/purchases_ui_flutter/Sources/purchases_ui_flutter/PurchasesUiPaywallView.swift
@@ -168,4 +168,8 @@ extension PurchasesUiPaywallView: PaywallViewControllerDelegateWrapper {
     func paywallViewControllerDidOpenWebCheckout(_ controller: PaywallViewController) {
         _methodChannel.invokeMethod("onWebCheckoutOpened", arguments: nil)
     }
+
+    func paywallViewController(_ controller: PaywallViewController, didOpenURL url: URL) {
+        _methodChannel.invokeMethod("onUrlOpened", arguments: ["url": url.absoluteString])
+    }
 }

--- a/purchases_ui_flutter/ios/purchases_ui_flutter/Sources/purchases_ui_flutter/PurchasesUiPaywallView.swift
+++ b/purchases_ui_flutter/ios/purchases_ui_flutter/Sources/purchases_ui_flutter/PurchasesUiPaywallView.swift
@@ -169,7 +169,7 @@ extension PurchasesUiPaywallView: PaywallViewControllerDelegateWrapper {
         _methodChannel.invokeMethod("onWebCheckoutOpened", arguments: nil)
     }
 
-    func paywallViewController(_ controller: PaywallViewController, didOpenURL url: URL) {
-        _methodChannel.invokeMethod("onUrlOpened", arguments: ["url": url.absoluteString])
+    func paywallViewController(_ controller: PaywallViewController, didOpenURL url: String) {
+        _methodChannel.invokeMethod("onUrlOpened", arguments: ["url": url])
     }
 }

--- a/purchases_ui_flutter/ios/purchases_ui_flutter/Sources/purchases_ui_flutter/PurchasesUiPaywallView.swift
+++ b/purchases_ui_flutter/ios/purchases_ui_flutter/Sources/purchases_ui_flutter/PurchasesUiPaywallView.swift
@@ -164,4 +164,8 @@ extension PurchasesUiPaywallView: PaywallViewControllerDelegateWrapper {
     func paywallViewControllerRequestedDismissal(_ controller: PaywallViewController) {
         _methodChannel.invokeMethod("onDismiss", arguments: nil)
     }
+
+    func paywallViewControllerDidOpenWebCheckout(_ controller: PaywallViewController) {
+        _methodChannel.invokeMethod("onWebCheckoutOpened", arguments: nil)
+    }
 }

--- a/purchases_ui_flutter/lib/views/paywall_view.dart
+++ b/purchases_ui_flutter/lib/views/paywall_view.dart
@@ -48,6 +48,9 @@ import 'paywall_view_method_handler.dart';
 /// dismiss. Currently, after a purchase is completed or when the close button
 /// is tapped.
 ///
+/// [onWebCheckoutOpened] (Optional) Callback that gets called when the user
+/// taps a web checkout CTA and leaves the app to complete payment externally.
+///
 /// [customVariables] (Optional) A map of custom variable names to their values.
 /// These values can be used for text substitution in paywalls using the
 /// `{{ custom.variable_name }}` syntax.
@@ -69,6 +72,7 @@ class PaywallView extends StatelessWidget {
   final Function(CustomerInfo customerInfo)? onRestoreCompleted;
   final Function(PurchasesError)? onRestoreError;
   final Function()? onDismiss;
+  final Function()? onWebCheckoutOpened;
 
   const PaywallView({
     Key? key,
@@ -83,6 +87,7 @@ class PaywallView extends StatelessWidget {
     this.onRestoreCompleted,
     this.onRestoreError,
     this.onDismiss,
+    this.onWebCheckoutOpened,
   }) : super(key: key);
 
   static const String _viewType = 'com.revenuecat.purchasesui/PaywallView';
@@ -151,6 +156,7 @@ class PaywallView extends StatelessWidget {
       onRestoreCompleted,
       onRestoreError,
       onDismiss,
+      onWebCheckoutOpened: onWebCheckoutOpened,
       purchaseLogic: purchaseLogic,
       methodChannel: methodChannel,
     );

--- a/purchases_ui_flutter/lib/views/paywall_view.dart
+++ b/purchases_ui_flutter/lib/views/paywall_view.dart
@@ -51,6 +51,10 @@ import 'paywall_view_method_handler.dart';
 /// [onWebCheckoutOpened] (Optional) Callback that gets called when the user
 /// taps a web checkout CTA and leaves the app to complete payment externally.
 ///
+/// [onUrlOpened] (Optional) Callback that gets called when the paywall opens a
+/// URL from a button URL destination or a text link. Not called for web
+/// checkout URLs.
+///
 /// [customVariables] (Optional) A map of custom variable names to their values.
 /// These values can be used for text substitution in paywalls using the
 /// `{{ custom.variable_name }}` syntax.
@@ -73,6 +77,7 @@ class PaywallView extends StatelessWidget {
   final Function(PurchasesError)? onRestoreError;
   final Function()? onDismiss;
   final Function()? onWebCheckoutOpened;
+  final Function(String url)? onUrlOpened;
 
   const PaywallView({
     Key? key,
@@ -88,6 +93,7 @@ class PaywallView extends StatelessWidget {
     this.onRestoreError,
     this.onDismiss,
     this.onWebCheckoutOpened,
+    this.onUrlOpened,
   }) : super(key: key);
 
   static const String _viewType = 'com.revenuecat.purchasesui/PaywallView';
@@ -157,6 +163,7 @@ class PaywallView extends StatelessWidget {
       onRestoreError,
       onDismiss,
       onWebCheckoutOpened: onWebCheckoutOpened,
+      onUrlOpened: onUrlOpened,
       purchaseLogic: purchaseLogic,
       methodChannel: methodChannel,
     );

--- a/purchases_ui_flutter/lib/views/paywall_view_method_handler.dart
+++ b/purchases_ui_flutter/lib/views/paywall_view_method_handler.dart
@@ -16,6 +16,7 @@ class PaywallViewMethodHandler {
   final Function(PurchasesError)? onRestoreError;
   final Function()? onDismiss;
   final Function()? onWebCheckoutOpened;
+  final Function(String url)? onUrlOpened;
   final PaywallPurchaseLogic? purchaseLogic;
   final MethodChannel? methodChannel;
 
@@ -28,6 +29,7 @@ class PaywallViewMethodHandler {
     this.onRestoreError,
     this.onDismiss, {
     this.onWebCheckoutOpened,
+    this.onUrlOpened,
     this.purchaseLogic,
     this.methodChannel,
   });
@@ -57,6 +59,11 @@ class PaywallViewMethodHandler {
         break;
       case 'onWebCheckoutOpened':
         onWebCheckoutOpened?.call();
+        break;
+      case 'onUrlOpened':
+        onUrlOpened?.call(
+          Map<String, dynamic>.from(call.arguments)['url'] as String,
+        );
         break;
       case 'onPerformPurchase':
         _handleOnPerformPurchase(call);

--- a/purchases_ui_flutter/lib/views/paywall_view_method_handler.dart
+++ b/purchases_ui_flutter/lib/views/paywall_view_method_handler.dart
@@ -15,6 +15,7 @@ class PaywallViewMethodHandler {
   final Function(CustomerInfo customerInfo)? onRestoreCompleted;
   final Function(PurchasesError)? onRestoreError;
   final Function()? onDismiss;
+  final Function()? onWebCheckoutOpened;
   final PaywallPurchaseLogic? purchaseLogic;
   final MethodChannel? methodChannel;
 
@@ -26,6 +27,7 @@ class PaywallViewMethodHandler {
     this.onRestoreCompleted,
     this.onRestoreError,
     this.onDismiss, {
+    this.onWebCheckoutOpened,
     this.purchaseLogic,
     this.methodChannel,
   });
@@ -52,6 +54,9 @@ class PaywallViewMethodHandler {
         break;
       case 'onDismiss':
         onDismiss?.call();
+        break;
+      case 'onWebCheckoutOpened':
+        onWebCheckoutOpened?.call();
         break;
       case 'onPerformPurchase':
         _handleOnPerformPurchase(call);


### PR DESCRIPTION
Adds `onWebCheckoutOpened` and `onUrlOpened` callbacks to `PaywallView`, forwarding the native paywall listener events (available in PHC 18.29.0).

- `onWebCheckoutOpened`: the user tapped a web checkout CTA and left the app to pay externally.
- `onUrlOpened(url)`: the paywall opened a URL from a button URL destination or a text-component link. Not called for web checkout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, optional listener API with no changes to purchase, restore, or dismiss flows; risk is mainly apps that open URLs in custom handlers without validating the string.
> 
> **Overview**
> Adds optional **`onWebCheckoutOpened`** and **`onUrlOpened`** callbacks on **`PaywallView`**, matching native paywall listener events from PHC 18.29.0.
> 
> **`onWebCheckoutOpened`** runs when the user taps a web checkout CTA and leaves the app for external payment. **`onUrlOpened(url)`** runs when the paywall opens a URL from a button destination or text link (not web checkout URLs).
> 
> Android and iOS platform views forward these via the existing method channel; **`PaywallViewMethodHandler`** dispatches them to the Dart callbacks. Existing paywall behavior is unchanged when the callbacks are omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e7267109b08151c753e7992f4e90ec61b94f082. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->