### PR TITLE
ci: notify external PRs feed on PRs from outside the org

### DIFF
--- a/.github/workflows/external-pr-notifications.yml
+++ b/.github/workflows/external-pr-notifications.yml
@@ -1,0 +1,13 @@
+name: External PR Notifications
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  notify:
+    uses: revenuecat/sdk-github-workflows/.github/workflows/external-pr-notifications.yml@3765ddb1c650fba52875e793217f737727425bdf # v7
+    secrets:
+      EXTERNAL_PR_SLACK_WEBHOOK_URL: ${{ secrets.EXTERNAL_PR_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
- Adds a workflow that posts to an internal Slack feed when a PR is opened by someone outside the RevenueCat org.
- Uses `pull_request_target` so the job has the webhook secret on fork PRs; it never checks out or runs PR code and holds a `GITHUB_TOKEN` with no permissions.


### Checklist

- [x] `actionlint` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change with empty token permissions and no PR code checkout; risk is limited to webhook secret handling in the reusable workflow.
> 
> **Overview**
> Adds a GitHub Actions workflow that notifies an internal Slack channel when someone **outside the RevenueCat org** opens a pull request.
> 
> The workflow runs on `pull_request_target` with `opened` only, sets **`permissions: {}`** on the job, and delegates to the shared **`revenuecat/sdk-github-workflows`** `external-pr-notifications` reusable workflow (pinned to v7). It passes the repo secret **`EXTERNAL_PR_SLACK_WEBHOOK_URL`** so fork PRs can trigger notifications without checking out or executing PR code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbca0aac1c99baa401b1e759dec285ba2a509b20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->