### PR TITLE
docs: state the minimum Kotlin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 To use this plugin, add `purchases_flutter` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/).
 
 ### Requirements
-*purchases_flutter* requires Xcode 14.0+ and minimum targets iOS 13.0+/Android SDK 21+ (Android 5.0+).
+*purchases_flutter* requires Xcode 14.0+, Kotlin 2.1.0+, and minimum targets iOS 13.0+/Android SDK 21+ (Android 5.0+).
 
 ## SDK Reference
  Our full SDK reference [can be found here](https://pub.dev/documentation/purchases_flutter/latest/).

--- a/e2e-tests/MaestroTestApp/android/build.gradle.kts
+++ b/e2e-tests/MaestroTestApp/android/build.gradle.kts
@@ -2,6 +2,11 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        // TODO: remove before merging, together with the purchases 11.0.0-SNAPSHOT pins.
+        maven {
+            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+            content { includeGroup("com.revenuecat.purchases") }
+        }
     }
 }
 

--- a/e2e-tests/MaestroTestApp/android/settings.gradle.kts
+++ b/e2e-tests/MaestroTestApp/android/settings.gradle.kts
@@ -20,7 +20,7 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.13.2" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.22" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.21" apply false
 }
 
 include(":app")

--- a/purchases_ui_flutter/android/build.gradle
+++ b/purchases_ui_flutter/android/build.gradle
@@ -19,6 +19,11 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        // TODO: remove with the purchases 11.0.0-SNAPSHOT pin below, before merging.
+        maven {
+            url 'https://central.sonatype.com/repository/maven-snapshots/'
+            content { includeGroup 'com.revenuecat.purchases' }
+        }
     }
 }
 
@@ -54,5 +59,9 @@ android {
     dependencies {
         implementation "com.revenuecat.purchases:purchases-hybrid-common-ui:$common_version"
         implementation 'androidx.compose.ui:ui-android:1.5.4'
+        // TODO: remove before merging. Forces the transitive purchases-android up to the v11
+        // snapshot so this module compiles against Kotlin metadata 2.2.0.
+        implementation 'com.revenuecat.purchases:purchases:11.0.0-SNAPSHOT'
+        implementation 'com.revenuecat.purchases:purchases-ui:11.0.0-SNAPSHOT'
     }
 }

--- a/purchases_ui_flutter/android/build.gradle
+++ b/purchases_ui_flutter/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.revenuecat.purchases_ui_flutter'
 version '10.10.1'
 
 buildscript {
-    ext.kotlin_version = '1.9.20'
+    ext.kotlin_version = '2.2.21'
     ext.common_version = '18.33.1'
     repositories {
         google()

--- a/revenuecat_examples/purchase_tester/android/build.gradle
+++ b/revenuecat_examples/purchase_tester/android/build.gradle
@@ -2,6 +2,11 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        // TODO: remove before merging, together with the purchases 11.0.0-SNAPSHOT pins.
+        maven {
+            url 'https://central.sonatype.com/repository/maven-snapshots/'
+            content { includeGroup 'com.revenuecat.purchases' }
+        }
     }
 }
 

--- a/revenuecat_examples/purchase_tester/android/settings.gradle
+++ b/revenuecat_examples/purchase_tester/android/settings.gradle
@@ -20,7 +20,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.13.2" apply false
-    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.21" apply false
 }
 
 include ":app"


### PR DESCRIPTION
Docs only. Adds the minimum Kotlin version that arrives with the next purchases-hybrid-common major.

- purchases-android v11 publishes `kotlin-stdlib` 2.2.21 at compile scope, so its metadata is 2.2.0. A Kotlin compiler reads metadata at most one minor ahead, so an app on a compiler older than 2.1 fails to build.
- Flutter applies the version declared in the **app's** `android/settings.gradle` to plugin subprojects, so the requirement lands on the consuming app. Verified: app at 1.8.22 fails, app at 2.1.21 builds, with the plugin's own `ext.kotlin_version` unchanged in both.
- Flutter's own app template already ships Kotlin 2.3.20, so only existing projects need the bump.

Depends on RevenueCat/purchases-hybrid-common#1844, which propagates the floor. Merge after the purchases-hybrid-common major that carries purchases-android v11.

### Checklist
- [ ] If applicable, unit tests were added
- [ ] If applicable, followup issues for other SDKs were created