### PR TITLE
feat(ads): ad reward tracking support

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
+++ b/android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java
@@ -966,7 +966,11 @@ public class PurchasesFlutterPlugin implements FlutterPlugin, MethodCallHandler,
     }
 
     private void pollRewardVerification(Map<String, Object> arguments, final Result result) {
-        CommonKt.pollRewardVerification((String) arguments.get("clientTransactionId"), getOnResult(result));
+        Object trackingMetadataArg = arguments.get("trackingMetadata");
+        Map<String, Object> trackingMetadata = trackingMetadataArg instanceof Map
+                ? stringKeyedMapWithoutNullValues((Map<?, ?>) trackingMetadataArg)
+                : null;
+        CommonKt.pollRewardVerification((String) arguments.get("clientTransactionId"), getOnResult(result), trackingMetadata);
     }
 
     private void runOnUiThread(Runnable runnable) {

--- a/api_tester/lib/api_tests/models/reward_verification_api_test.dart
+++ b/api_tester/lib/api_tests/models/reward_verification_api_test.dart
@@ -61,3 +61,24 @@ class _RewardVerificationResultApiTest {
     List<VerifiedReward> moreRewards = result.moreRewards;
   }
 }
+
+class _RewardedAdTrackingMetadataApiTest {
+  void _checkConstructor() {
+    RewardedAdTrackingMetadata data = const RewardedAdTrackingMetadata(
+      mediatorName: AdMediatorName.adMob,
+      adFormat: AdFormat.rewarded,
+      adUnitId: 'unit-1',
+      impressionId: 'imp-1',
+    );
+  }
+
+  void _checkProperties(RewardedAdTrackingMetadata data) {
+    String? networkName = data.networkName;
+    AdMediatorName mediatorName = data.mediatorName;
+    AdFormat adFormat = data.adFormat;
+    String? placement = data.placement;
+    String adUnitId = data.adUnitId;
+    String impressionId = data.impressionId;
+    Map<String, dynamic> map = data.toMap();
+  }
+}

--- a/api_tester/lib/api_tests/purchases_flutter_api_test.dart
+++ b/api_tester/lib/api_tests/purchases_flutter_api_test.dart
@@ -753,6 +753,18 @@ class _PurchasesFlutterApiTest {
         await Purchases.pollRewardVerification('client-transaction-id');
   }
 
+  void _checkPollRewardVerificationWithTrackingMetadata() async {
+    RewardVerificationResult result = await Purchases.pollRewardVerification(
+      'client-transaction-id',
+      trackingMetadata: const RewardedAdTrackingMetadata(
+        mediatorName: AdMediatorName.adMob,
+        adFormat: AdFormat.rewarded,
+        adUnitId: 'unit-1',
+        impressionId: 'imp-1',
+      ),
+    );
+  }
+
   void _checkTrackCustomPaywallImpression() {
     Future<void> future = Purchases.trackCustomPaywallImpression();
   }

