### PR TITLE
Remove workflows dangerous settings

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -125,12 +125,11 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                         .argument("automaticDeviceIdentifierCollectionEnabled");
                 Boolean diagnosticsEnabled = call.argument("diagnosticsEnabled");
                 String preferredUILocaleOverride = call.argument("preferredUILocaleOverride");
-                Boolean useWorkflows = call.argument("useWorkflows");
                 setupPurchases(apiKey, appUserId, purchasesAreCompletedBy, useAmazon,
                         shouldShowInAppMessagesAutomatically, verificationMode,
                         pendingTransactionsForPrepaidPlansEnabled,
                         automaticDeviceIdentifierCollectionEnabled, diagnosticsEnabled,
-                        preferredUILocaleOverride, useWorkflows, result);
+                        preferredUILocaleOverride, result);
                 break;
             case "setAllowSharingStoreAccount":
                 Boolean allowSharing = call.argument("allowSharing");
@@ -426,7 +425,6 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
             @Nullable Boolean automaticDeviceIdentifierCollectionEnabled,
             @Nullable Boolean diagnosticsEnabled,
             @Nullable String preferredUILocaleOverride,
-            @Nullable Boolean useWorkflows,
             final Result result) {
         if (this.applicationContext != null) {
             PlatformInfo platformInfo = new PlatformInfo(PLATFORM_NAME, PLUGIN_VERSION);
@@ -435,16 +433,13 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
                 store = Store.AMAZON;
             }
 
-            DangerousSettings dangerousSettings = useWorkflows != null && useWorkflows
-                    ? DangerousSettings.forWorkflows(true)
-                    : new DangerousSettings();
             CommonKt.configure(this.applicationContext,
                     apiKey,
                     appUserID,
                     purchasesAreCompletedBy,
                     platformInfo,
                     store,
-                    dangerousSettings,
+                    new DangerousSettings(),
                     shouldShowInAppMessagesAutomatically,
                     verificationMode,
                     pendingTransactionsForPrepaidPlansEnabled,

--- a/api_tester/lib/api_tests/models/purchase_configuration_api_test.dart
+++ b/api_tester/lib/api_tests/models/purchase_configuration_api_test.dart
@@ -25,23 +25,9 @@ class _PurchaseConfigurationApiTest {
     configuration.storeKitVersion = storeKitVersion;
     configuration.automaticDeviceIdentifierCollectionEnabled = true;
     configuration.diagnosticsEnabled = true;
-    DangerousSettings? dangerousSettings = configuration.dangerousSettings;
-    configuration.dangerousSettings = null;
-    configuration.dangerousSettings = dangerousSettings;
 
     // deprecated, but we still need to check that the API hasn't been removed.
     configuration.pendingTransactionsForPrepaidPlansEnabled = true;
-  }
-
-  void _checkDangerousSettingsConstructor() {
-    DangerousSettings settings = DangerousSettings();
-    DangerousSettings settingsWithWorkflows =
-        DangerousSettings(useWorkflows: true);
-  }
-
-  void _checkDangerousSettingsProperties(DangerousSettings settings) {
-    bool useWorkflows = settings.useWorkflows;
-    settings.useWorkflows = true;
   }
 
   void _checkAmazonConfigurationConstructor() {

--- a/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
+++ b/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
@@ -84,7 +84,6 @@ shouldShowInAppMessagesAutomatically: shouldShowInAppMessagesAutomatically
 automaticDeviceIdentifierCollectionEnabled:automaticDeviceIdentifierCollectionEnabled
           diagnosticsEnabled:diagnosticsEnabled
    preferredUILocaleOverride:preferredUILocaleOverride
-            useWorkflows:[arguments[@"useWorkflows"] mappingNSNullToNil]
                       result:result];
     } else if ([@"setAllowSharingStoreAccount" isEqualToString:call.method]) {
         [self setAllowSharingStoreAccount:[arguments[@"allowSharing"] boolValue] result:result];
@@ -311,7 +310,6 @@ shouldShowInAppMessagesAutomatically:(BOOL)shouldShowInAppMessagesAutomatically
 automaticDeviceIdentifierCollectionEnabled:(BOOL)automaticDeviceIdentifierCollectionEnabled
     diagnosticsEnabled:(BOOL)diagnosticsEnabled
  preferredUILocaleOverride:(nullable NSString *)preferredUILocaleOverride
-           useWorkflows:(nullable NSNumber *)useWorkflows
                  result:(FlutterResult)result {
     if ([appUserID isKindOfClass:NSNull.class]) {
         appUserID = nil;
@@ -320,13 +318,7 @@ automaticDeviceIdentifierCollectionEnabled:(BOOL)automaticDeviceIdentifierCollec
         userDefaultsSuiteName = nil;
     }
 
-    // Stay nil unless the Dart side actually set dangerousSettings, so the default path keeps
-    // relying on the native DangerousSettings defaults instead of pinning them here. An explicit
-    // NO is forwarded as such rather than collapsing into the unset case.
-    RCDangerousSettings *dangerousSettings = useWorkflows == nil
-        ? nil
-        : [RCDangerousSettings createDangerousSettingsWithAutoSyncPurchases:YES
-                                                               useWorkflows:useWorkflows.boolValue];
+    // nil so the native SDK applies its own DangerousSettings defaults.
     RCPurchases *purchases = [RCPurchases configureWithAPIKey:apiKey
                                                     appUserID:appUserID
                                       purchasesAreCompletedBy:purchasesAreCompletedBy
@@ -334,7 +326,7 @@ automaticDeviceIdentifierCollectionEnabled:(BOOL)automaticDeviceIdentifierCollec
                                                platformFlavor:self.platformFlavor
                                         platformFlavorVersion:self.platformFlavorVersion
                                               storeKitVersion:storeKitVersion
-                                            dangerousSettings:dangerousSettings
+                                            dangerousSettings:nil
                          shouldShowInAppMessagesAutomatically:shouldShowInAppMessagesAutomatically
                                              verificationMode:verificationMode
                                            diagnosticsEnabled:diagnosticsEnabled

--- a/lib/models/purchases_configuration.dart
+++ b/lib/models/purchases_configuration.dart
@@ -80,17 +80,6 @@ class PurchasesConfiguration {
   /// No personal identifiable information will be collected.
   /// The default value is false.
   bool diagnosticsEnabled = false;
-
-  /// Dangerous settings for the SDK. Internal RevenueCat use only.
-  DangerousSettings? dangerousSettings;
-}
-
-/// Internal RevenueCat-only settings that may change without warning.
-class DangerousSettings {
-  /// Enables RevenueCat Workflows (multipage paywalls).
-  bool useWorkflows;
-
-  DangerousSettings({this.useWorkflows = false});
 }
 
 /// A [PurchasesConfiguration] convenience object that

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -191,7 +191,6 @@ class Purchases {
         'diagnosticsEnabled': purchasesConfiguration.diagnosticsEnabled,
         'preferredUILocaleOverride':
             purchasesConfiguration.preferredUILocaleOverride,
-        'useWorkflows': purchasesConfiguration.dangerousSettings?.useWorkflows,
       },
     );
   }

--- a/test/purchases_flutter_test.dart
+++ b/test/purchases_flutter_test.dart
@@ -103,7 +103,6 @@ void main() {
             'automaticDeviceIdentifierCollectionEnabled': true,
             'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
-            'useWorkflows': null,
           },
         ),
       ],
