### PR TITLE
chore(ads): remove experimental annotations from ads apis

### DIFF
--- a/api_tester/analysis_options.yaml
+++ b/api_tester/analysis_options.yaml
@@ -14,7 +14,6 @@ analyzer:
     # make sure flutter analyze catches missing case in the api tests
     missing_enum_constant_in_switch: error
     depend_on_referenced_packages: ignore
-    experimental_member_use: ignore
 
 linter:
   # The lint rules applied to this project can be customized in the

--- a/lib/models/ad_displayed_data.dart
+++ b/lib/models/ad_displayed_data.dart
@@ -1,9 +1,6 @@
-import 'package:meta/meta.dart';
-
 import 'ad_format.dart';
 import 'ad_mediator_name.dart';
 
-@experimental
 class AdDisplayedData {
   final String? networkName;
   final AdMediatorName mediatorName;

--- a/lib/models/ad_failed_to_load_data.dart
+++ b/lib/models/ad_failed_to_load_data.dart
@@ -1,9 +1,6 @@
-import 'package:meta/meta.dart';
-
 import 'ad_format.dart';
 import 'ad_mediator_name.dart';
 
-@experimental
 class AdFailedToLoadData {
   final AdMediatorName mediatorName;
   final AdFormat adFormat;

--- a/lib/models/ad_format.dart
+++ b/lib/models/ad_format.dart
@@ -1,8 +1,5 @@
-import 'package:meta/meta.dart';
-
 /// Use the predefined constants for common ad formats, or create a custom
 /// value for other ad format types.
-@experimental
 class AdFormat {
   final String value;
 

--- a/lib/models/ad_loaded_data.dart
+++ b/lib/models/ad_loaded_data.dart
@@ -1,9 +1,6 @@
-import 'package:meta/meta.dart';
-
 import 'ad_format.dart';
 import 'ad_mediator_name.dart';
 
-@experimental
 class AdLoadedData {
   final String? networkName;
   final AdMediatorName mediatorName;

--- a/lib/models/ad_mediator_name.dart
+++ b/lib/models/ad_mediator_name.dart
@@ -1,8 +1,5 @@
-import 'package:meta/meta.dart';
-
 /// Use the predefined constants for common mediators, or create a custom
 /// value for other mediation networks.
-@experimental
 class AdMediatorName {
   final String value;
 

--- a/lib/models/ad_opened_data.dart
+++ b/lib/models/ad_opened_data.dart
@@ -1,9 +1,6 @@
-import 'package:meta/meta.dart';
-
 import 'ad_format.dart';
 import 'ad_mediator_name.dart';
 
-@experimental
 class AdOpenedData {
   final String? networkName;
   final AdMediatorName mediatorName;

--- a/lib/models/ad_revenue_data.dart
+++ b/lib/models/ad_revenue_data.dart
@@ -1,10 +1,7 @@
-import 'package:meta/meta.dart';
-
 import 'ad_format.dart';
 import 'ad_mediator_name.dart';
 import 'ad_revenue_precision.dart';
 
-@experimental
 class AdRevenueData {
   final String? networkName;
   final AdMediatorName mediatorName;

--- a/lib/models/ad_revenue_precision.dart
+++ b/lib/models/ad_revenue_precision.dart
@@ -1,8 +1,5 @@
-import 'package:meta/meta.dart';
-
 /// Use the predefined constants for common precision types, or create a custom
 /// value for other precision types.
-@experimental
 class AdRevenuePrecision {
   final String value;
 

--- a/lib/models/reward_verification_result.dart
+++ b/lib/models/reward_verification_result.dart
@@ -1,9 +1,6 @@
-import 'package:meta/meta.dart';
-
 import 'verified_reward.dart';
 
 /// Result delivered after reward verification polling for a rewarded ad.
-@experimental
 class RewardVerificationResult {
   /// True when verification did not complete successfully (rejected, timeout,
   /// network, etc.).

--- a/lib/models/reward_verification_token.dart
+++ b/lib/models/reward_verification_token.dart
@@ -1,12 +1,9 @@
-import 'package:meta/meta.dart';
-
 /// Ties a loaded rewarded ad to its server-side reward verification.
 ///
 /// Produced by [Purchases.generateRewardVerificationToken]. Forward [customData]
 /// and [appUserID] to your ad network's server-side verification options, and
 /// keep [clientTransactionId] to correlate the reward callback with
 /// [Purchases.pollRewardVerification].
-@experimental
 class RewardVerificationToken {
   final String customData;
   final String clientTransactionId;

--- a/lib/models/rewarded_ad_tracking_metadata.dart
+++ b/lib/models/rewarded_ad_tracking_metadata.dart
@@ -1,11 +1,8 @@
-import 'package:meta/meta.dart';
-
 import 'ad_format.dart';
 import 'ad_mediator_name.dart';
 
 /// Ad metadata for a rewarded ad, passed to [Purchases.pollRewardVerification]
 /// to have the SDK automatically track reward-verification events for it.
-@experimental
 class RewardedAdTrackingMetadata {
   final String? networkName;
   final AdMediatorName mediatorName;

--- a/lib/models/verified_reward.dart
+++ b/lib/models/verified_reward.dart
@@ -1,5 +1,3 @@
-import 'package:meta/meta.dart';
-
 /// A single reward granted by a verified rewarded ad.
 ///
 /// This is an abstract base type; inspect the concrete subtype to read the
@@ -14,7 +12,6 @@ import 'package:meta/meta.dart';
 ///   unlock(reward.identifier);
 /// }
 /// ```
-@experimental
 abstract class VerifiedReward {
   const VerifiedReward._();
 
@@ -42,7 +39,6 @@ abstract class VerifiedReward {
 }
 
 /// A reward of [amount] units of the virtual currency [code].
-@experimental
 class VerifiedVirtualCurrencyReward extends VerifiedReward {
   final String code;
   final int amount;
@@ -54,7 +50,6 @@ class VerifiedVirtualCurrencyReward extends VerifiedReward {
 }
 
 /// A reward granting the entitlement [identifier].
-@experimental
 class VerifiedEntitlementReward extends VerifiedReward {
   final String identifier;
 
@@ -68,13 +63,11 @@ class VerifiedEntitlementReward extends VerifiedReward {
 }
 
 /// Verification completed but no reward was granted.
-@experimental
 class VerifiedNoReward extends VerifiedReward {
   const VerifiedNoReward() : super._();
 }
 
 /// Verification completed with a reward type not modeled by this SDK version.
-@experimental
 class VerifiedUnsupportedReward extends VerifiedReward {
   const VerifiedUnsupportedReward() : super._();
 }

--- a/lib/purchases_flutter.dart
+++ b/lib/purchases_flutter.dart
@@ -4,7 +4,6 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-import 'package:meta/meta.dart';
 
 import 'object_wrappers.dart';
 
@@ -1499,7 +1498,6 @@ class Purchases {
     return data;
   }
 
-  @experimental
   static final adTracker = PurchasesAdTracker._();
 
   /// Generates a reward verification token for a loaded rewarded ad.
@@ -1508,7 +1506,6 @@ class Purchases {
   /// `appUserID` to your ad network's server-side verification options, then
   /// keep `clientTransactionId` for [pollRewardVerification] when the reward
   /// callback fires.
-  @experimental
   static Future<RewardVerificationToken> generateRewardVerificationToken(
     String impressionId,
   ) async {
@@ -1526,7 +1523,6 @@ class Purchases {
   /// Pass [trackingMetadata] to have the SDK automatically track
   /// reward-verification events for the ad it belongs to; omit it to poll
   /// without tracking.
-  @experimental
   static Future<RewardVerificationResult> pollRewardVerification(
     String clientTransactionId, {
     RewardedAdTrackingMetadata? trackingMetadata,
@@ -1696,27 +1692,21 @@ class PromotedPurchaseResult {
 
 class UnsupportedPlatformException implements Exception {}
 
-@experimental
 class PurchasesAdTracker {
   PurchasesAdTracker._();
 
-  @experimental
   Future<void> trackAdDisplayed(AdDisplayedData data) =>
       Purchases._channel.invokeMethod('trackAdDisplayed', data.toMap());
 
-  @experimental
   Future<void> trackAdOpened(AdOpenedData data) =>
       Purchases._channel.invokeMethod('trackAdOpened', data.toMap());
 
-  @experimental
   Future<void> trackAdLoaded(AdLoadedData data) =>
       Purchases._channel.invokeMethod('trackAdLoaded', data.toMap());
 
-  @experimental
   Future<void> trackAdRevenue(AdRevenueData data) =>
       Purchases._channel.invokeMethod('trackAdRevenue', data.toMap());
 
-  @experimental
   Future<void> trackAdFailedToLoad(AdFailedToLoadData data) =>
       Purchases._channel.invokeMethod('trackAdFailedToLoad', data.toMap());
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,6 @@ dependencies:
     sdk: flutter
   web: ^1.1.1
   equatable: ^2.0.0
-  meta: ^1.0.0
 
 dev_dependencies:
   flutter_driver:


### PR DESCRIPTION
Removes the experimental annotation from ads api surface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation and dependency cleanup only; no runtime or API signature changes.
> 
> **Overview**
> Promotes the **ads and rewarded-ad verification** surface from experimental to stable by stripping all `@experimental` annotations and dropping the `meta` package dependency.
> 
> **Public API:** `Purchases.adTracker`, `Purchases.generateRewardVerificationToken`, `Purchases.pollRewardVerification`, `PurchasesAdTracker` tracking methods, and the related model types (`Ad*Data`, `AdFormat`, `RewardVerification*`, `VerifiedReward` hierarchy, etc.) are no longer marked experimental—behavior and method channels are unchanged.
> 
> **Tooling:** `api_tester/analysis_options.yaml` no longer ignores `experimental_member_use`, since those diagnostics no longer apply to this code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 630c06783293a4294c849e1b72dde9bcb16d168a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->