--- a/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
+++ b/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
@@ -788,8 +788,10 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
 }
 
 - (void)pollRewardVerification:(NSDictionary *)arguments result:(FlutterResult)result {
+    NSDictionary *trackingMetadata = arguments[@"trackingMetadata"].mappingNSNullToNil;
     [RCCommonFunctionality pollRewardVerificationWithClientTransactionId:arguments[@"clientTransactionId"]
-                                                             completion:[self getResponseCompletionBlock:result]];
+                                                        trackingMetadata:trackingMetadata
+                                                              completion:[self getResponseCompletionBlock:result]];
 }
 
 - (void)trackCustomPaywallImpression:(NSDictionary *)arguments result:(FlutterResult)result {

--- a/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
+++ b/ios/purchases_flutter/Sources/purchases_flutter/PurchasesFlutterPlugin.m
@@ -788,7 +788,7 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
 }
 
 - (void)pollRewardVerification:(NSDictionary *)arguments result:(FlutterResult)result {
-    NSDictionary *trackingMetadata = arguments[@"trackingMetadata"].mappingNSNullToNil;
+    NSDictionary *trackingMetadata = [arguments[@"trackingMetadata"] mappingNSNullToNil];
     [RCCommonFunctionality pollRewardVerificationWithClientTransactionId:arguments[@"clientTransactionId"]
                                                         trackingMetadata:trackingMetadata
                                                               completion:[self getResponseCompletionBlock:result]];

--- a/lib/models/rewarded_ad_tracking_metadata.dart
+++ b/lib/models/rewarded_ad_tracking_metadata.dart
@@ -1,0 +1,34 @@
+import 'package:meta/meta.dart';
+
+import 'ad_format.dart';
+import 'ad_mediator_name.dart';
+
+/// Ad metadata for a rewarded ad, passed to [Purchases.pollRewardVerification]
+/// to have the SDK automatically track reward-verification events for it.
+@experimental
+class RewardedAdTrackingMetadata {
+  final String? networkName;
+  final AdMediatorName mediatorName;
+  final AdFormat adFormat;
+  final String? placement;
+  final String adUnitId;
+  final String impressionId;
+
+  const RewardedAdTrackingMetadata({
+    this.networkName,
+    required this.mediatorName,
+    required this.adFormat,
+    this.placement,
+    required this.adUnitId,
+    required this.impressionId,
+  });
+
+  Map<String, dynamic> toMap() => {
+        'networkName': networkName,
+        'mediatorName': mediatorName.value,
+        'adFormat': adFormat.value,
+        'placement': placement,
+        'adUnitId': adUnitId,
+        'impressionId': impressionId,
+      };
+}

--- a/lib/object_wrappers.dart
+++ b/lib/object_wrappers.dart
@@ -33,6 +33,7 @@ export 'models/purchases_configuration.dart';
 export 'models/purchases_error.dart';
 export 'models/reward_verification_result.dart';
 export 'models/reward_verification_token.dart';
+export 'models/rewarded_ad_tracking_metadata.dart';
 export 'models/store.dart';
 export 'models/store_product_change.dart';
 export 'models/store_product_discount.dart';

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -1522,13 +1522,22 @@ class Purchases {
   /// Polls the backend until reward verification completes, then returns the
   /// result. Call when your ad network's reward callback fires, passing the
   /// `clientTransactionId` from [generateRewardVerificationToken].
+  ///
+  /// Pass [trackingMetadata] to have the SDK automatically track
+  /// reward-verification events for the ad it belongs to; omit it to poll
+  /// without tracking.
   @experimental
   static Future<RewardVerificationResult> pollRewardVerification(
-    String clientTransactionId,
-  ) async {
+    String clientTransactionId, {
+    RewardedAdTrackingMetadata? trackingMetadata,
+  }) async {
     final result = await _invokeReturningMap(
       'pollRewardVerification',
-      {'clientTransactionId': clientTransactionId},
+      {
+        'clientTransactionId': clientTransactionId,
+        if (trackingMetadata != null)
+          'trackingMetadata': trackingMetadata.toMap(),
+      },
     );
     return RewardVerificationResult.fromMap(result);
   }


### PR DESCRIPTION
### Description

This change exposes the ad reward tracking functionality - which is just a new parameter for the polling function.

**Do** **not** **merge** until android and ios sdks are released with the feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the native iOS/Android reward-verification bridge and depends on unreleased native SDK APIs; the Dart change is an optional additive parameter.
> 
> **Overview**
> Lets callers optionally attach rewarded-ad metadata when polling reward verification so the SDK can auto-track those events.
> 
> Adds experimental `RewardedAdTrackingMetadata` and an optional `trackingMetadata` argument on `Purchases.pollRewardVerification`. Android and iOS plugins forward the map to hybrid common; omitting it keeps the previous poll-only behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 907e9e4116494e4733d58a9585cc3a57703d3da4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->