@@ -136,7 +135,6 @@ void main() {
             'automaticDeviceIdentifierCollectionEnabled': true,
             'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
-            'useWorkflows': null,
           },
         ),
       ],
@@ -167,7 +165,6 @@ void main() {
             'automaticDeviceIdentifierCollectionEnabled': true,
             'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
-            'useWorkflows': null,
           },
         ),
       ],
@@ -201,67 +198,6 @@ void main() {
             'automaticDeviceIdentifierCollectionEnabled': true,
             'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
-            'useWorkflows': null,
-          },
-        ),
-      ],
-    );
-  });
-
-  test('setupPurchases with workflows', () async {
-    await Purchases.configure(
-      PurchasesConfiguration('api_key')
-        ..dangerousSettings = DangerousSettings(useWorkflows: true),
-    );
-    expect(
-      log,
-      <Matcher>[
-        isMethodCall(
-          'setupPurchases',
-          arguments: <String, dynamic>{
-            'apiKey': 'api_key',
-            'appUserId': null,
-            'purchasesAreCompletedBy': 'REVENUECAT',
-            'userDefaultsSuiteName': null,
-            'useAmazon': false,
-            'storeKitVersion': 'DEFAULT',
-            'shouldShowInAppMessagesAutomatically': true,
-            'entitlementVerificationMode': 'DISABLED',
-            'pendingTransactionsForPrepaidPlansEnabled': false,
-            'automaticDeviceIdentifierCollectionEnabled': true,
-            'diagnosticsEnabled': false,
-            'preferredUILocaleOverride': null,
-            'useWorkflows': true,
-          },
-        ),
-      ],
-    );
-  });
-
-  test('setupPurchases with workflows explicitly disabled', () async {
-    await Purchases.configure(
-      PurchasesConfiguration('api_key')
-        ..dangerousSettings = DangerousSettings(useWorkflows: false),
-    );
-    expect(
-      log,
-      <Matcher>[
-        isMethodCall(
-          'setupPurchases',
-          arguments: <String, dynamic>{
-            'apiKey': 'api_key',
-            'appUserId': null,
-            'purchasesAreCompletedBy': 'REVENUECAT',
-            'userDefaultsSuiteName': null,
-            'useAmazon': false,
-            'storeKitVersion': 'DEFAULT',
-            'shouldShowInAppMessagesAutomatically': true,
-            'entitlementVerificationMode': 'DISABLED',
-            'pendingTransactionsForPrepaidPlansEnabled': false,
-            'automaticDeviceIdentifierCollectionEnabled': true,
-            'diagnosticsEnabled': false,
-            'preferredUILocaleOverride': null,
-            'useWorkflows': false,
           },
         ),
       ],
@@ -1797,7 +1733,6 @@ void main() {
             'automaticDeviceIdentifierCollectionEnabled': true,
             'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
-            'useWorkflows': null,
           },
         ),
       ],
@@ -1829,7 +1764,6 @@ void main() {
             'automaticDeviceIdentifierCollectionEnabled': true,
             'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
-            'useWorkflows': null,
           },
         ),
       ],
@@ -1862,7 +1796,6 @@ void main() {
             'automaticDeviceIdentifierCollectionEnabled': true,
             'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
-            'useWorkflows': null,
           },
         ),
       ],
@@ -1896,7 +1829,6 @@ void main() {
             'automaticDeviceIdentifierCollectionEnabled': true,
             'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
-            'useWorkflows': null,
           },
         ),
       ],
@@ -1927,7 +1859,6 @@ void main() {
             'automaticDeviceIdentifierCollectionEnabled': false,
             'diagnosticsEnabled': false,
             'preferredUILocaleOverride': null,
-            'useWorkflows': null,
           },
         ),
       ],
@@ -1958,7 +1889,6 @@ void main() {
             'automaticDeviceIdentifierCollectionEnabled': true,
             'diagnosticsEnabled': false,
             'preferredUILocaleOverride': 'de_DE',
-            'useWorkflows': null,
           },
         ),
       ],
@@ -1989,7 +1919,6 @@ void main() {
             'automaticDeviceIdentifierCollectionEnabled': true,
             'diagnosticsEnabled': true,
             'preferredUILocaleOverride': null,
-            'useWorkflows': null,
           },
         ),
       ],


### PR DESCRIPTION
Workflows are always enabled now, so this flag has nothing left to toggle, and both native calls the plugin made are already gone:

- iOS: `createDangerousSettingsWithAutoSyncPurchases:useWorkflows:` is deleted by RevenueCat/purchases-hybrid-common#1794 (follow-up to RevenueCat/purchases-ios#7327)
- Android: `DangerousSettings.forWorkflows()` is already gone from `purchases-android` main via RevenueCat/purchases-android#3864

So without this the plugin stops compiling on the next bump of either.

`DangerousSettings` held `useWorkflows` and nothing else, so the class and `PurchasesConfiguration.dangerousSettings` go with it. Both were documented "Internal RevenueCat use only", and the flag shipped in 10.5.0 under Other Changes as internal support.

Each plugin now lets the native SDK apply its own DangerousSettings defaults, which is exactly what the unset path already did. That means this compiles against both the current and the next versions of both SDKs, so it can land before or after the PHC bump.

**Label question for the reviewer:** tagged `pr:other` to mirror how #1829 added it, but `PurchasesConfiguration.dangerousSettings` was public and released, so if we want to be strict this is `pr:breaking`. Happy to switch.

- [x] A description about what and why you are contributing, even if it's trivial.
- [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.
- [x] If applicable, unit tests. (removed the two tests covering the flag; the rest of the suite passes)

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: this PR
- Branch: `facu/remove-workflows-dangerous-settings`
- Author / human owner: @facumenzella
- Agent(s): Claude Code (claude-opus-5[1m])
- Session source: current conversation
- Generated: 2026-07-31
- Context document version: 1

## Goal

Remove `useWorkflows` from purchases-flutter so the plugin keeps compiling after the iOS and Android SDKs dropped the underlying dangerous setting.

## Initial Prompt

"can you work on flutter?" — following a cross-repo sweep that found purchases-flutter still calling the removed native APIs. The work that defined this task was the earlier iOS removal (RevenueCat/purchases-ios#7327) and tracing its blast radius across the hybrid repos.

## Important Follow-up Prompts

- None. The scope was set by the iOS/Android removals and the PHC precedent (#1794).

## Agent Contribution

- Traced the break: found `PurchasesFlutterPlugin.m:328` calling the PHC factory that #1794 deletes, and `PurchasesFlutterPlugin.java:439` calling `DangerousSettings.forWorkflows(true)`, already absent from purchases-android main.
- Established that `DangerousSettings` in Dart existed solely for this flag, so removing the field would leave an empty class and a pointless `dangerousSettings` property.
- Removed the flag across the Dart API, both native plugins, the api_tester, and the unit tests.
- Confirmed the flag had shipped (10.5.0) rather than being unreleased, which is what makes the label question real.

## Human Decisions

- Decision: work Flutter before Unity, since PHC #1794 is the trigger for the iOS side of the Flutter break.
- Open for the reviewer: `pr:other` vs `pr:breaking` (see above).

## Key Implementation Decisions

- Decision: delete the `DangerousSettings` class and `PurchasesConfiguration.dangerousSettings` rather than keep an empty class.
  - Rationale: the class had exactly one field. Mirrors PHC #1794 deleting `DangerousSettings+HybridAdditions.swift` outright.
  - Rejected: keeping a deprecated no-op field. It would preserve source compatibility, but leaves a permanently empty public class in a hybrid SDK.
- Decision: iOS passes `dangerousSettings:nil`, Android passes `new DangerousSettings()`.
  - Rationale: both are exactly what the previous unset/false paths did, so behavior is unchanged and the plugin compiles against old and new native SDKs alike. No coordinated merge order required.
- Decision: deleted the two tests dedicated to the flag ("setupPurchases with workflows" and "...explicitly disabled") rather than adapting them; their subject no longer exists. Dropped the `useWorkflows` key from the other 13 expected-argument maps.

## Files / Symbols Touched

- `lib/models/purchases_configuration.dart`
  - Why: remove the public Dart surface.
  - Symbols: `DangerousSettings` (class removed), `PurchasesConfiguration.dangerousSettings` (property removed)
  - Review relevance: this is the only consumer-visible removal in the PR.
- `lib/purchases_flutter.dart`
  - Why: stop sending `useWorkflows` over the method channel.
  - Symbols: `configure` argument map
- `ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m`
  - Why: it called the PHC factory deleted by #1794.
  - Symbols: `setupPurchases:...` (param dropped), the `RCDangerousSettings` construction (removed)
  - Review relevance: confirm `dangerousSettings:nil` is the intended default, matching the old unset path.
- `android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java`
  - Why: it called the removed `DangerousSettings.forWorkflows()`.
  - Symbols: `setupPurchases(...)` (param dropped), `CommonKt.configure` call
  - Review relevance: the `DangerousSettings` import is still needed for `new DangerousSettings()`.
- `api_tester/lib/api_tests/models/purchase_configuration_api_test.dart`
  - Why: asserted the now-removed API.
  - Symbols: `_checkDangerousSettingsConstructor`, `_checkDangerousSettingsProperties` (both removed), plus the `dangerousSettings` property checks
- `test/purchases_flutter_test.dart`
  - Why: two flag-specific tests plus 13 expected-argument maps.

## Dependencies / Config / Migrations

- No dependency or version changes. Deliberately compatible with both the current and next PHC / purchases-android versions, so merge order is unconstrained.

## Validation

- Commands run:
  - `flutter pub get`: succeeded.
  - `flutter test`: **All tests passed!** (168 tests)
  - `flutter analyze`: 365 issues, **zero errors or warnings in any file this PR touches**. Verified by filtering the analyzer output to the changed paths. The errors present are in `purchases_ui_flutter/`, `revenuecat_examples/`, and `e2e-tests/MaestroTestApp`, which need their own `pub get`; they are untouched by this PR.
  - `grep -rn "useWorkflows"` across the repo: no matches remain.
- Manual verification:
  - Not run. No app was launched on a device or simulator.
- CI:
  - Not captured at time of writing.

## Validation Gaps

- **Neither native plugin was compiled locally.** The ObjC change needs an iOS build of the example app (pod install) and the Java change needs a Gradle/Android SDK build; neither was run. Both edits are mechanical (drop a threaded parameter, drop a local construction), but that is reasoning, not a compile. CI is the real check here.
- No integration test exercised `configure` end to end against a native SDK, so "native applies its own defaults" is verified by reading the previous unset path, not by observing it.

## Review Focus

- iOS: is `dangerousSettings:nil` right, or should it construct a default `RCDangerousSettings`? The old code passed nil whenever the Dart side hadn't set the property, which was the normal case, so nil should be the status quo.
- Android: `new DangerousSettings()` replaces the previous ternary's else branch verbatim. Worth confirming `CommonKt.configure` has no non-null expectation beyond that.
- Dart: removing a released public property is the one consumer-visible change. Is `pr:other` the right label, or `pr:breaking`?
- Anything else in the plugin that assumed `dangerousSettings` could be non-null?

## Risks / Reviewer Notes

- Risk: source break for any app that set `dangerousSettings`.
  - Evidence: the property and class were both documented "Internal RevenueCat use only", and the feature shipped in 10.5.0 under Other Changes rather than as a public feature. Realistically only RevenueCat-internal apps set it.
  - Mitigation: none applied. Raised as the label question instead.
- Risk: a native plugin fails to compile in CI.
  - Evidence: not compiled locally, see Validation Gaps.
  - Mitigation: CI builds both plugins.

## Non-goals / Out of Scope

- `purchases-unity` still calls both removed APIs (`RCPurchasesUnityDangerousSettingsFactory.swift` on iOS, `PurchasesWrapper.java` for `forWorkflows`) and exposes a public C# `UseWorkflows` field. Not addressed here; it needs its own PR.
- No changes to `purchases_ui_flutter` or the example apps.

## Omitted Context

- Raw transcript, unrelated exploration, sensitive details, repetitive attempts, and chain-of-thought-style content were omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes released public Dart API (`DangerousSettings`, `PurchasesConfiguration.dangerousSettings`) and changes configure bridging; native compile compatibility is the main integration risk until CI builds iOS/Android plugins.
> 
> **Overview**
> Removes the **workflows** dangerous-setting surface from purchases-flutter now that native iOS/Android SDKs always enable workflows and have dropped the related APIs.
> 
> **Dart API:** Deletes the `DangerousSettings` class and `PurchasesConfiguration.dangerousSettings`. `Purchases.configure` no longer sends `useWorkflows` over the method channel.
> 
> **Native plugins:** Android stops reading `useWorkflows` and no longer calls `DangerousSettings.forWorkflows()`; configure uses `new DangerousSettings()` (same as the previous unset path). iOS passes `dangerousSettings:nil` so the native SDK applies its own defaults instead of building settings from Dart.
> 
> **Tests:** Workflow-specific unit tests and api_tester checks for `DangerousSettings` are removed; expected `setupPurchases` argument maps no longer include `useWorkflows`.
> 
> Apps that set `dangerousSettings` / `useWorkflows` will need to remove that configuration; runtime behavior for typical apps should match the old default (workflows on).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c2629092f6b43d40b14fe45bd1472e254126b07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->